### PR TITLE
[v0.91.8][closeout][audit] Register all closed v0.91.7 issues

### DIFF
--- a/adl/tools/build_v0917_closeout_register.sh
+++ b/adl/tools/build_v0917_closeout_register.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=${1:-.}
+out_dir="$repo_root/docs/milestones/v0.91.7/review"
+json_out="$out_dir/V0917_CLOSED_ISSUE_CLOSEOUT_REGISTER.json"
+md_out="$out_dir/V0917_CLOSED_ISSUE_CLOSEOUT_REGISTER.md"
+mkdir -p "$out_dir"
+
+issues_json=$(mktemp)
+trap 'rm -f "$issues_json"' EXIT
+gh issue list --state closed --label version:v0.91.7 --limit 1000 \
+  --json number,title,state,closedAt,closedByPullRequestsReferences,labels,url > "$issues_json"
+
+tmp_rows=$(mktemp)
+trap 'rm -f "$issues_json" "$tmp_rows"' EXIT
+printf '[]' > "$tmp_rows"
+
+while IFS= read -r issue; do
+  number=$(jq -r '.number' <<<"$issue")
+  typed=false
+  record_path=""
+  if [[ -f "$repo_root/.csdlc/issues/$number/index.json" ]]; then
+    typed=true
+    record_path=".csdlc/issues/$number/index.json"
+  fi
+receipt_path=".git/csdlc-v2/closeout/$number.json"
+  valid_receipt=false
+  common_git_dir=$(git -C "$repo_root" rev-parse --git-common-dir)
+  receipt_file="$common_git_dir/csdlc-v2/closeout/$number.json"
+  if [[ -f "$receipt_file" ]] && jq -e --argjson issue "$number" '
+    .schema == "csdlc.terminal_receipt.v1" and
+    .issue == $issue and
+    .record.schema == "csdlc.issue.index.v1" and
+    .record.issue == $issue and
+    .record.phase == "closed_out" and
+    (.record.terminal != null) and
+    (.record.claim == null)
+  ' "$receipt_file" >/dev/null 2>&1; then
+    valid_receipt=true
+  fi
+
+  prs='[]'
+  while IFS= read -r pr; do
+    [[ -z "$pr" ]] && continue
+    pr_json=$(gh pr view "$pr" --json number,state,mergedAt,url,headRefOid,baseRefName 2>/dev/null || printf '{"number":%s,"state":"unknown"}' "$pr")
+    prs=$(jq --argjson item "$pr_json" '. + [$item]' <<<"$prs")
+  done < <(jq -r '.closedByPullRequestsReferences[]?.number' <<<"$issue")
+
+  if [[ "$typed" == true ]]; then
+    class="typed_projection"
+    disposition="typed_receipt_required"
+    evidence="tracked typed projection exists; receipt and terminal parity must be checked"
+    if [[ "$valid_receipt" == true ]]; then
+      disposition="typed_receipt_present"
+      evidence="tracked typed projection and retained shared terminal receipt exist"
+    fi
+  elif [[ "$valid_receipt" == true ]]; then
+    class="orphaned_typed_receipt"
+    disposition="orphaned_typed_receipt"
+    evidence="valid csdlc.terminal_receipt.v1 exists with closed_out record, but no tracked projection exists; no cards are fabricated"
+  elif jq -e 'any(.[]; .state == "MERGED" and .mergedAt != null)' >/dev/null <<<"$prs"; then
+    class="legacy"
+    disposition="legacy_merged_pr"
+    evidence="GitHub closedByPullRequestsReferences includes a merged PR"
+  elif [[ $(jq 'length' <<<"$prs") -gt 0 ]]; then
+    class="legacy"
+    disposition="legacy_linked_pr_not_merged"
+    evidence="GitHub closedByPullRequestsReferences exists, but no linked PR is observed merged"
+  else
+    class="legacy"
+    disposition="legacy_closed_without_linked_pr"
+    evidence="GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+  fi
+
+  row=$(jq -n \
+    --argjson issue "$issue" \
+    --argjson typed "$typed" \
+    --arg record_path "$record_path" \
+    --arg receipt_path "$receipt_path" \
+    --argjson receipt "$valid_receipt" \
+    --arg class "$class" \
+    --arg disposition "$disposition" \
+    --arg evidence "$evidence" \
+    --argjson prs "$prs" \
+    '$issue + {class:$class,typed_projection:$typed,tracked_record:$record_path,shared_receipt:$receipt,receipt_path:$receipt_path,linked_prs:$prs,disposition:$disposition,evidence:$evidence}')
+  jq --argjson row "$row" '. + [$row]' "$tmp_rows" > "$tmp_rows.next"
+  mv "$tmp_rows.next" "$tmp_rows"
+done < <(jq -c '.[]' "$issues_json")
+
+jq '{schema:"adl.v0.91.7.closed_issue_closeout_register.v1",generated_at:(now|todateiso8601),source:{issue_label:"version:v0.91.7",issue_state:"closed"},summary:{total:length,typed_projection:(map(select(.class=="typed_projection"))|length),orphaned_typed_receipt:(map(select(.class=="orphaned_typed_receipt"))|length),legacy:(map(select(.class=="legacy"))|length),valid_receipts:(map(select(.shared_receipt))|length)},issues:.}' "$tmp_rows" > "$json_out"
+
+{
+  echo '# v0.91.7 Closed-Issue Closeout Register'
+  echo
+  echo 'Generated from live GitHub closed issues labeled `version:v0.91.7` and local typed C-SDLC v2 projections/receipts. Legacy issues remain legacy; this register does not fabricate typed cards.'
+  echo
+  jq -r '.summary | "- Total closed issues: \(.total)\n- Typed projections: \(.typed_projection)\n- Orphaned valid typed receipts: \(.orphaned_typed_receipt)\n- Legacy/pre-v2 closures: \(.legacy)\n- Valid shared receipts: \(.valid_receipts)"' "$json_out"
+  echo
+  echo '| Issue | Class | Disposition | Evidence | Linked PRs |'
+  echo '|---:|---|---|---|---|'
+  jq -r '.issues[] | "| [#\(.number)](\(.url)) | \(.class) | \(.disposition) | \(.evidence) | \([.linked_prs[]?.number] | map("#"+tostring) | join(", ")) |"' "$json_out"
+} > "$md_out"
+
+echo "$json_out"
+echo "$md_out"

--- a/docs/milestones/v0.91.7/review/V0917_CLOSED_ISSUE_CLOSEOUT_REGISTER.json
+++ b/docs/milestones/v0.91.7/review/V0917_CLOSED_ISSUE_CLOSEOUT_REGISTER.json
@@ -1,0 +1,29955 @@
+{
+  "schema": "adl.v0.91.7.closed_issue_closeout_register.v1",
+  "generated_at": "2026-07-19T06:02:47Z",
+  "source": {
+    "issue_label": "version:v0.91.7",
+    "issue_state": "closed"
+  },
+  "summary": {
+    "total": 427,
+    "typed_projection": 46,
+    "orphaned_typed_receipt": 3,
+    "legacy": 378,
+    "valid_receipts": 48
+  },
+  "issues": [
+    {
+      "closedAt": "2026-07-19T00:42:33Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zcFD2",
+          "number": 5555,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5555"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5551,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2][closeout] Repair #5527 retained terminal plan-step truth",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5551",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5551/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5551.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "e0a4d4256316d85615f26142836ea76a2d339086",
+          "mergedAt": "2026-07-19T00:42:32Z",
+          "number": 5555,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5555"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-19T00:51:40Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zcEhE",
+          "number": 5554,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5554"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6F-w",
+          "name": "wp:WP-20",
+          "description": "v0.91.5 work package 20 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3KBPw",
+          "name": "area:architecture",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5547,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-20][review-fix] Disposition C-SDLC identity and ownership-split residuals",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5547",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5547/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5547.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "c66c8edf5a32f2711d95e333857f20654214c191",
+          "mergedAt": "2026-07-19T00:51:39Z",
+          "number": 5554,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5554"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-19T01:06:20Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zcRqT",
+          "number": 5559,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5559"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q4Pw",
+          "name": "area:security",
+          "description": "Security-related changes",
+          "color": "d93f0b"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6F-w",
+          "name": "wp:WP-20",
+          "description": "v0.91.5 work package 20 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5546,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-20][review-fix] Repair coverage, supply-chain, and AWS-boundary proof gaps",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5546",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5546.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "a72447ae739c467448fa6f17a198cc62e09238a8",
+          "mergedAt": "2026-07-19T01:06:19Z",
+          "number": 5559,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5559"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-19T04:29:48Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zcL-V",
+          "number": 5557,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5557"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q4Pw",
+          "name": "area:security",
+          "description": "Security-related changes",
+          "color": "d93f0b"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6F-w",
+          "name": "wp:WP-20",
+          "description": "v0.91.5 work package 20 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3J_yQ",
+          "name": "area:provider",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5545,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-20][review-fix] Fix provider and Runtime v3 API hardening findings",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5545",
+      "class": "orphaned_typed_receipt",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5545.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "1c3730bdaafbeb9d5a9627c52ff934702311efeb",
+          "mergedAt": "2026-07-19T04:29:47Z",
+          "number": 5557,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5557"
+        }
+      ],
+      "disposition": "orphaned_typed_receipt",
+      "evidence": "valid csdlc.terminal_receipt.v1 exists with closed_out record, but no tracked projection exists; no cards are fabricated"
+    },
+    {
+      "closedAt": "2026-07-19T00:49:27Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zcEKW",
+          "number": 5553,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5553"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6F-w",
+          "name": "wp:WP-20",
+          "description": "v0.91.5 work package 20 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5544,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-20][review-fix] Reconcile release truth and external-review gates",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5544",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5544/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5544.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "246a5fc9b7f4b4e025e2431d0f78e5a629509432",
+          "mergedAt": "2026-07-19T00:49:26Z",
+          "number": 5553,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5553"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-19T00:39:59Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zb6pU",
+          "number": 5549,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5549"
+        },
+        {
+          "id": "PR_kwDORHPd2M7zcC3q",
+          "number": 5552,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5552"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5542,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-17][docs] Repair post-merge closeout and v0.91.8 bridge truth",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5542",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5542/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5542.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "85fa620b764964c4a0e2a497eebed8499d62a7e8",
+          "mergedAt": "2026-07-19T00:30:11Z",
+          "number": 5549,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5549"
+        },
+        {
+          "baseRefName": "main",
+          "headRefOid": "ddd4252e99f921c443fe3edd0ca66c7fd91c3ae1",
+          "mergedAt": "2026-07-19T00:39:58Z",
+          "number": 5552,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5552"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-18T16:09:25Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zXCaZ",
+          "number": 5522,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5522"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5521,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2][closeout] Complete #5518 terminal plan-step truth",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5521",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5521/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5521.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "f21e98155441271d095c9d1d43d8d4d343aaac4b",
+          "mergedAt": "2026-07-18T16:09:24Z",
+          "number": 5522,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5522"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-18T15:52:55Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zW191",
+          "number": 5519,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5519"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5518,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2][closeout] Repair stale terminal plan-step truth atomically",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5518",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5518/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5518.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "45a6348f44e80dcddf8bef7c13f88002dfcece20",
+          "mergedAt": "2026-07-18T15:52:55Z",
+          "number": 5519,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5519"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-18T15:11:31Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zWWlQ",
+          "number": 5517,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5517"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5516,
+      "state": "CLOSED",
+      "title": "[v0.91.7][review-fix][WP-07A] Correct #5494 retained Runtime v3 design truth",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5516",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5516/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5516.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "d80791ff220db788787ce0a7170e14c4fd5a5f3e",
+          "mergedAt": "2026-07-18T15:11:30Z",
+          "number": 5517,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5517"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-18T13:32:33Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zVW7M",
+          "number": 5515,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5515"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5514,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tooling][coverage] Preserve the complete ADL CSM suite in Runtime v3 bridge coverage",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5514",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5514/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5514.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "6787d12a21a81e99bd441590ccd113c220a43a60",
+          "mergedAt": "2026-07-18T13:32:32Z",
+          "number": 5515,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5515"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-18T12:47:22Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zU12f",
+          "number": 5513,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5513"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACaajtzA",
+          "name": "area:tooling",
+          "description": "",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5512,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tooling][CI] Remove foreign binary selectors from Runtime v3 CSM coverage",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5512",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5512/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5512.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "325d8f490129f4198198222e9a95c0c94fa9410c",
+          "mergedAt": "2026-07-18T12:47:21Z",
+          "number": 5513,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5513"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-18T12:12:29Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zUiyf",
+          "number": 5511,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5511"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACaajtzA",
+          "name": "area:tooling",
+          "description": "",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5509,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tooling][CI] Keep mixed Runtime v3 and CSM validation out of Runtime v2 coverage",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5509",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5509/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5509.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "23fbe8a6de84734c2b517c3d36220b3fd960a4db",
+          "mergedAt": "2026-07-18T12:12:28Z",
+          "number": 5511,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5511"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-18T10:02:35Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zTUHC",
+          "number": 5507,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5507"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYqw",
+          "name": "area:tests",
+          "description": "Tests/coverage",
+          "color": "fef2c0"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACaajtzA",
+          "name": "area:tooling",
+          "description": "",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5506,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tooling][coverage] Register Runtime v3 API-auth coverage without mixed-lane escalation",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5506",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5506/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5506.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "5620c6e920dcbb232c4160c171c5bf3f4e60f845",
+          "mergedAt": "2026-07-18T10:02:34Z",
+          "number": 5507,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5507"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-18T23:15:22Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zbT6y",
+          "number": 5525,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5525"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5495,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2][publish] Avoid stale review loop after publication metadata commit",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5495",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5495/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5495.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "0581f3ab9a7ca6e1d9ea9bcd7bf00ba470086a3d",
+          "mergedAt": "2026-07-18T23:15:21Z",
+          "number": 5525,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5525"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-18T14:39:40Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zS3yd",
+          "number": 5504,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5504"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5494,
+      "state": "CLOSED",
+      "title": "[v0.91.7][review-fix][WP-07A] Complete the unfinished #5409 runtime acceptance boundary",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5494",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5494/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5494.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "d6e55367ec3b9fe9c8908f4ca8fe499e4b0a693c",
+          "mergedAt": "2026-07-18T14:39:39Z",
+          "number": 5504,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5504"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-19T02:29:45Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zcgM1",
+          "number": 5564,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5564"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACntpjPQ",
+          "name": "area:planning",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACrt8N4w",
+          "name": "wp:WP-21A",
+          "description": "Work package WP-21A",
+          "color": "BFDADC"
+        }
+      ],
+      "number": 5489,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-21A][planning] Prepare next milestone docs closeout plan",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5489",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5489/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5489.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "c19c0c886fb108c35e061b0a94c33f0ddee5e265",
+          "mergedAt": "2026-07-19T02:29:43Z",
+          "number": 5564,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5564"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-18T07:57:53Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zSHp9",
+          "number": 5491,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5491"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACh2jWNQ",
+          "name": "area:records",
+          "description": "Records lifecycle and metadata hygiene issues",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5487,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2][closeout] Add typed terminal design repair before receipt reconciliation",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5487",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5487/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5487.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "0119c2efbf573c7711eae8d725f5799e5c3d85ab",
+          "mergedAt": "2026-07-18T07:57:52Z",
+          "number": 5491,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5491"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-18T06:24:23Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zREjM",
+          "number": 5471,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5471"
+        },
+        {
+          "id": "PR_kwDORHPd2M7zRIN2",
+          "number": 5473,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5473"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACaajtzA",
+          "name": "area:tooling",
+          "description": "",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5468,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2][records] Normalize terminal SRP status during reconciliation",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5468",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5468/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5468.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "4e63a400b2e3592ad8b6aa30933a0a5bce2746f4",
+          "mergedAt": "2026-07-18T06:24:22Z",
+          "number": 5471,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5471"
+        },
+        {
+          "baseRefName": "main",
+          "headRefOid": "9026bfb16fd45ea6e32bc7596a5bb9fb5566471e",
+          "mergedAt": "2026-07-18T06:28:52Z",
+          "number": 5473,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5473"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-18T07:16:13Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zRrbz",
+          "number": 5485,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5485"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5467,
+      "state": "CLOSED",
+      "title": "[v0.91.7][ci] Repair unreachable backend-snapshot contract assertions",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5467",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5467/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5467.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "cf96c76f32ec7c4e3c05df660ba259f96730023a",
+          "mergedAt": "2026-07-18T07:16:12Z",
+          "number": 5485,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5485"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-18T06:26:46Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zRGz5",
+          "number": 5472,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5472"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5466,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2][closeout] Reconcile merged PR after a late reviewed-head advance",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5466",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5466/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5466.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "53092f4a89f4a5ba9cc138543a4c83d5654a6214",
+          "mergedAt": "2026-07-18T06:26:46Z",
+          "number": 5472,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5472"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-18T07:50:56Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zR_Zj",
+          "number": 5490,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5490"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5464,
+      "state": "CLOSED",
+      "title": "[v0.91.7][ci] Remove cargo-nextest 0.9.140 unsupported-binary fallback",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5464",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5464/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5464.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "cd1a7c902d5a9475786213df4a8499ef411acc80",
+          "mergedAt": "2026-07-18T07:50:55Z",
+          "number": 5490,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5490"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-18T07:03:47Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zRhY3",
+          "number": 5483,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5483"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5463,
+      "state": "CLOSED",
+      "title": "[v0.91.7][ci] Upgrade pinned Actions away from deprecated Node 20 runtime",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5463",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5463/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5463.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "e3829a5a18db93b18ba0940fdd8e30fd2ff727cf",
+          "mergedAt": "2026-07-18T07:03:46Z",
+          "number": 5483,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5483"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-18T05:54:43Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zQvo0",
+          "number": 5462,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5462"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5461,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2][bind] Support issue-local initialization without writing primary main checkout",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5461",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5461.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "3782e33787bf6674daf9f17144745dfe1562a888",
+          "mergedAt": "2026-07-18T05:54:42Z",
+          "number": 5462,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5462"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-18T05:30:49Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zQkco",
+          "number": 5460,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5460"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5455,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2][install] Fail closed on stale stable owner-binary provenance",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5455",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5455/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5455.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "fb7d09a561a169e906eb48166f14099c98d5a974",
+          "mergedAt": "2026-07-18T05:30:48Z",
+          "number": 5460,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5460"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-18T04:59:43Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zQI-o",
+          "number": 5454,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5454"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5453,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tooling][spot] Bind live SSH proof to the hosted runner CIDR",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5453",
+      "class": "orphaned_typed_receipt",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5453.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "bf16f3d8a842b3fe516b874886a89e1e939dd9fa",
+          "mergedAt": "2026-07-18T04:59:42Z",
+          "number": 5454,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5454"
+        }
+      ],
+      "disposition": "orphaned_typed_receipt",
+      "evidence": "valid csdlc.terminal_receipt.v1 exists with closed_out record, but no tracked projection exists; no cards are fabricated"
+    },
+    {
+      "closedAt": "2026-07-18T06:01:22Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zQ00o",
+          "number": 5465,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5465"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5452,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tooling][spot] Preserve builder summary generation failures",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5452",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5452/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5452.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "ec722b9b773c9faaf4f9b8e1555c7afbc6922500",
+          "mergedAt": "2026-07-18T06:01:21Z",
+          "number": 5465,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5465"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-18T03:45:49Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zPgG4",
+          "number": 5451,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5451"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5450,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tooling][spot] Make SSH key mode detection Linux-first",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5450",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5450.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "f9dadf9782b72ce40153abb177224a509baed300",
+          "mergedAt": "2026-07-18T03:45:48Z",
+          "number": 5451,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5451"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-18T03:32:13Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zPWgG",
+          "number": 5449,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5449"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5448,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tooling][spot] Derive retained cache shape before validation",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5448",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5448.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "e12faf43d8e4291816e5cf43c5efcce5472054fa",
+          "mergedAt": "2026-07-18T03:32:12Z",
+          "number": 5449,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5449"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-18T03:18:11Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zPMnt",
+          "number": 5447,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5447"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5446,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tooling][spot] Align remote-validation wrapper with reusable workflow arguments",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5446",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5446.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "7ce3c7be3a83f6d902ca3e98c8dec2050e220366",
+          "mergedAt": "2026-07-18T03:18:10Z",
+          "number": 5447,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5447"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-16T23:17:49Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7yvnkS",
+          "number": 5441,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5441"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACaajtzA",
+          "name": "area:tooling",
+          "description": "",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5440,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2][design] Support audited post-readiness design reapproval",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5440",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5440/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5440.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "77fafde96e9681b1b4871d1c033de532adc7df32",
+          "mergedAt": "2026-07-16T23:17:48Z",
+          "number": 5441,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5441"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-18T05:16:12Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zQbLz",
+          "number": 5456,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5456"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5427,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2][cards] Add typed repair for stale card identity metadata",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5427",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5427/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5427.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "289015763c35d1516ca486359d3241633bf0dad5",
+          "mergedAt": "2026-07-18T05:16:11Z",
+          "number": 5456,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5456"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-16T20:20:24Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7ysWsR",
+          "number": 5430,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5430"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5426,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2][readiness] Let terminal validation supersede earlier nonterminal evidence",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5426",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5426/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5426.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "d1ed65343d71bcf55274affb1fb731e1dd9ad2a9",
+          "mergedAt": "2026-07-16T20:20:23Z",
+          "number": 5430,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5430"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-16T21:02:53Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7ytSGI",
+          "number": 5435,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5435"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5423,
+      "state": "CLOSED",
+      "title": "[v0.91.7][review-fix][register] Reconcile sprint review register after remediation wave",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5423",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5423/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5423.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "afffd91407e4ec8e3e643176f5fb89524d6b4083",
+          "mergedAt": "2026-07-16T21:02:52Z",
+          "number": 5435,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5435"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-18T06:17:01Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zQ_xM",
+          "number": 5469,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5469"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5415,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2][tooling] Closed issue stale broad claim blocks follow-on issue setup",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5415",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5415.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "b027837e3dc4d358e761f4deee8e068d6101364f",
+          "mergedAt": "2026-07-18T06:17:00Z",
+          "number": 5469,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5469"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-18T06:51:38Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zRQJT",
+          "number": 5477,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5477"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5413,
+      "state": "CLOSED",
+      "title": "[v0.91.7][review-fix][runtime-v3] Resolve #5276 live parity and Observatory findings",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5413",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5413/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5413.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "8127883103f54fdcf3e44bb488639295f100ed7d",
+          "mergedAt": "2026-07-18T06:51:37Z",
+          "number": 5477,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5477"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-18T05:58:58Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zQhRk",
+          "number": 5459,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5459"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5412,
+      "state": "CLOSED",
+      "title": "[v0.91.7][review-fix][runtime-v3][security] Resolve #5247 state authenticity and readiness findings",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5412",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5412/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5412.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "6318706c380b4af8a65ae8792d3baf999113a669",
+          "mergedAt": "2026-07-18T05:58:57Z",
+          "number": 5459,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5459"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-17T18:27:09Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7yv3lN",
+          "number": 5442,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5442"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5411,
+      "state": "CLOSED",
+      "title": "[v0.91.7][review-fix][runtime-v3] Resolve #5227 selector, guardian, and pressure-stop findings",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5411",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5411/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5411.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "432913ed43f316ddd40543c5268f20a43d68702b",
+          "mergedAt": "2026-07-17T18:27:08Z",
+          "number": 5442,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5442"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-16T22:10:30Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7yum4d",
+          "number": 5437,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5437"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5410,
+      "state": "CLOSED",
+      "title": "[v0.91.7][review-fix][runtime-v3] Assemble and secure the #5174 live kernel",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5410",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5410/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5410.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "b46184afe4eb1c2328b9bb8a361ee14fa7de083f",
+          "mergedAt": "2026-07-16T22:10:29Z",
+          "number": 5437,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5437"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-18T14:43:33Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5409,
+      "state": "CLOSED",
+      "title": "[v0.91.7][review-fix][WP-07A] Complete and prove the #5121 runtime rearchitecture",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5409",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5409/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5409.json",
+      "linked_prs": [],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-19T01:36:10Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5408,
+      "state": "CLOSED",
+      "title": "[v0.91.7][review-fix][WP-07] Resolve #5045 runtime hardening findings",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5408",
+      "class": "orphaned_typed_receipt",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5408.json",
+      "linked_prs": [],
+      "disposition": "orphaned_typed_receipt",
+      "evidence": "valid csdlc.terminal_receipt.v1 exists with closed_out record, but no tracked projection exists; no cards are fabricated"
+    },
+    {
+      "closedAt": "2026-07-16T19:07:23Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7yqsho",
+          "number": 5424,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5424"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5407,
+      "state": "CLOSED",
+      "title": "[v0.91.7][review-fix][tools] Resolve #5036 reliability-tail findings",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5407",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5407/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5407.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "6618c080596ddf0943128c9abdaf67507479b8cc",
+          "mergedAt": "2026-07-16T19:07:21Z",
+          "number": 5424,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5424"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-16T18:04:55Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7yQE9H",
+          "number": 5416,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5416"
+        },
+        {
+          "id": "PR_kwDORHPd2M7ypPzj",
+          "number": 5421,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5421"
+        },
+        {
+          "id": "PR_kwDORHPd2M7yperf",
+          "number": 5422,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5422"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5406,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2][records] Retain auditable lifecycle and sprint closeout truth after v1 sunset",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5406",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5406/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5406.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "afe2e16f19aae82f9edc61c9d4641a2afd146cd0",
+          "mergedAt": "2026-07-15T23:08:34Z",
+          "number": 5416,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5416"
+        },
+        {
+          "baseRefName": "main",
+          "headRefOid": "f847332f40e090dcc9afb1295474b206435e0b67",
+          "mergedAt": "2026-07-16T18:04:53Z",
+          "number": 5421,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5421"
+        },
+        {
+          "baseRefName": "main",
+          "headRefOid": "cb9c1aa49eef60f280bc72cd814cff6073e9bb5e",
+          "mergedAt": "2026-07-16T18:14:44Z",
+          "number": 5422,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5422"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-18T05:18:12Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zO_ec",
+          "number": 5445,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5445"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5405,
+      "state": "CLOSED",
+      "title": "[v0.91.7][review-fix][WP-13] Resolve #5403 guild, Godel, and economics findings",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5405",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5405/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5405.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "7a3b66a7c76167828b80ecae5451fec4b3673ece",
+          "mergedAt": "2026-07-18T05:18:11Z",
+          "number": 5445,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5445"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-18T02:23:32Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7yQU0q",
+          "number": 5417,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5417"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5404,
+      "state": "CLOSED",
+      "title": "[v0.91.7][review-fix][WP-12] Resolve #5403 security and protocol findings",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5404",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5404/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5404.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "fc761b2a8a170426d3cd42f837b912ba8ba7ab06",
+          "mergedAt": "2026-07-18T02:23:31Z",
+          "number": 5417,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5417"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-15T23:19:56Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7yPJcF",
+          "number": 5414,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5414"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5403,
+      "state": "CLOSED",
+      "title": "[v0.91.7][review][sprint] Complete remaining closed-sprint reviews",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5403",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5403/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5403.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "8924e4a572aa1b0d53afaaa8e172d1d396722dc3",
+          "mergedAt": "2026-07-15T23:19:55Z",
+          "number": 5414,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5414"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-15T19:43:11Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7yJ5Jx",
+          "number": 5396,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5396"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5390,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3][bug] Make Observatory local HTTPS and report bound control address",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5390",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5390/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5390.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "699da9a4c5ea9643e64da599bf06f5d1b7286040",
+          "mergedAt": "2026-07-15T19:43:10Z",
+          "number": 5396,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5396"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-15T17:03:42Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7yIdj_",
+          "number": 5388,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5388"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5385,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3][review-fix] Reconcile sprint closeout and historical state truth",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5385",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5385.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "f6a080cfbdf2dcfe4594e673f9993104f29e95a3",
+          "mergedAt": "2026-07-15T17:03:41Z",
+          "number": 5388,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5388"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-15T18:26:48Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7yIfdm",
+          "number": 5389,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5389"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6CFw",
+          "name": "wp:WP-01",
+          "description": "v0.91.5 work package 01 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3LPWw",
+          "name": "type:planning",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3LPXA",
+          "name": "area:milestone-planning",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5383,
+      "state": "CLOSED",
+      "title": "[v0.91.7][planning] Restore WP-14 routing and create v0.91.8 planning package",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5383",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5383/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5383.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "6553ec83d45de32a30e4ac0a3ceed3d23cb3e12a",
+          "mergedAt": "2026-07-15T18:26:47Z",
+          "number": 5389,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5389"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-15T16:35:38Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7yHjj4",
+          "number": 5377,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5377"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5375,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2][review] Review full clean-room and cutover sprint",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5375",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5375.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "c9c5fef0e618aec01f850550922826c28f4d4827",
+          "mergedAt": "2026-07-15T16:35:37Z",
+          "number": 5377,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5377"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-15T16:57:10Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7yIN-t",
+          "number": 5386,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5386"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYkISGQ",
+          "name": "track:backlog",
+          "description": "",
+          "color": "BFD4F2"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACaajtzA",
+          "name": "area:tooling",
+          "description": "",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5371,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2] Add live PR state collection to v2 shepherding",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5371",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5371.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "a07e3d300d0dc5f6049c8a96c90ac22dc199007b",
+          "mergedAt": "2026-07-15T16:57:08Z",
+          "number": 5386,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5386"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-15T16:46:35Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7yHwXZ",
+          "number": 5378,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5378"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYkISGQ",
+          "name": "track:backlog",
+          "description": "",
+          "color": "BFD4F2"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACaajtzA",
+          "name": "area:tooling",
+          "description": "",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5373,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2] Expose shepherd input schema and examples at CLI boundary",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5373",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5373.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "8d32145ce5c2d621a8b0a8d314fd3d00569443b7",
+          "mergedAt": "2026-07-15T16:46:34Z",
+          "number": 5378,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5378"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-15T16:53:26Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7yH1V-",
+          "number": 5379,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5379"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYkISGQ",
+          "name": "track:backlog",
+          "description": "",
+          "color": "BFD4F2"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACaajtzA",
+          "name": "area:tooling",
+          "description": "",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5372,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2] Document v1-origin PR tail handling after v1 sunset",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5372",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5372.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "794861944892fbf38c6eb47cbda4d3dc086b17f1",
+          "mergedAt": "2026-07-15T16:53:25Z",
+          "number": 5379,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5379"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-15T16:57:09Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7yIN-t",
+          "number": 5386,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5386"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYkISGQ",
+          "name": "track:backlog",
+          "description": "",
+          "color": "BFD4F2"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACaajtzA",
+          "name": "area:tooling",
+          "description": "",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5370,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2] Add shared-token PR state collector for v2 tooling",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5370",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5370.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "a07e3d300d0dc5f6049c8a96c90ac22dc199007b",
+          "mergedAt": "2026-07-15T16:57:08Z",
+          "number": 5386,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5386"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-15T16:33:43Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYkISGQ",
+          "name": "track:backlog",
+          "description": "",
+          "color": "BFD4F2"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACaajtzA",
+          "name": "area:tooling",
+          "description": "",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5369,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2] Fix csdlc-install resolve against selector file shape",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5369",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5369.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-15T16:15:18Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7yGnSb",
+          "number": 5376,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5376"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW1JCAg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACaajtzA",
+          "name": "area:tooling",
+          "description": "",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5368,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2][P1] Prevent dirty-review to clean-publication lifecycle dead-end",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5368",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5368.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "05fd9f156bef6b4b2a6fe2536b057beddad8106d",
+          "mergedAt": "2026-07-15T16:15:17Z",
+          "number": 5376,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5376"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-15T21:54:36Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7yK8h_",
+          "number": 5398,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5398"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW1JCAg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACntpjPQ",
+          "name": "area:planning",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5367,
+      "state": "CLOSED",
+      "title": "[v0.91.7][planning][bug] Add planned-milestone mode to repo staleness validation",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5367",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5367.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "2bd4e61201a9ec9b796366a627c6753685cbb297",
+          "mergedAt": "2026-07-15T21:54:35Z",
+          "number": 5398,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5398"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-15T18:16:23Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7yIOVl",
+          "number": 5387,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5387"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5366,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2][docs] Align active helper skills with final typed-v2 authority",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5366",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5366.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "90f69d49599790846ed6aec3a405eab31ae54f19",
+          "mergedAt": "2026-07-15T18:16:22Z",
+          "number": 5387,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5387"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-15T16:51:55Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7yH32M",
+          "number": 5381,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5381"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW1JCAg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACaajtzA",
+          "name": "area:tooling",
+          "description": "",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5365,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2][bug] Stop generating deleted v1 validation commands in VPP cards",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5365",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5365.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "6700d2d68f7effc5b539345827cfd9b77025bb49",
+          "mergedAt": "2026-07-15T16:51:54Z",
+          "number": 5381,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5381"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-15T16:48:20Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7yH68L",
+          "number": 5382,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5382"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW1JCAg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACaajtzA",
+          "name": "area:tooling",
+          "description": "",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5364,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2][bug] Add audited bound-phase replan path for planning cards",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5364",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5364.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "fa5429c06a6d432d13c24eb8bbb9d4f3562e0007",
+          "mergedAt": "2026-07-15T16:48:19Z",
+          "number": 5382,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5382"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-14T19:01:19Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7xsyKq",
+          "number": 5374,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5374"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACaajtzA",
+          "name": "area:tooling",
+          "description": "",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5353,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2][bug] Make init and design approval safe for issue-local design paths",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5353",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5353/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5353.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "05080e98d65fd05f0cc5cec40fe51016379a21a4",
+          "mergedAt": "2026-07-14T19:01:18Z",
+          "number": 5374,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5374"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-15T18:49:13Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7yK1fk",
+          "number": 5397,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5397"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5330,
+      "state": "CLOSED",
+      "title": "[runtime-v3][ci] Give Runtime v3 an independent fast validation lane",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5330",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5330/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5330.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "f302dcffa8303c6fb0c18048a6f245923dcf684c",
+          "mergedAt": "2026-07-15T18:49:11Z",
+          "number": 5397,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5397"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-15T18:25:37Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACaajtzA",
+          "name": "area:tooling",
+          "description": "",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5328,
+      "state": "CLOSED",
+      "title": "[tooling] pr finish stale-base preflight should fail fast before slow publication work",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5328",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5328.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-15T14:48:29Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7xeuuL",
+          "number": 5334,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5334"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW1JCAg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACneI3-Q",
+          "name": "tools",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5327,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tooling] Make pr.sh finish prefer installed owner binary over stale target fallback",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5327",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5327.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "e4ac47657864e2388f67b4ef8a496f20627fbb37",
+          "mergedAt": "2026-07-15T14:48:28Z",
+          "number": 5334,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5334"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-15T14:48:30Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7xeuuL",
+          "number": 5334,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5334"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5325,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][pr-finish] Preserve explicit cargo fallback for stale worktree finish",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5325",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5325.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "e4ac47657864e2388f67b4ef8a496f20627fbb37",
+          "mergedAt": "2026-07-15T14:48:28Z",
+          "number": 5334,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5334"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-14T18:26:37Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7xbzwz",
+          "number": 5329,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5329"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXNRw",
+          "name": "area:demo",
+          "description": "",
+          "color": "FBCA04"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5323,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3][observatory] Remove hardcoded bind and CORS IPs",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5323",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5323.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "58a8ee3b911e07a8f54e4b4ac093a45a7127e087",
+          "mergedAt": "2026-07-14T18:26:36Z",
+          "number": 5329,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5329"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-14T06:26:07Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7xaDJ1",
+          "number": 5324,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5324"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5322,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][pr-finish] Prefer current issue-worktree finish delegate for release-gate lanes",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5322",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5322.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "9e54f40a9129e510637c61ed5ed23a171c0793da",
+          "mergedAt": "2026-07-14T06:26:06Z",
+          "number": 5324,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5324"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-14T18:18:01Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5307,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2] Gate 10D4: read-only importer sunset",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5307",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5307.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-14T18:17:58Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5308,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2] Gate 10D3: executable rollback sunset",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5308",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5308.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-14T12:26:21Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5306,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2] Gate 10D2: approved bounded v1 deletion wave",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5306",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/5306/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/5306.json",
+      "linked_prs": [],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-13T04:21:25Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7w5XN9",
+          "number": 5316,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5316"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5305,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2] Gate 10D1: non-mutating deletion eligibility and manifest",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5305",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5305.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "af30a5fe682059ba8e7ed445a9244774c10f3b4c",
+          "mergedAt": "2026-07-13T04:21:24Z",
+          "number": 5316,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5316"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-14T02:53:42Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7w4CxP",
+          "number": 5309,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5309"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5296,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][usage] Add shareable Codex usage guard automation wrapper",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5296",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5296.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "c93ad29dd70c80d5ed0855ff888a46614b770909",
+          "mergedAt": "2026-07-14T02:53:41Z",
+          "number": 5309,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5309"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-14T18:15:24Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5295,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2] Gate 10D: deletion eligibility, bounded removal, and sunsets",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5295",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5295.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-13T02:15:03Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7w3pmu",
+          "number": 5304,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5304"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5294,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2] Gate 10C: reversible default switch with v1 retained",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5294",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5294.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "4b72db9995b55c8f9965e3afc7b434ab1db952a2",
+          "mergedAt": "2026-07-13T02:15:02Z",
+          "number": 5304,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5304"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-13T01:20:37Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7w3CFC",
+          "number": 5301,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5301"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5293,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2] Gate 10B: pre-switch independent proof with v1 intact",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5293",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5293.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "f4286bd1e15622e407c1f516c5c45f9449c4553c",
+          "mergedAt": "2026-07-13T01:20:36Z",
+          "number": 5301,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5301"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-13T00:35:53Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7w2hCd",
+          "number": 5298,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5298"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5292,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2] Gate 10A: coexistence contracts, skills, and stable binaries",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5292",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5292.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "b6e38c18a18bcf87225d08e6b3a19b4057a1ee13",
+          "mergedAt": "2026-07-13T00:35:52Z",
+          "number": 5298,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5298"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-13T04:54:50Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7w5v8I",
+          "number": 5317,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5317"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXNRw",
+          "name": "area:demo",
+          "description": "",
+          "color": "FBCA04"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5286,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3][observatory] Prove live Observatory consumption of Runtime v3 surfaces",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5286",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5286.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "5674fd3a16a754800a93c7b857291874624bbbd3",
+          "mergedAt": "2026-07-13T04:54:49Z",
+          "number": 5317,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5317"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T23:56:43Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7w1xPx",
+          "number": 5289,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5289"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5287,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][usage] Add Codex status UI collector for usage watcher",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5287",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5287.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "340e4bb0a638d1daafdf11caa4558b724a27ced4",
+          "mergedAt": "2026-07-12T23:56:42Z",
+          "number": 5289,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5289"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-13T04:05:47Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7w5Ho6",
+          "number": 5315,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5315"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5285,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3][parity] Prove ACIP A2A cloud network parity",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5285",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5285.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "5bf069948264d5d5dd86002b4d81a5b6118effc0",
+          "mergedAt": "2026-07-13T04:05:45Z",
+          "number": 5315,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5315"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T23:31:13Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7w1q4t",
+          "number": 5288,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5288"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5284,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3][parity] Prove agents provider scheduler parity",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5284",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5284.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "0296b240bde6a5d66156799c2df03d36fb4eefad",
+          "mergedAt": "2026-07-12T23:31:12Z",
+          "number": 5288,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5288"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-13T03:40:52Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7w4xku",
+          "number": 5314,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5314"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5283,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3][parity] Prove delegation and resource contract parity",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5283",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5283.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "79e2a376b3fa9a16a97e6b59cad39d138f5efb10",
+          "mergedAt": "2026-07-13T03:40:51Z",
+          "number": 5314,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5314"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-13T03:16:29Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7w4daQ",
+          "number": 5313,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5313"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5282,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3][parity] Prove Freedom Gate and AEE governance parity",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5282",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5282.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "cf1d3cc67991b417a4ee8229fbcbafe47d46c579",
+          "mergedAt": "2026-07-13T03:16:28Z",
+          "number": 5313,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5313"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-13T02:50:14Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7w4G9J",
+          "number": 5310,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5310"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5281,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3][parity] Prove adaptive learning DAG parity",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5281",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5281.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "2c1925e648d79366a96a561b542c8ffe17e73e46",
+          "mergedAt": "2026-07-13T02:50:13Z",
+          "number": 5310,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5310"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-13T01:46:23Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7w3UGz",
+          "number": 5302,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5302"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5280,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3][parity] Prove continuity replay recovery parity",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5280",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5280.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "820a4328a244a761896fc11cdfb84d258e0e8d29",
+          "mergedAt": "2026-07-13T01:46:22Z",
+          "number": 5302,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5302"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-13T01:06:16Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7w2yfE",
+          "number": 5299,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5299"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5279,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3][parity] Prove service contracts and configuration parity",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5279",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5279.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "165c33e820eabb51e6d31f7d49e81018cf46b34d",
+          "mergedAt": "2026-07-13T01:06:15Z",
+          "number": 5299,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5299"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-13T00:27:42Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7w2aHE",
+          "number": 5297,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5297"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5278,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3][parity] Prove topology and backpressure parity",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5278",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5278.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "2014781fd20ee015a06296733a8df209ec86aee3",
+          "mergedAt": "2026-07-13T00:27:41Z",
+          "number": 5297,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5297"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T23:43:41Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7w19oT",
+          "number": 5291,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5291"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5277,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3][parity] Prove live kernel lifecycle parity",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5277",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5277.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "c49ffecfd54045e41e7e9b2f98fc7bcd05e2ff2f",
+          "mergedAt": "2026-07-12T23:43:40Z",
+          "number": 5291,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5291"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-13T05:03:24Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXNRw",
+          "name": "area:demo",
+          "description": "",
+          "color": "FBCA04"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXxFQ",
+          "name": "area:release",
+          "description": "",
+          "color": "F9D0C4"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoBXlrg",
+          "name": "type:sprint",
+          "description": "Sprint umbrella issue",
+          "color": "BFD4F2"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5276,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3][cutover][sprint] Close live parity and Observatory integration blockers",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5276",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5276.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-14T07:40:23Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7w29JV",
+          "number": 5300,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5300"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5267,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime][coverage] Align CSM service readiness fixture with required runtime components",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5267",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5267.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "ab70bde4bf79a828fb0edaf78fdcc98d5d30a563",
+          "mergedAt": "2026-07-14T07:40:22Z",
+          "number": 5300,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5300"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-15T15:48:26Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7xeIOl",
+          "number": 5333,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5333"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5260,
+      "state": "CLOSED",
+      "title": "[v0.91.7][ci][merge] Validate final base-plus-head result before merge",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5260",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5260.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "f1d02399819572d80d52f026c6b347a9823a525e",
+          "mergedAt": "2026-07-15T15:48:25Z",
+          "number": 5333,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5333"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T22:48:29Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wuqXi",
+          "number": 5258,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5258"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5256,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime][coverage] Align API Gateway bridge fixtures with weather route",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5256",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5256.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "a92be409055bd751b9e37fa77b8f9f08d7f3399e",
+          "mergedAt": "2026-07-12T22:48:28Z",
+          "number": 5258,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5258"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T14:07:43Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wwNI_",
+          "number": 5271,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5271"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXxFQ",
+          "name": "area:release",
+          "description": "",
+          "color": "F9D0C4"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5254,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3][cutover] Decide default switch and Runtime v2 decommission path",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5254",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5254.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "b3311c7da5376c72df21121387a809b08ad21f60",
+          "mergedAt": "2026-07-12T14:07:42Z",
+          "number": 5271,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5271"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T13:36:08Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wv5pk",
+          "number": 5269,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5269"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXxFQ",
+          "name": "area:release",
+          "description": "",
+          "color": "F9D0C4"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5253,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3][soak] Run production-like soak and rollback proof",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5253",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5253.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "5134f38142f48402917df80dded9274af3bb0e42",
+          "mergedAt": "2026-07-12T13:36:08Z",
+          "number": 5269,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5269"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T13:09:36Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wvpXG",
+          "number": 5266,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5266"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn0KQxg",
+          "name": "area:observability",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5252,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3][weather] Retain GPU/weather and CloudWatch proof",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5252",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5252.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "6e9d638bb699be93eba4508ecdf0bb262cb9e89e",
+          "mergedAt": "2026-07-12T13:09:35Z",
+          "number": 5266,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5266"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T12:42:15Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wvYi8",
+          "number": 5264,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5264"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5251,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3][cognition] Add governed cognition adapters or reviewed non-cutover dispositions",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5251",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5251.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "d19bf375b60395c488a754d49ccfc4d4582792c0",
+          "mergedAt": "2026-07-12T12:42:14Z",
+          "number": 5264,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5264"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T12:17:33Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wvKt7",
+          "number": 5262,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5262"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5250,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3][identity] Build citizen identity and memory-continuity adapters",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5250",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5250.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "9042f53d592afa3400643469282e17c2765e316a",
+          "mergedAt": "2026-07-12T12:17:32Z",
+          "number": 5262,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5262"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T11:52:48Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wu76z",
+          "number": 5261,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5261"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5249,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3][security] Prove private-state and security equivalence",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5249",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5249.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "e56ef6eee763ceb9159ff1dd06a993914781b549",
+          "mergedAt": "2026-07-12T11:52:47Z",
+          "number": 5261,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5261"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T11:25:07Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wusOc",
+          "number": 5259,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5259"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5248,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3][parity] Add live black-box parity fixtures for cutover-critical groups",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5248",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5248.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "8497386d8c155f5db048835e813ddaf74191705a",
+          "mergedAt": "2026-07-12T11:25:06Z",
+          "number": 5259,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5259"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T14:10:19Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXxFQ",
+          "name": "area:release",
+          "description": "",
+          "color": "F9D0C4"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5247,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3][cutover][sprint] Finish Runtime v3 cutover readiness",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5247",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5247.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-13T02:28:57Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7w3jT9",
+          "number": 5303,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5303"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW1JCAg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACneI3-Q",
+          "name": "tools",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5246,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools] Distinguish PR validation empty-check timeout from running checks",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5246",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5246.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "2064db44b3d80f58d91bbed74f57a93fb7ababce",
+          "mergedAt": "2026-07-13T02:28:56Z",
+          "number": 5303,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5303"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-15T22:43:19Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5243,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07A][spot][ci] Run adl-ci and adl-coverage on managed AWS Spot builders",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5243",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5243.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-14T06:44:45Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5240,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2] Gate 10: operator migration, cutover, and deletion",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5240",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5240.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-12T23:37:32Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7w16FS",
+          "number": 5290,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5290"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5239,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2] Gate 9: opt-in soak and cutover decision",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5239",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5239.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "973806194112615b57881b3fd2e528fb243afb98",
+          "mergedAt": "2026-07-12T23:37:31Z",
+          "number": 5290,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5290"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T15:38:50Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wxIFP",
+          "number": 5275,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5275"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5238,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2] Gate 8: legacy import and shadow parity",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5238",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5238.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "f6ce8eb63b9702d5e982526338f37fe065ed92a4",
+          "mergedAt": "2026-07-12T15:38:49Z",
+          "number": 5275,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5275"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T15:06:35Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wwzit",
+          "number": 5274,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5274"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5237,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2] Gate 7: PR readiness and closeout",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5237",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5237.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "09187076a97047734dfca75936df5ed82f62da76",
+          "mergedAt": "2026-07-12T15:06:34Z",
+          "number": 5274,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5274"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T14:31:45Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wwc9W",
+          "number": 5272,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5272"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5236,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2] Gate 6: idempotent GitHub publication",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5236",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5236.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "30a6afb064c6fd3bd4aa36c3330c0b3abdca9b13",
+          "mergedAt": "2026-07-12T14:31:44Z",
+          "number": 5272,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5272"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T14:01:33Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wwJpX",
+          "number": 5270,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5270"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5235,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2] Gate 5: pre-publication review truth",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5235",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5235.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "76d503192eeec3c3feb219832142ecdf8aaaf58a",
+          "mergedAt": "2026-07-12T14:01:32Z",
+          "number": 5270,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5270"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T13:22:29Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wvxk-",
+          "number": 5268,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5268"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5234,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2] Gate 4: PVF, scheduler, shepherd, and validation",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5234",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5234.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "9a12d471954bb3b697e471d73b75abf091f0d955",
+          "mergedAt": "2026-07-12T13:22:28Z",
+          "number": 5268,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5268"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T12:35:01Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wvUeg",
+          "number": 5263,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5263"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5233,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2] Gate 3: initialization, worktree binding, and claims",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5233",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5233.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "f079a5ea295cd3fa56e1bcd717f44edc6e42332d",
+          "mergedAt": "2026-07-12T12:35:00Z",
+          "number": 5263,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5263"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T11:39:04Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wuqDk",
+          "number": 5257,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5257"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5232,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2] Gate 2: clean-room state engine, automated cards, and doctor",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5232",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5232.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "cfb20f7a424ab36ee7d9a20accbe6f895f3c8276",
+          "mergedAt": "2026-07-12T11:39:04Z",
+          "number": 5257,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5257"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T09:32:09Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wtu-j",
+          "number": 5244,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5244"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACqEU16g",
+          "name": "validation",
+          "description": "Validation tooling, proof lanes, and check routing",
+          "color": "5319e7"
+        }
+      ],
+      "number": 5229,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][validation] Teach PR-fast validation lane about adl-runtime crate surfaces",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5229",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5229.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "844092ce7578dca4ef4d4836abad3873a1999986",
+          "mergedAt": "2026-07-12T09:32:08Z",
+          "number": 5244,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5244"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T08:16:47Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wtBtr",
+          "number": 5231,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5231"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5228,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc-v2] Establish clean-room architecture and retained-behavior baseline",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5228",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5228.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "a3641c6db7969875b37fa9ff32fd30d7ea224479",
+          "mergedAt": "2026-07-12T08:16:46Z",
+          "number": 5231,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5231"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T14:50:13Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXxFQ",
+          "name": "area:release",
+          "description": "",
+          "color": "F9D0C4"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5227,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3][cutover][sprint] Execute Runtime v3 cutover",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5227",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5227.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-12T09:54:01Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wsuQ9",
+          "number": 5230,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5230"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5225,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3][guardian] Adopt rust-tokio-supervisor wrapper or build tiny guardian",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5225",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5225.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "a4df679f0334c70fc28e87f9c5708d567319eb72",
+          "mergedAt": "2026-07-12T09:54:00Z",
+          "number": 5230,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5230"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T06:38:16Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5224,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3][guardian] Evaluate rustysd and COTS guardian fallbacks",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5224",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5224.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-12T10:23:01Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wt37d",
+          "number": 5245,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5245"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn0KQxg",
+          "name": "area:observability",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5222,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3][weather] Qualify resource and GPU monitoring",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5222",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5222.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "03dd81af34c984b762a24642bf7db5bc310e1eb7",
+          "mergedAt": "2026-07-12T10:23:00Z",
+          "number": 5245,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5245"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T06:50:09Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXxFQ",
+          "name": "area:release",
+          "description": "",
+          "color": "F9D0C4"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5221,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3][guardian] Pin fixed Horust release and rollout guardian",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5221",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5221.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-12T14:39:33Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wwhkv",
+          "number": 5273,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5273"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXxFQ",
+          "name": "area:release",
+          "description": "",
+          "color": "F9D0C4"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5220,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3][cutover] Run release proof gate",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5220",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5220.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "dfe3d7903785a6c264579a3ed1bfb04e7fbc7526",
+          "mergedAt": "2026-07-12T14:39:31Z",
+          "number": 5273,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5273"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T09:33:31Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wtKUP",
+          "number": 5242,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5242"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXxFQ",
+          "name": "area:release",
+          "description": "",
+          "color": "F9D0C4"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5219,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3][cutover] Add explicit Runtime v3 entrypoint switch",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5219",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5219.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "8afdf7c0d62f50a5a42fffdf118c1bda41415f93",
+          "mergedAt": "2026-07-12T09:33:30Z",
+          "number": 5242,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5242"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T05:46:56Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wr1Fj",
+          "number": 5223,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5223"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXxFQ",
+          "name": "area:release",
+          "description": "",
+          "color": "F9D0C4"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5218,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3][cutover] Prepare cutover decision gate",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5218",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5218.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "c39610f01a2edb163543e9cb03499902769847ac",
+          "mergedAt": "2026-07-12T05:46:55Z",
+          "number": 5223,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5223"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-14T02:53:55Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7w4a_C",
+          "number": 5311,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5311"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW1JCAg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACneI3-Q",
+          "name": "tools",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5215,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tooling] Fix PR-number shepherd closeout routing",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5215",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5215.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "9073a76097d87ab320d4cac0474224480140d9fe",
+          "mergedAt": "2026-07-14T02:53:55Z",
+          "number": 5311,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5311"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-14T07:50:41Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7xamjV",
+          "number": 5326,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5326"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW1JCAg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACneI3-Q",
+          "name": "tools",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5214,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tooling] Repair Codex subagent Responses API authentication failure",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5214",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5214.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "48e370ac805c267aaedcb334a64201941917da92",
+          "mergedAt": "2026-07-14T07:50:40Z",
+          "number": 5326,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5326"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T06:49:54Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5211,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3][guardian] Adopt and qualify Horust as the cross-platform Runtime v3 service manager",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5211",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5211.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-11T20:56:24Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5200,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][runtime] Refresh low-disk health after storage recovery",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5200",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5200.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-11T19:56:52Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wmj-e",
+          "number": 5196,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5196"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5194,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][shepherd] Prune merged issue worktrees automatically",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5194",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5194.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "1a9890f3b7258c59d0c6b1aa75ca852517f9e0c6",
+          "mergedAt": "2026-07-11T19:56:51Z",
+          "number": 5196,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5196"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-15T22:13:45Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7xTHKV",
+          "number": 5319,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5319"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5191,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07A][spot] Make AWS Spot validation bulletproof and simple",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5191",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5191.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "decaedbb57f1e54d284b9d883862171647adce11",
+          "mergedAt": "2026-07-15T22:13:44Z",
+          "number": 5319,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5319"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-14T05:32:04Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7xX025",
+          "number": 5321,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5321"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5184,
+      "state": "CLOSED",
+      "title": "[v0.91.7][workflow] Fix conductor PR payload and closed-issue routing",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5184",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5184.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "f7759d04dac46e8a374c691a1c2ed592a0b29cf2",
+          "mergedAt": "2026-07-14T05:32:03Z",
+          "number": 5321,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5321"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-11T20:02:59Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wm6qd",
+          "number": 5198,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5198"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5177,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3] Add control API health and observability components",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5177",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5177.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "06abe3ce157385fcd5804eaeb186ccb01050f6f2",
+          "mergedAt": "2026-07-11T20:02:58Z",
+          "number": 5198,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5198"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-11T23:05:41Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wolPj",
+          "number": 5203,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5203"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5178,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3] Implement Freedom Gate and governed execution components",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5178",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5178.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "7271dcc52b994cf127c14ab40a0bfb44d8f10026",
+          "mergedAt": "2026-07-11T23:05:40Z",
+          "number": 5203,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5203"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-11T21:15:51Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wnmfw",
+          "number": 5201,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5201"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5180,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3] Implement reasoning loops and adaptive learning DAGs",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5180",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5180.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "f322fb6175b4c25ccaf6a1d619300397a7d1c07e",
+          "mergedAt": "2026-07-11T21:15:50Z",
+          "number": 5201,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5201"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-11T18:57:35Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wmNiR",
+          "number": 5195,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5195"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5181,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3] Implement continuity replay and governed recovery",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5181",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5181.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "bc496c5b72607c2cb4b2a0fab1aade725f2e6e22",
+          "mergedAt": "2026-07-11T18:57:34Z",
+          "number": 5195,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5195"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-11T18:05:29Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wlsC7",
+          "number": 5192,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5192"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5182,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3] Add configuration registry and topology construction",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5182",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5182.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "5a26c3c98bc26d6427674e1703e01fa9ba16ba1b",
+          "mergedAt": "2026-07-11T18:05:29Z",
+          "number": 5192,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5192"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-11T23:36:18Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wo2ij",
+          "number": 5207,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5207"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5183,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3] Add agent provider scheduler and integration components",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5183",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5183.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "2a1c9b8a84081caf2f2c19d55bf91e4ba4db3548",
+          "mergedAt": "2026-07-11T23:36:17Z",
+          "number": 5207,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5207"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T02:19:00Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wqOPJ",
+          "number": 5213,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5213"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5175,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3] Prove guardian packaging soak and closeout readiness",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5175",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5175.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "e4a4842c3585b91df87701adf892efcc42b4230b",
+          "mergedAt": "2026-07-12T02:18:59Z",
+          "number": 5213,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5213"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-11T17:25:01Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wlOZ4",
+          "number": 5188,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5188"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5176,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3] Define parity inventory and component contracts",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5176",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5176.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "ae4f921b3f4b27554e79f0382bcde10a709ef057",
+          "mergedAt": "2026-07-11T17:25:00Z",
+          "number": 5188,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5188"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T00:17:39Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wpNyf",
+          "number": 5209,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5209"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5179,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3] Build Runtime v2 shadow parity and migration harness",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5179",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5179.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "f545ffee7b0d6a1d80435e14d1be0df833c3621c",
+          "mergedAt": "2026-07-12T00:17:38Z",
+          "number": 5209,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5209"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T07:04:55Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5174,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime-v3][sprint] Lightweight runtime parity mini-sprint",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5174",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5174.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-11T10:41:32Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wgYg7",
+          "number": 5173,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5173"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5170,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime] Build clean-room supervised component runtime kernel",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5170",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5170.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "02ca761dfe956155107559c12ae0681655e2f1a6",
+          "mergedAt": "2026-07-11T10:41:31Z",
+          "number": 5173,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5173"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T05:17:27Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wrDU0",
+          "number": 5216,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5216"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5169,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][runtime] Clear recovered CSM storage-pressure state without restart",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5169",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5169.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "a4d356660869ff55481b56dc831caaeca3e9615a",
+          "mergedAt": "2026-07-12T05:17:26Z",
+          "number": 5216,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5216"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T21:55:36Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wpqte",
+          "number": 5210,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5210"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5164,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07A][build] Make CodeBuild Rust validation deterministic and self-verifying",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5164",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5164.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "a249269d8a1f6a4d8c5de92934eea65753be7711",
+          "mergedAt": "2026-07-12T21:55:35Z",
+          "number": 5210,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5210"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-11T02:31:58Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wajLO",
+          "number": 5153,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5153"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3J_yQ",
+          "name": "area:provider",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5150,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07A][runtime][provider] Make CSM resident agents use the runtime provider substrate",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5150",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5150.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "e0bd5c16882ea182e21f3897414e6db237fa4d32",
+          "mergedAt": "2026-07-11T02:31:57Z",
+          "number": 5153,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5153"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T23:37:40Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wYbr9",
+          "number": 5145,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5145"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5143,
+      "state": "CLOSED",
+      "title": "[v0.91.7][review] Add separate WP-07 and WP-08 findings docs",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5143",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5143.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "ad6c2a1d11a41276f7b9bd6f11261af24b2e89ec",
+          "mergedAt": "2026-07-10T23:37:39Z",
+          "number": 5145,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5145"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T22:24:34Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wWkTD",
+          "number": 5138,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5138"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6D2w",
+          "name": "wp:WP-11",
+          "description": "v0.91.5 work package 11 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3J_yQ",
+          "name": "area:provider",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5136,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-11][godel-ghb] Integrate GHB as Runtime v2 agent runtime",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5136",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5136.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "7443fc44b1588d640f4f32ace69ca0dbacea0ca6",
+          "mergedAt": "2026-07-10T22:24:33Z",
+          "number": 5138,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5138"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T22:53:10Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wW90L",
+          "number": 5140,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5140"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5135,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07A][runtime] Implement polis Shepherd Agent as CSM operator agent",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5135",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5135.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "0379097b104db494a46c50b605f113fc446b12af",
+          "mergedAt": "2026-07-10T22:53:09Z",
+          "number": 5140,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5140"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T22:26:20Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wXs2y",
+          "number": 5141,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5141"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5134,
+      "state": "CLOSED",
+      "title": "[v0.91.7][review] Finish late sprint review register updates",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5134",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5134.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "9dc319b38bcb24d68f687742359f65152d61be1f",
+          "mergedAt": "2026-07-10T22:26:19Z",
+          "number": 5141,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5141"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T19:19:39Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wT3_J",
+          "number": 5133,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5133"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5130,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][coverage] Speed up adl-coverage by separating fast and long coverage work",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5130",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5130.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "d4d6a2c410065386a6f56728ae9d9f58927abaa6",
+          "mergedAt": "2026-07-10T19:19:38Z",
+          "number": 5133,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5133"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T10:56:33Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wtHvq",
+          "number": 5241,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5241"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5126,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07A][runtime][acip] Implement ACIP carrier for protobuf and WebSocket runtime paths",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5126",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5126.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "30de73c0e49777475fe055811dff78eaed425b40",
+          "mergedAt": "2026-07-12T10:56:32Z",
+          "number": 5241,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5241"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-11T09:39:40Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7weiCW",
+          "number": 5162,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5162"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5124,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07A][runtime] Implement Curiosity Engine as CSM runtime component",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5124",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5124.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "514ed3b11bd879292941a10ec845bf7183003ab2",
+          "mergedAt": "2026-07-11T09:39:39Z",
+          "number": 5162,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5162"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-14T03:02:35Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wbcPE",
+          "number": 5158,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5158"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5123,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07A][security][runtime] Implement CAV as CSM runtime component",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5123",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5123.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "412173cc09665b5fc6760866c1d26aed132d0426",
+          "mergedAt": "2026-07-14T03:02:34Z",
+          "number": 5158,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5158"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-13T00:27:23Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wuleJ",
+          "number": 5255,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5255"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5125,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07A][runtime] Implement Constructability Gate as CSM runtime component",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5125",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5125.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "d74d99b65f1d400ae2307be21c355c2e95de204c",
+          "mergedAt": "2026-07-13T00:27:22Z",
+          "number": 5255,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5255"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T10:05:39Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wbF80",
+          "number": 5156,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5156"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5122,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07A][runtime] Implement Freedom Gate as first-class CSM runtime component",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5122",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5122.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "5f26b1e0ed643b7cb399dcb087866ad79e0442e7",
+          "mergedAt": "2026-07-12T10:05:38Z",
+          "number": 5156,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5156"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T19:23:07Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wTaVG",
+          "number": 5131,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5131"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5121,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07A][sprint] CSM runtime rearchitecture and crate-backed topology proof",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5121",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5121.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "252b0b88dc95533889a021d3a840c9c4973e2986",
+          "mergedAt": "2026-07-10T19:23:06Z",
+          "number": 5131,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5131"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-13T00:52:29Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wvaDX",
+          "number": 5265,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5265"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5120,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][soak][runtime] Prove assembled CSM runtime topology soak",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5120",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5120.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "a30eb17be098015492ca702172db0d7e07dd7f6f",
+          "mergedAt": "2026-07-13T00:52:28Z",
+          "number": 5265,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5265"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T09:11:22Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wpwTe",
+          "number": 5212,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5212"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5118,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][runtime] Implement native reasoning_runtime component for graphs loops and adaptive DAGs",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5118",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5118.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "1f41fb61262d2f48347094fb4ee488ffcc201e2d",
+          "mergedAt": "2026-07-12T09:11:21Z",
+          "number": 5212,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5212"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T01:43:19Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wovef",
+          "number": 5205,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5205"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn0KQxg",
+          "name": "area:observability",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5117,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][observability][runtime] Integrate Vector as CSM-managed observability pipeline component",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5117",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5117.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "86a56ef94b1102abff86923930b802e3274273ac",
+          "mergedAt": "2026-07-12T01:43:18Z",
+          "number": 5205,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5205"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T07:22:07Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wo0Wo",
+          "number": 5206,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5206"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5119,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][runtime] Separate checkpoint continuity from lifelog history primitives",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5119",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5119.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "0f57f22202f26b9245b3a347e3f693dfd2e1211b",
+          "mergedAt": "2026-07-12T07:22:06Z",
+          "number": 5206,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5206"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T09:36:18Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wloZG",
+          "number": 5190,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5190"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5114,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][runtime] Implement governed CSM shutdown DAG",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5114",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5114.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "e479b6af97358e4298abc421caa8eb30d9193b23",
+          "mergedAt": "2026-07-12T09:36:17Z",
+          "number": 5190,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5190"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-11T23:18:08Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wohoe",
+          "number": 5202,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5202"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5115,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][cloud][runtime] Make CSM cloud_bridge fail closed for AWS publishability and cursors",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5115",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5115.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "c2194e383ad6a6402e93e6790c9dd9ccb6a02c21",
+          "mergedAt": "2026-07-11T23:18:07Z",
+          "number": 5202,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5202"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T03:30:42Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wor9Z",
+          "number": 5204,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5204"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5116,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][security][runtime] Add auth to CSM runtime API loopback control surface",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5116",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5116.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "3841d7b906765f620d71f0a416b6699ea87526b9",
+          "mergedAt": "2026-07-12T03:30:42Z",
+          "number": 5204,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5204"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-11T11:49:29Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wgXCu",
+          "number": 5172,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5172"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5111,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][runtime] Define deterministic core and nondeterministic shell boundary",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5111",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5111.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "b0c7270c889a994f052c0a39d38be68f242bcae2",
+          "mergedAt": "2026-07-11T11:49:28Z",
+          "number": 5172,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5172"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-11T17:14:28Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7whhJZ",
+          "number": 5186,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5186"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5112,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][runtime] Implement CSM component supervision policy matrix",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5112",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5112.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "89c413c06580db3734e6c80e8f889468845906d0",
+          "mergedAt": "2026-07-11T17:14:27Z",
+          "number": 5186,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5186"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-11T17:15:28Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wixMz",
+          "number": 5187,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5187"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5113,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][runtime] Implement typed channel backpressure policy matrix",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5113",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5113.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "609ef7e40555ba017b703d46fd7843f352ecfcf1",
+          "mergedAt": "2026-07-11T17:15:27Z",
+          "number": 5187,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5187"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-11T00:14:57Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wZStN",
+          "number": 5148,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5148"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5110,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][runtime] Split CSM into adl-runtime crate boundary",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5110",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5110.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "85fc2f78ff28a5deb64876b559f94b467c355c17",
+          "mergedAt": "2026-07-11T00:14:57Z",
+          "number": 5148,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5148"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T17:26:04Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wQ0jh",
+          "number": 5108,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5108"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXNRw",
+          "name": "area:demo",
+          "description": "",
+          "color": "FBCA04"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DiA",
+          "name": "wp:WP-09",
+          "description": "v0.91.5 work package 09 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5100,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-09][html] Finish HTML Observatory runtime control room",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5100",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5100.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "ae5f57825831d6d9c3b6eaa484e8b24f31a2621c",
+          "mergedAt": "2026-07-10T17:26:03Z",
+          "number": 5108,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5108"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T09:35:02Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wGjMf",
+          "number": 5102,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5102"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5098,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][runtime][chronosense] Make CSM own embedded ntpd-rs time observation",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5098",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5098.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "97578f0e158e33c486a11a10eabcce7e9916d9d3",
+          "mergedAt": "2026-07-10T09:35:01Z",
+          "number": 5102,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5102"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-13T09:04:05Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7w6XRK",
+          "number": 5318,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5318"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5097,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime][unification] Implement unified runtime kernel integration path",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5097",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5097.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "2f12830b4ea3addc169d17608bea93b742f4acfc",
+          "mergedAt": "2026-07-13T09:04:04Z",
+          "number": 5318,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5318"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T19:21:21Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wSqI4",
+          "number": 5127,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5127"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6D2w",
+          "name": "wp:WP-11",
+          "description": "v0.91.5 work package 11 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3KBPw",
+          "name": "area:architecture",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5096,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-11][godel][ghb] Implement full GHB recursive self-improvement loop",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5096",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5096.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "1a1d6a1661bec48f8cfbb8a0b2dd4e1e493c8ddc",
+          "mergedAt": "2026-07-10T19:21:20Z",
+          "number": 5127,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5127"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T03:06:02Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7v_vYT",
+          "number": 5087,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5087"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5086,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][binaries] Repair owner binary installer defaults and no-build behavior",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5086",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5086.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "39c2b2c5a66b100d7a7e184de37171a392937c85",
+          "mergedAt": "2026-07-10T03:06:01Z",
+          "number": 5087,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5087"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T02:14:39Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7v--Ez",
+          "number": 5085,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5085"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5083,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][coverage] Repair adl-coverage PR-fast late failures",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5083",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5083.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "dcfb77d84dfc4f6dc371ced93024cae58c9c15d0",
+          "mergedAt": "2026-07-10T02:14:38Z",
+          "number": 5085,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5085"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T08:14:26Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7v-2He",
+          "number": 5084,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5084"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5082,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][validation] Keep slow runtime_v2 proof tests out of default fast lane",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5082",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5082.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "d730ee83093e59fccbd4fb9b890240f5381f6067",
+          "mergedAt": "2026-07-10T08:14:25Z",
+          "number": 5084,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5084"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T00:56:59Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7v99Gr",
+          "number": 5080,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5080"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5079,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][ci] Split monolithic adl-ci into fast parallel required lanes",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5079",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5079.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "00dceade3ea16554c607f06a062191038c34b04a",
+          "mergedAt": "2026-07-10T00:56:58Z",
+          "number": 5080,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5080"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-12T00:15:13Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wo_XO",
+          "number": 5208,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5208"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW1JCAg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACneI3-Q",
+          "name": "tools",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5076,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][watch] pr watch/shepherd can hang after PR validation fetch",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5076",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5076.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "412fb3a97e2de3f15582d0b613ad76a64c543f20",
+          "mergedAt": "2026-07-12T00:15:12Z",
+          "number": 5208,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5208"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T00:10:39Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7v9MOp",
+          "number": 5077,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5077"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3J_yQ",
+          "name": "area:provider",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5075,
+      "state": "CLOSED",
+      "title": "[v0.91.7][models][dspark] Publish Qwen and Gemma vLLM speculative-decoding proof",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5075",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5075.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "60ed756e9aa524098f9e21ca7f24d52f97985056",
+          "mergedAt": "2026-07-10T00:10:38Z",
+          "number": 5077,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5077"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-09T21:41:08Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7v64JH",
+          "number": 5073,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5073"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5070,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][binaries] Install durable owner binaries outside target",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5070",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5070.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "051f06ca125370d847ed73fe62ac47e8c6550ee7",
+          "mergedAt": "2026-07-09T21:41:07Z",
+          "number": 5073,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5073"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T17:43:39Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wRgX5",
+          "number": 5109,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5109"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5068,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][runtime] Rearchitect CSM runtime around proven Rust crates",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5068",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5068.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "3013264a1676dc87f7e5fac91f23f90aee9b6a79",
+          "mergedAt": "2026-07-10T17:43:38Z",
+          "number": 5109,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5109"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-09T20:48:51Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7v51Ro",
+          "number": 5069,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5069"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXxFQ",
+          "name": "area:release",
+          "description": "",
+          "color": "F9D0C4"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5062,
+      "state": "CLOSED",
+      "title": "[v0.91.7][release][version] Update Cargo.toml version to 0.91.7",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5062",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5062.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "adafc8032f5b67a915b094fadbdc2b6544efa45d",
+          "mergedAt": "2026-07-09T20:48:50Z",
+          "number": 5069,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5069"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T05:35:43Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wARN-",
+          "number": 5090,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5090"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5053,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][runtime] Implement CSM low-disk backpressure and checkpoint survivability",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5053",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5053.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "476ea1336c9e96a36eff517a0e4c33d0b6b2b5e2",
+          "mergedAt": "2026-07-10T05:35:42Z",
+          "number": 5090,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5090"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T17:33:56Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5045,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][sprint] Complete remaining CSM runtime hardening follow-on issues",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5045",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5045.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-09T17:44:29Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7vBpHc",
+          "number": 5050,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5050"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3J_yQ",
+          "name": "area:provider",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5044,
+      "state": "CLOSED",
+      "title": "[v0.91.7][provider][anthropic] Run Fable 5 UTS provider acceptance panel",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5044",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5044.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "e82d113fe6af33702e9ab8c0dda3a764b1528de9",
+          "mergedAt": "2026-07-09T17:44:28Z",
+          "number": 5050,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5050"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-09T17:41:40Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7vBhfI",
+          "number": 5049,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5049"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5042,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][tools] Let pr finish consume broad runtime owner-lane proof",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5042",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5042.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "93201871d47777cb63cb0fda5ab5ed26764bc92c",
+          "mergedAt": "2026-07-09T17:41:39Z",
+          "number": 5049,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5049"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T06:50:26Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wArgt",
+          "number": 5093,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5093"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5041,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][runtime][chronosense] Integrate ntpd-rs into CSM runtime time synchronization",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5041",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5041.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "b03f32488eecd9fbe7f38af66e9d2fd84401656b",
+          "mergedAt": "2026-07-10T06:50:25Z",
+          "number": 5093,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5093"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T02:03:54Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7v4_NW",
+          "number": 5063,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5063"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5040,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][runtime] Implement CSM port registry and connection pooling plan",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5040",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5040.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "25e2b0cfc7b85fc84c84c4dabfd0842123d2c2cf",
+          "mergedAt": "2026-07-10T02:03:53Z",
+          "number": 5063,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5063"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T07:57:00Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7v5Lpl",
+          "number": 5064,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5064"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5039,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][runtime][aws] Implement governed CSM API Gateway bridge",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5039",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5039.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "a865a637edd50aadfd954418f40860d91c3f0167",
+          "mergedAt": "2026-07-10T07:56:59Z",
+          "number": 5064,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5064"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-09T16:36:01Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7u_ZSn",
+          "number": 5046,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5046"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5037,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][ci] Make PR CI and coverage lanes materially faster",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5037",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5037.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "eb0aead9954b586443ccbfb3377cc4bfc3f2bfaa",
+          "mergedAt": "2026-07-09T16:36:00Z",
+          "number": 5046,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5046"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T18:26:11Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5036,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][sprint] Complete tools workflow reliability tail",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5036",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5036.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-10T06:20:50Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3KBPw",
+          "name": "area:architecture",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoBXlrg",
+          "name": "type:sprint",
+          "description": "Sprint umbrella issue",
+          "color": "BFD4F2"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5035,
+      "state": "CLOSED",
+      "title": "[v0.91.7][rust][sprint] Execute Rust tooling simplification wave",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5035",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5035.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-09T19:20:57Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7v25B4",
+          "number": 5056,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5056"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5034,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][closeout] Repair merged PR closeout when watcher attachment packet is missing",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5034",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5034.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "52192c72b2d2f7cc64e700c6681bd5acada5827d",
+          "mergedAt": "2026-07-09T19:20:56Z",
+          "number": 5056,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5056"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-09T19:22:14Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7v3zum",
+          "number": 5058,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5058"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5032,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][validation] Require durable build-action logs for every build and validation action",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5032",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5032.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "faf6094ffedc346b76a888477149274c8677fdc3",
+          "mergedAt": "2026-07-09T19:22:13Z",
+          "number": 5058,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5058"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-09T20:19:21Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7v4Vkp",
+          "number": 5060,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5060"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5031,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][worktree] Separate open and dirty closed worktrees in prune reports",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5031",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5031.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "38be1a63b45d90fb4118292422774e380d51d86a",
+          "mergedAt": "2026-07-09T20:19:20Z",
+          "number": 5060,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5060"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-07T18:18:45Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7u7c5w",
+          "number": 5030,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5030"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5028,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][cards] Enforce required source-prompt sections during bootstrap",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5028",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5028.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "52e086f973d7325eb8280f28a7185874ed270a75",
+          "mergedAt": "2026-07-07T18:18:44Z",
+          "number": 5030,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5030"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-09T21:44:36Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7vABwW",
+          "number": 5047,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5047"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3J_yQ",
+          "name": "area:provider",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5025,
+      "state": "CLOSED",
+      "title": "[v0.91.7][provider][z-ai] Implement native Z.ai provider adapter and tests",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5025",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5025.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "9d4fb73cfd5dc87094262526b601363e883b4d24",
+          "mergedAt": "2026-07-09T21:44:35Z",
+          "number": 5047,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5047"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-09T20:37:34Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7v4h4X",
+          "number": 5061,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5061"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3J_yQ",
+          "name": "area:provider",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5026,
+      "state": "CLOSED",
+      "title": "[v0.91.7][provider][proof] Run Z.ai and Bedrock provider acceptance smoke tests",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5026",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5026.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "23fde112fa516552bb02811f2823475e8ade8494",
+          "mergedAt": "2026-07-09T20:37:33Z",
+          "number": 5061,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5061"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T00:23:38Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7v9duX",
+          "number": 5078,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5078"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3J_yQ",
+          "name": "area:provider",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoBXlrg",
+          "name": "type:sprint",
+          "description": "Sprint umbrella issue",
+          "color": "BFD4F2"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5027,
+      "state": "CLOSED",
+      "title": "[v0.91.7][provider][sprint] Implement native Z.ai and AWS Bedrock providers",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5027",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5027.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "08f68235734c9e6d477b3fe2619e5abb3ff39b9c",
+          "mergedAt": "2026-07-10T00:23:37Z",
+          "number": 5078,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5078"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-09T17:43:58Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7vA-Mu",
+          "number": 5048,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5048"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3J_yQ",
+          "name": "area:provider",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5024,
+      "state": "CLOSED",
+      "title": "[v0.91.7][provider][bedrock] Implement native AWS Bedrock provider adapter and tests",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5024",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5024.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "6ce6578e918c79dbdff733e231c9be51dde9f319",
+          "mergedAt": "2026-07-09T17:43:56Z",
+          "number": 5048,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5048"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-07T16:11:36Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7u6P_c",
+          "number": 5023,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5023"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DVg",
+          "name": "wp:WP-08",
+          "description": "v0.91.5 work package 08 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn0KQxg",
+          "name": "area:observability",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5022,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-08][records] Reconcile #4998 bridge-tail closeout in sprint records",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5022",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5022.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "3012417d9be4ab877aef61008ee611d17fea2a60",
+          "mergedAt": "2026-07-07T16:11:34Z",
+          "number": 5023,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5023"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-07T04:52:19Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uqPcU",
+          "number": 5021,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5021"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DVg",
+          "name": "wp:WP-08",
+          "description": "v0.91.5 work package 08 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5020,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-08][records] Reconcile sprint register after WP-08 closeout",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5020",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5020.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "ed6228bb28047d062805499028c690e9b8f3d98c",
+          "mergedAt": "2026-07-07T04:52:18Z",
+          "number": 5021,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5021"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-07T04:42:21Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uqAfT",
+          "number": 5019,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5019"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5017,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][janitor] Expose repo-native pr janitor entrypoint or update janitor skill routing",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5017",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5017.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "bce2e0a2de6ca842d9bca4661ff9f651aef002ed",
+          "mergedAt": "2026-07-07T04:42:20Z",
+          "number": 5019,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5019"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-07T18:18:29Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7u7Zfe",
+          "number": 5029,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5029"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW1JCAg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACneI3-Q",
+          "name": "tools",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5012,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][pr] Fix adl pr watch/shepherd --help dispatch",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5012",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5012.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "88868a11692b954bfc3e3d43aad3f110081cadf4",
+          "mergedAt": "2026-07-07T18:18:28Z",
+          "number": 5029,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5029"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-07T14:42:40Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7upY5g",
+          "number": 5015,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5015"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5009,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][watcher] Require watcher attachment for every issue-bound PR",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5009",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5009.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "5af86d44b433fdf5fbf485aeacc4bf3c9418ad89",
+          "mergedAt": "2026-07-07T14:42:39Z",
+          "number": 5015,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5015"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-07T03:14:18Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uoypY",
+          "number": 5011,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5011"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DVg",
+          "name": "wp:WP-08",
+          "description": "v0.91.5 work package 08 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn0KQxg",
+          "name": "area:observability",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5006,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-08][ACIP-SNS] Remove retained full AWS account SHA from proof summaries",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5006",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5006.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "410bfc773aab19261e6b09971cb427cc5f04b15f",
+          "mergedAt": "2026-07-07T03:14:17Z",
+          "number": 5011,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5011"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-09T16:35:06Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7u95Zt",
+          "number": 5043,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5043"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5005,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][csm] Implement governed emergency polis stop path",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5005",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5005.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "f25668e82f8a8c2f09e934f2b9ae38e89d9d94cd",
+          "mergedAt": "2026-07-09T16:35:05Z",
+          "number": 5043,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5043"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-09T20:49:46Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7v5M1G",
+          "number": 5065,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5065"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXNRw",
+          "name": "area:demo",
+          "description": "",
+          "color": "FBCA04"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5003,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][csm] Add loopback browser access policy for CSM runtime API",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5003",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5003.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "b7a254b5df1296cbea27a1002c622ecb1af029b4",
+          "mergedAt": "2026-07-09T20:49:45Z",
+          "number": 5065,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5065"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-09T20:51:23Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7v5Qbu",
+          "number": 5066,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5066"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW1JCAg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACneI3-Q",
+          "name": "tools",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5002,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][watch] Align pr watch and doctor SOR readiness reporting",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5002",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5002.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "8bd480320f33ad9c8dbf38a86a7bec80c030db74",
+          "mergedAt": "2026-07-09T20:51:22Z",
+          "number": 5066,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5066"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-07T03:13:31Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uoqiu",
+          "number": 5010,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5010"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW1JCAg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACneI3-Q",
+          "name": "tools",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 5001,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][pr-finish] Align finish wrapper flags with delegated binary argument support",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/5001",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/5001.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "34b56375de93fd427c1d0fc427190fcf1378b0ce",
+          "mergedAt": "2026-07-07T03:13:30Z",
+          "number": 5010,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5010"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T01:29:28Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7v6RKo",
+          "number": 5071,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5071"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW1JCAg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACneI3-Q",
+          "name": "tools",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4999,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tooling][subagents] Review agent can hang without terminal status during ADL pre-PR review",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4999",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4999.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "a55636569e879a9b0572f2cf9955794834376c02",
+          "mergedAt": "2026-07-10T01:29:27Z",
+          "number": 5071,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5071"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-07T15:56:48Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7upkIq",
+          "number": 5016,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5016"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DVg",
+          "name": "wp:WP-08",
+          "description": "v0.91.5 work package 08 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn0KQxg",
+          "name": "area:observability",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4998,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][WP-08][csm] Send governed shutdown and degradation notices through control-plane channels",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4998",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4998.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "987297982ccdd0e24d6c730f317cb14c2e4b2ae1",
+          "mergedAt": "2026-07-07T15:56:47Z",
+          "number": 5016,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5016"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-07T01:14:48Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7umsta",
+          "number": 5000,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5000"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4997,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][csm] Make CSM daemon service mode permanent and classify any exit",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4997",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4997.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "d80eb1f675e4fe5e2f421fa89a92c91c1dd99a0d",
+          "mergedAt": "2026-07-07T01:14:47Z",
+          "number": 5000,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5000"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T00:08:25Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7v66W8",
+          "number": 5074,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5074"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3KBPw",
+          "name": "area:architecture",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4995,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][cli] Expose C-SDLC control plane through canonical csdlc",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4995",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4995.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "c01f61e705d3dc695afaa85839564023946b3282",
+          "mergedAt": "2026-07-10T00:08:24Z",
+          "number": 5074,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5074"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-11T00:30:43Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wZT6I",
+          "number": 5149,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5149"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW1JCAg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACneI3-Q",
+          "name": "tools",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4990,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][validation] Map HTML Observatory demo paths to a runnable proof lane",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4990",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4990.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "e6eada928f3fc8a74e065a95c1d490271fd1dd83",
+          "mergedAt": "2026-07-11T00:30:43Z",
+          "number": 5149,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5149"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-07T00:06:26Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7umDX1",
+          "number": 4996,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4996"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3KBPw",
+          "name": "area:architecture",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4989,
+      "state": "CLOSED",
+      "title": "[v0.91.7][ADR] Write v0.91.7 architecture decision records",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4989",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4989.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "b4afc637aa24d6d64fa255d3e24eeb62fd979ff7",
+          "mergedAt": "2026-07-07T00:06:25Z",
+          "number": 4996,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4996"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T15:52:00Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wHYRZ",
+          "number": 5103,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5103"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW1JCAg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACneI3-Q",
+          "name": "tools",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4987,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][cards] VPP bootstrap references missing PVF lane registry path",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4987",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4987.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "539938e3b0f50839f4de935e584e896518c156ea",
+          "mergedAt": "2026-07-10T15:51:59Z",
+          "number": 5103,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5103"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T20:17:45Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7ugdGX",
+          "number": 4992,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4992"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn0KQxg",
+          "name": "area:observability",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4986,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][csm][observability] Classify CSM service startup before first daemon record",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4986",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4986.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "7de2c08829df44f45cb0fb8d484441bb5f109896",
+          "mergedAt": "2026-07-06T20:17:44Z",
+          "number": 4992,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4992"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T05:35:08Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7v_-qo",
+          "number": 5089,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5089"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4985,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][runtime] Guard finish cleanup around active CSM runtime state",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4985",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4985.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "00f09780e8565532de38c48a7c9ca910c465f0d6",
+          "mergedAt": "2026-07-10T05:35:07Z",
+          "number": 5089,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5089"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-07T18:19:02Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7u8fTG",
+          "number": 5038,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5038"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3KBPw",
+          "name": "area:architecture",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4983,
+      "state": "CLOSED",
+      "title": "[v0.91.7][architecture] Document ADL Platform CLI binary taxonomy",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4983",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4983.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "3b4ae2845fd85bb66b0cace6d15155de53bf4766",
+          "mergedAt": "2026-07-07T18:19:01Z",
+          "number": 5038,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5038"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-07T16:45:59Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7upIx9",
+          "number": 5013,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5013"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn0KQxg",
+          "name": "area:observability",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4980,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][csm] Define canonical CSM runtime API port and bind contract",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4980",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4980.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "32f54fa2cfea586f9332135cfe75b4d693c4ce39",
+          "mergedAt": "2026-07-07T16:45:58Z",
+          "number": 5013,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5013"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T15:51:24Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7v2a0J",
+          "number": 5055,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5055"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4979,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][csm] Split runtime control-plane commands from adl tooling binary",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4979",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4979.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "8fe044de7d41525772d08cff9641c793a2c5f4b8",
+          "mergedAt": "2026-07-10T15:51:23Z",
+          "number": 5055,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5055"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T05:15:49Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7v1y4U",
+          "number": 5054,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5054"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4977,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][tools] Ensure CSM owner binary is always available for runtime work",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4977",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4977.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "82cd50255bc5839c98b59b661313eb9b8a3d1ce7",
+          "mergedAt": "2026-07-10T05:15:48Z",
+          "number": 5054,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5054"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T18:07:09Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7ud6NU",
+          "number": 4981,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4981"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4976,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][runtime] Run intermediate CSM operational liveness test",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4976",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4976.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "bafc364fae06f8678e59800795f859524fb83119",
+          "mergedAt": "2026-07-06T18:07:08Z",
+          "number": 4981,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4981"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-09T19:22:48Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7v37w_",
+          "number": 5059,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5059"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4974,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][tools][remote-build] Repair AWS Spot interruption serialization and resume handling",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4974",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4974.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "f16b7aadda967692b225a2ef6e58a65d1fa62cb0",
+          "mergedAt": "2026-07-09T19:22:47Z",
+          "number": 5059,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5059"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T16:54:44Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7udB_p",
+          "number": 4973,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4973"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6Cbg",
+          "name": "wp:WP-03",
+          "description": "v0.91.5 work package 03 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4972,
+      "state": "CLOSED",
+      "title": "[v0.91.7][review][WP-03] Refresh sprint review register and review WP-03",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4972",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4972.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "a1557f5f1b359e7db20b8f415de53298b1bc77d8",
+          "mergedAt": "2026-07-06T16:54:43Z",
+          "number": 4973,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4973"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T08:35:14Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uQMuJ",
+          "number": 4963,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4963"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4961,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][review] Remediate repo-native workflow stabilization sprint review findings",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4961",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4961.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "8345fe5680a8a07ef945c6f4863458f7d56b182c",
+          "mergedAt": "2026-07-06T08:35:13Z",
+          "number": 4963,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4963"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T18:04:47Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uQnjf",
+          "number": 4965,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4965"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4960,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][sprint] Remove remaining raw gh usage from sprint-conductor helpers",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4960",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4960.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "d9394fb3fba7e4555c85f82aed74b8a81319934a",
+          "mergedAt": "2026-07-06T18:04:46Z",
+          "number": 4965,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4965"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T16:54:18Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uP5B6",
+          "number": 4962,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4962"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4959,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][closeout] Repair #4806 sprint closeout truth and evidence retention",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4959",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4959.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "c2204a062d900772a2ff6db45fa2d7c54b428d88",
+          "mergedAt": "2026-07-06T16:54:17Z",
+          "number": 4962,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4962"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T07:10:16Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uOaLM",
+          "number": 4957,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4957"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DCw",
+          "name": "wp:WP-06",
+          "description": "v0.91.5 work package 06 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4955,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-06][remote-build] Make Nessus and Spot builder-image paths operational before WP-08",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4955",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4955.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "abb3bae9ab6eafd0afb2b047cfcc5284e7b31b24",
+          "mergedAt": "2026-07-06T07:10:15Z",
+          "number": 4957,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4957"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T07:01:47Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uN5e_",
+          "number": 4956,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4956"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6Cbg",
+          "name": "wp:WP-03",
+          "description": "v0.91.5 work package 03 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4953,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-03][tools] Repair shepherd closeout truth and review findings",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4953",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4953.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "ca3ec5c3156394ce22feae9a70336aee0dc446dc",
+          "mergedAt": "2026-07-06T07:01:46Z",
+          "number": 4956,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4956"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T06:17:56Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uNXbZ",
+          "number": 4954,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4954"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DCw",
+          "name": "wp:WP-06",
+          "description": "v0.91.5 work package 06 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACntpjPQ",
+          "name": "area:planning",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4952,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-06][records] Finalize WP-06 milestone truth and WP-08 readiness handoff",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4952",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4952.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "bddb9d0defb95c0f3718bb2a1450b4ab27d83c28",
+          "mergedAt": "2026-07-06T06:17:55Z",
+          "number": 4954,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4954"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-07T02:52:42Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7ufYkc",
+          "number": 4988,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4988"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6Cbg",
+          "name": "wp:WP-03",
+          "description": "v0.91.5 work package 03 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4950,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][watch] Distinguish validated closeout from closeout-needed state",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4950",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4950.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "a0ae3545d78194f3e38e42dd9676da811f056e15",
+          "mergedAt": "2026-07-07T02:52:41Z",
+          "number": 4988,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4988"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T05:59:32Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uNAb3",
+          "number": 4951,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4951"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6CrA",
+          "name": "wp:WP-04",
+          "description": "v0.91.5 work package 04 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4946,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-04][records] Repair closeout and lifecycle truth after sprint review",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4946",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4946.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "ded3875d2dafd86653db114da5c5d2876a7b05f2",
+          "mergedAt": "2026-07-06T05:59:31Z",
+          "number": 4951,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4951"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T05:47:21Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uM1vk",
+          "number": 4948,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4948"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DCw",
+          "name": "wp:WP-06",
+          "description": "v0.91.5 work package 06 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4945,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-06][records] Repair sprint review and AWS lane closeout truth after review",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4945",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4945.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "57a7bd21074bdc03fc63b043dfcbd28057a3dee4",
+          "mergedAt": "2026-07-06T05:47:20Z",
+          "number": 4948,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4948"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T18:18:02Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wSzY2",
+          "number": 5128,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5128"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4938,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][validation] Classify scheduler JSON fixture repairs into a runnable focused proof lane",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4938",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4938.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "39e1d1253c28d89f307afe362f497e58e5dcb8c0",
+          "mergedAt": "2026-07-10T18:18:01Z",
+          "number": 5128,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5128"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T02:50:19Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uKWKI",
+          "number": 4939,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4939"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DCw",
+          "name": "wp:WP-06",
+          "description": "v0.91.5 work package 06 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4936,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-06][records] Repair closed issue sprint truth",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4936",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4936.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "2b05c93436f03f1a95081ec6ac36483a18745fbf",
+          "mergedAt": "2026-07-06T02:50:19Z",
+          "number": 4939,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4939"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T09:01:05Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uQSlk",
+          "number": 4964,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4964"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4933,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][persistence][csm] Decide and implement canonical binary snapshot segment format",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4933",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4933.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "946191c76131b0eea46327780652ff1c3c50c777",
+          "mergedAt": "2026-07-06T09:01:04Z",
+          "number": 4964,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4964"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T06:08:40Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uKRy2",
+          "number": 4937,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4937"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6C9g",
+          "name": "wp:WP-05",
+          "description": "v0.91.5 work package 05 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4932,
+      "state": "CLOSED",
+      "title": "[v0.91.7][review][WP-05] Create sprint review register and repair WP-05 review truth",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4932",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4932.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "9219b1ecb5971acd166db2d75be79da095f29f7e",
+          "mergedAt": "2026-07-06T06:08:39Z",
+          "number": 4937,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4937"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T10:15:37Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uRoe9",
+          "number": 4967,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4967"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn0KQxg",
+          "name": "area:observability",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4929,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][observability][csm] Add CSM runtime observability API endpoints",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4929",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4929.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "a86ab4a1c9dad31a453f7d8e4bd849c3cfef9f06",
+          "mergedAt": "2026-07-06T10:15:36Z",
+          "number": 4967,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4967"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T02:08:10Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uJ2qI",
+          "number": 4930,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4930"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DCw",
+          "name": "wp:WP-06",
+          "description": "v0.91.5 work package 06 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4928,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-06][validation] Operationalize validation platform routing",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4928",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4928.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "a8c93bac943ff62cc6cb7695997ced6bdc34d6f6",
+          "mergedAt": "2026-07-06T02:08:09Z",
+          "number": 4930,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4930"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-07T17:19:37Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACneI3-Q",
+          "name": "tools",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4927,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][sprint] Complete workflow tooling stabilization follow-up wave",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4927",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4927.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-06T06:09:09Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uM0Ll",
+          "number": 4947,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4947"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW1JCAg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACneI3-Q",
+          "name": "tools",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4924,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][cards] Align SOR renderer with PR-publication doctor truth",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4924",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4924.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "81d511b903e54f2489fba7158082b228b36910cd",
+          "mergedAt": "2026-07-06T06:09:08Z",
+          "number": 4947,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4947"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T10:38:02Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uTDdW",
+          "number": 4968,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4968"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4922,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][ops] Create incident-command runbooks for CSM Polis survival",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4922",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4922.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "f42238fe18b24e91213fddeaf53c8466d3b06068",
+          "mergedAt": "2026-07-06T10:38:01Z",
+          "number": 4968,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4968"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T16:48:38Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uWSs1",
+          "number": 4971,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4971"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4921,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][resilience] Implement overload and backpressure policy for CSM Polis",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4921",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4921.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "ed61d7730f4d62186a19f214d122e5d2f5c3e980",
+          "mergedAt": "2026-07-06T16:48:37Z",
+          "number": 4971,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4971"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T23:37:22Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wYOHt",
+          "number": 5144,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5144"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q4Pw",
+          "name": "area:security",
+          "description": "Security-related changes",
+          "color": "d93f0b"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6EAQ",
+          "name": "wp:WP-12",
+          "description": "v0.91.5 work package 12 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4920,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-12][security] Define key rotation and break-glass policy for CSM Polis",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4920",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4920.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "2e61a6148f8ac272298af350acf953b86a03034c",
+          "mergedAt": "2026-07-10T23:37:21Z",
+          "number": 5144,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5144"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T12:12:18Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uUHK7",
+          "number": 4970,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4970"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4919,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][recovery] Implement restore fire-drill cadence for Polis state",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4919",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4919.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "d94ff7e4980cf3d1793e65271b92c088be3a78e6",
+          "mergedAt": "2026-07-06T12:12:17Z",
+          "number": 4970,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4970"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T10:52:43Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uTcp5",
+          "number": 4969,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4969"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4918,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][recovery] Define and prove CSM Polis RTO/RPO targets",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4918",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4918.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "20c712102dccf1bb718356caac2e1bfd21449161",
+          "mergedAt": "2026-07-06T10:52:42Z",
+          "number": 4969,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4969"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T22:19:55Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wW8GK",
+          "number": 5139,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5139"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q4Pw",
+          "name": "area:security",
+          "description": "Security-related changes",
+          "color": "d93f0b"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6EAQ",
+          "name": "wp:WP-12",
+          "description": "v0.91.5 work package 12 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4917,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-12][security] Implement tamper-evident custody for Polis artifacts",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4917",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4917.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "5d01f6a0d98c282b63ac32a41eb5a93d93a7c68e",
+          "mergedAt": "2026-07-10T22:19:54Z",
+          "number": 5139,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5139"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T05:05:08Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uKlQL",
+          "number": 4941,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4941"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW1JCAg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACneI3-Q",
+          "name": "tools",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4916,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][validation] Make PR fast-lane warm-cache Python/runtime failures residue-free",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4916",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4916.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "2208e5b93f71d439dbbb15887c06d53acfe1f0e7",
+          "mergedAt": "2026-07-06T05:05:07Z",
+          "number": 4941,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4941"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-07T02:24:57Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uioPm",
+          "number": 4994,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4994"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DVg",
+          "name": "wp:WP-08",
+          "description": "v0.91.5 work package 08 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn0KQxg",
+          "name": "area:observability",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4915,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-08][cloudfront] Add AWS CloudFront and control-plane hooks",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4915",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4915.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "9c12793459f84d6c22b3a97f5161f554cd3b8e78",
+          "mergedAt": "2026-07-07T02:24:56Z",
+          "number": 4994,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4994"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-11T05:25:16Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wbzlA",
+          "number": 5160,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5160"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q4Pw",
+          "name": "area:security",
+          "description": "Security-related changes",
+          "color": "d93f0b"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6EAQ",
+          "name": "wp:WP-12",
+          "description": "v0.91.5 work package 12 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4914,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-12][security] Demonstrate CAV red-blue tactics in CSM runtime",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4914",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4914.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "0fb530134bf7d776b17ffa00b10d1944cc498b39",
+          "mergedAt": "2026-07-11T05:25:15Z",
+          "number": 5160,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5160"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T21:38:28Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uhsuh",
+          "number": 4993,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4993"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DVg",
+          "name": "wp:WP-08",
+          "description": "v0.91.5 work package 08 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn0KQxg",
+          "name": "area:observability",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4913,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-08][storage] Prove 12-nines-class durable storage for Polis state",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4913",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4913.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "69d299a91d05842af3c8c3c1c1079427a1a666d3",
+          "mergedAt": "2026-07-06T21:38:27Z",
+          "number": 4993,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4993"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T17:27:13Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wIUNW",
+          "number": 5106,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5106"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6D2w",
+          "name": "wp:WP-11",
+          "description": "v0.91.5 work package 11 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3KBPw",
+          "name": "area:architecture",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4912,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-11][godel] Implement per-agent versioned snapshot and diff protocol",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4912",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4912.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "e7edb38b514abed994277e964353a37b0e88baf8",
+          "mergedAt": "2026-07-10T17:27:12Z",
+          "number": 5106,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5106"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T06:29:33Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uM2zc",
+          "number": 4949,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4949"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4911,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][resilience] Implement safe-fail serialization maximization",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4911",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4911.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "254f6ff6ecb28cee06906de9b988d6d4750529b5",
+          "mergedAt": "2026-07-06T06:29:32Z",
+          "number": 4949,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4949"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T03:54:48Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uKh4C",
+          "number": 4940,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4940"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4910,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][persistence] Implement freeze-dry Polis migration from wuji to EC2",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4910",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4910.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "a1265633fd06ab58b17731ea969b73e7336dcd4b",
+          "mergedAt": "2026-07-06T03:54:47Z",
+          "number": 4940,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4940"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T02:14:31Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uJeg8",
+          "number": 4926,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4926"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn0KQxg",
+          "name": "area:observability",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4909,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][observability] Define no-sparrow event-loss SLO and telemetry coverage",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4909",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4909.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "c1ed1f33b15bddcae3e7bdcdc64f10c7d61de499",
+          "mergedAt": "2026-07-06T02:14:30Z",
+          "number": 4926,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4926"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T02:40:05Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW1JCAg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACneI3-Q",
+          "name": "tools",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4908,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][ci] Fix long-lived tokio finish validation profile fail-closed regression",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4908",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4908.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-06T02:15:16Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uJ8K_",
+          "number": 4931,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4931"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW1JCAg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACneI3-Q",
+          "name": "tools",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4907,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][workflow] pr shepherd should resolve repo-owned fallback binary without requiring a local build",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4907",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4907.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "47837847ef5ecae63fcef8d454f3d662cb05ee9a",
+          "mergedAt": "2026-07-06T02:15:15Z",
+          "number": 4931,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4931"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T16:00:41Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wH9iQ",
+          "number": 5105,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5105"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4906,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][soak] Run final post-blocker CSM runtime coherence gate",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4906",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4906.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "a46ae2ae7fe1407343d9d7f0351e847b2252a9da",
+          "mergedAt": "2026-07-10T16:00:40Z",
+          "number": 5105,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5105"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T05:05:20Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uLACb",
+          "number": 4943,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4943"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW1JCAg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACneI3-Q",
+          "name": "tools",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4905,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][ci] Classify long-running adl-coverage wait states with bounded liveness evidence",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4905",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4905.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "decb586f3af06c799f061ba90b82a7b9bbb7135f",
+          "mergedAt": "2026-07-06T05:05:19Z",
+          "number": 4943,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4943"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T01:30:44Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uH4pp",
+          "number": 4925,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4925"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn0KQxg",
+          "name": "area:observability",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4904,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][otel] Implement CSM OTLP exporter and collector proof",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4904",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4904.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "a4ae3ac0877445aefd2429623b8632a16e083269",
+          "mergedAt": "2026-07-06T01:30:43Z",
+          "number": 4925,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4925"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-05T20:16:58Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uGb7T",
+          "number": 4923,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4923"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4903,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][csm] Implement production CSM daemon service envelope",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4903",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4903.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "6e3ccb68175c4029c2c35a0784d57c645cfdc6e7",
+          "mergedAt": "2026-07-05T20:16:57Z",
+          "number": 4923,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4923"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T05:52:22Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wCN6H",
+          "number": 5095,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5095"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3KBPw",
+          "name": "area:architecture",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4899,
+      "state": "CLOSED",
+      "title": "[v0.91.7][rust][signing] Version canonical JSON signing profile",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4899",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4899.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "871dad6448cd36cc0d647cbe67e02710ffee6324",
+          "mergedAt": "2026-07-10T05:52:21Z",
+          "number": 5095,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5095"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T02:39:12Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7v6oHJ",
+          "number": 5072,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5072"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3KBPw",
+          "name": "area:architecture",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4898,
+      "state": "CLOSED",
+      "title": "[v0.91.7][rust][security] Implement secret and digest hygiene wrappers",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4898",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4898.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "2c5386a8c3f5e08d1fb82fdb8e3a0e588306b774",
+          "mergedAt": "2026-07-10T02:39:11Z",
+          "number": 5072,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5072"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T05:40:34Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wBRwS",
+          "number": 5094,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5094"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3KBPw",
+          "name": "area:architecture",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4897,
+      "state": "CLOSED",
+      "title": "[v0.91.7][rust][providers] Refactor provider HTTP mechanics onto middleware retry and URL helpers",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4897",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4897.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "9a75d258ef96b9db3516dbf9541096fb58c264c0",
+          "mergedAt": "2026-07-10T05:40:33Z",
+          "number": 5094,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5094"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T05:37:31Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wAn0x",
+          "number": 5092,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5092"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3KBPw",
+          "name": "area:architecture",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4896,
+      "state": "CLOSED",
+      "title": "[v0.91.7][rust][observability] Implement tracing-backed ADL event compatibility layer",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4896",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4896.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "16e91bd22486f4d50ba9fc98ce8faf7c935ac2a8",
+          "mergedAt": "2026-07-10T05:37:30Z",
+          "number": 5092,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5092"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T05:34:21Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7v_4nh",
+          "number": 5088,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5088"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3KBPw",
+          "name": "area:architecture",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4895,
+      "state": "CLOSED",
+      "title": "[v0.91.7][rust][enum] Integrate prompt-card enums into structured prompt validation",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4895",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4895.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "b803b644bd0150248a0bec583201dd6d1ac25ea9",
+          "mergedAt": "2026-07-10T05:34:20Z",
+          "number": 5088,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5088"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T02:17:05Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7v-fkM",
+          "number": 5081,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5081"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3KBPw",
+          "name": "area:architecture",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4894,
+      "state": "CLOSED",
+      "title": "[v0.91.7][rust][enum] Integrate prompt-card enums into editor and values validation",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4894",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4894.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "941439a5a47c0d2f02786a08d695033c15f26db6",
+          "mergedAt": "2026-07-10T02:17:04Z",
+          "number": 5081,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5081"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-09T20:50:48Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7v5bFn",
+          "number": 5067,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5067"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3KBPw",
+          "name": "area:architecture",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4893,
+      "state": "CLOSED",
+      "title": "[v0.91.7][rust][enum] Implement shared prompt-card enum surface",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4893",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4893.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "a36044188e85d2bc14264a30c2c7c25aae1762ce",
+          "mergedAt": "2026-07-09T20:50:47Z",
+          "number": 5067,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5067"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-09T19:21:37Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7v3v4_",
+          "number": 5057,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5057"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3KBPw",
+          "name": "area:architecture",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4892,
+      "state": "CLOSED",
+      "title": "[v0.91.7][rust][enum] Inventory finite Rust enum/string contracts",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4892",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4892.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "df981025670bcedb904bc99ff003d59995e50f4a",
+          "mergedAt": "2026-07-09T19:21:36Z",
+          "number": 5057,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5057"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-05T19:29:42Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7t_c45",
+          "number": 4891,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4891"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4890,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][runtime] Split runtime into dedicated csm owner binary",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4890",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4890.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "16a2bbf500b2ad9106f5718b3fb5182afe85e2b9",
+          "mergedAt": "2026-07-05T19:29:41Z",
+          "number": 4891,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4891"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-05T04:30:22Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7t-tQH",
+          "number": 4887,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4887"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4885,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][runtime] Add supervised daemon mode for integrated runtime",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4885",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4885.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "08377c66316936a51b8012fae7599650191df494",
+          "mergedAt": "2026-07-05T04:30:21Z",
+          "number": 4887,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4887"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T05:04:55Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uKKV9",
+          "number": 4934,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4934"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW1JCAg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACneI3-Q",
+          "name": "tools",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4882,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][validation] Map explicit .gitignore guardrail changes to a finish validation lane",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4882",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4882.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "b05d22bf690956f31fa56a10b224ab5f7908928d",
+          "mergedAt": "2026-07-06T05:04:55Z",
+          "number": 4934,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4934"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-05T04:40:10Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7t-yyU",
+          "number": 4888,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4888"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4880,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][soak] Run final integrated Runtime Soak 2 rerun",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4880",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4880.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "c43626062b1805fc1e56e6036091e7a6f8995e9a",
+          "mergedAt": "2026-07-05T04:40:09Z",
+          "number": 4888,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4888"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T02:43:40Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7t92-v",
+          "number": 4881,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4881"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DCw",
+          "name": "wp:WP-06",
+          "description": "v0.91.5 work package 06 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4879,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-06][aws] Add reusable ADL builder image for validation platforms",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4879",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4879.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "514ccfa4d58548b8bb4cad73a06eee08b9e50dc5",
+          "mergedAt": "2026-07-06T02:43:39Z",
+          "number": 4881,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4881"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-05T05:36:44Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7t-TcF",
+          "number": 4884,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4884"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4877,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][skills] Resolve sprint-conductor installed/tracked parity drift",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4877",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4877.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "8b9af698bd5d6e1bf9ac9b753dae11a6913bd2e2",
+          "mergedAt": "2026-07-05T05:36:44Z",
+          "number": 4884,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4884"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-04T23:51:08Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7t8rF1",
+          "number": 4878,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4878"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4876,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][skills] Add VPP editor skill",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4876",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4876.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "32694e097e272258fefb4460e920587bc3a69397",
+          "mergedAt": "2026-07-04T23:51:07Z",
+          "number": 4878,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4878"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-04T22:33:51Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tyj--",
+          "number": 4866,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4866"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4864,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][review] Fix code-review gate redaction false positives on deleted diff lines",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4864",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4864.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "c05663f7fe036f5e5d12450c07c49a971b188ed5",
+          "mergedAt": "2026-07-04T22:33:50Z",
+          "number": 4866,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4866"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-04T01:16:37Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DCw",
+          "name": "wp:WP-06",
+          "description": "v0.91.5 work package 06 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4859,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-06][aws] Prove GitHub Actions plus AWS CodeFriend build lane",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4859",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4859.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-04T01:16:37Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DCw",
+          "name": "wp:WP-06",
+          "description": "v0.91.5 work package 06 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4858,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-06][aws] Finish AWS Spot EC2 remote validation lane integration",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4858",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4858.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-05T05:37:12Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7t-g9d",
+          "number": 4886,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4886"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4854,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][validation] Align scheduler finish profile with validation manager",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4854",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4854.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "5d1b913e316b219f162861d1459f85b67b950db5",
+          "mergedAt": "2026-07-05T05:37:11Z",
+          "number": 4886,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4886"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-04T07:24:24Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tyygr",
+          "number": 4867,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4867"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACqEU16g",
+          "name": "validation",
+          "description": "Validation tooling, proof lanes, and check routing",
+          "color": "5319e7"
+        }
+      ],
+      "number": 4853,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][finish] Break draft PR ready-promotion deadlock when adl-ci is gated by pr_draft",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4853",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4853.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "491d3051a8a8499ebe651a842d26bdb4afc6c316",
+          "mergedAt": "2026-07-04T07:24:23Z",
+          "number": 4867,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4867"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-04T02:20:07Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7txuIq",
+          "number": 4861,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4861"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6C9g",
+          "name": "wp:WP-05",
+          "description": "v0.91.5 work package 05 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4850,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-05][closeout] Repair scheduler/provider card and closeout truth",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4850",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4850.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "d86560bf73144f86e938e4e5c252234a326f5837",
+          "mergedAt": "2026-07-04T02:20:06Z",
+          "number": 4861,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4861"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-04T02:01:17Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7txFbY",
+          "number": 4855,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4855"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6C9g",
+          "name": "wp:WP-05",
+          "description": "v0.91.5 work package 05 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3J_yQ",
+          "name": "area:provider",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4849,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-05][scheduler] Fix provider-route and model-suitability mismatch",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4849",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4849.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "ef6c6668cd95e7554c5b51e8cc329b31cc4fcedd",
+          "mergedAt": "2026-07-04T02:01:16Z",
+          "number": 4855,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4855"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T08:14:23Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uOmlG",
+          "number": 4958,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4958"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW1JCAg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACneI3-Q",
+          "name": "tools",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4848,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][finish] Runtime command finish lane expands to unrelated pr_cmd nextest failures",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4848",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4848.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "6a415c59e5462c0b74a4298836176f4916eacb25",
+          "mergedAt": "2026-07-06T08:14:22Z",
+          "number": 4958,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4958"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-04T23:34:44Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7t14eb",
+          "number": 4875,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4875"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACntpjPQ",
+          "name": "area:planning",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4845,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][handoff] Produce final pre-v0.92 runtime-coherence disposition",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4845",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4845.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "8164a900b6e48c2362f47c69a7d58ece2b4627f4",
+          "mergedAt": "2026-07-04T23:34:44Z",
+          "number": 4875,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4875"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-04T23:32:03Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7t1uCc",
+          "number": 4874,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4874"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4844,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][review] Produce Soak 2 review and blocker register",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4844",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4844.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "0c33e9f8e1206bac7dbf697616802df11fa65a38",
+          "mergedAt": "2026-07-04T23:32:02Z",
+          "number": 4874,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4874"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-04T23:20:09Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7t0hKV",
+          "number": 4870,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4870"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4843,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][matrix] Implement Soak 2 feature-list integration matrix and fixtures",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4843",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4843.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "79eb88c7190fcadf398d7cb78c8673e179577770",
+          "mergedAt": "2026-07-04T23:20:08Z",
+          "number": 4870,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4870"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-04T06:50:47Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7twzzJ",
+          "number": 4851,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4851"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3KBPw",
+          "name": "area:architecture",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4842,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][runtime-v2] Reconcile Runtime v2 prototype with current runtime substrate",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4842",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4842.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "aa8ae6bb38d812087d8c1260283ebd95a8177769",
+          "mergedAt": "2026-07-04T06:50:46Z",
+          "number": 4851,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4851"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T02:13:54Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tyP9m",
+          "number": 4865,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4865"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DCw",
+          "name": "wp:WP-06",
+          "description": "v0.91.5 work package 06 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4838,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-06][aws] Add GitHub Actions AWS CodeFriend build lane",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4838",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4838.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "94e00b3a9f0115a017adc4459056601458b0b244",
+          "mergedAt": "2026-07-06T02:13:53Z",
+          "number": 4865,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4865"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T01:29:17Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tx8-u",
+          "number": 4863,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4863"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DCw",
+          "name": "wp:WP-06",
+          "description": "v0.91.5 work package 06 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4837,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-06][aws] Integrate AWS Spot EC2 remote validation lane",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4837",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4837.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "1689c4344e92fb0c131b0bc63a6174fadfb1bb7d",
+          "mergedAt": "2026-07-06T01:29:16Z",
+          "number": 4863,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4863"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T23:39:36Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tweQC",
+          "number": 4846,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4846"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4836,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][pr] Repair pr finish root owner-binary discovery",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4836",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4836.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "cf828117480856d0ab72862688dc7072fac42aee",
+          "mergedAt": "2026-07-03T23:39:35Z",
+          "number": 4846,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4846"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T23:54:13Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7twoky",
+          "number": 4847,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4847"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4835,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][validation] Keep pr_cmd slow E2E tests out of the default fast lane",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4835",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4835.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "adf420d4fe2c65d39eab0bded73ee032ca88875a",
+          "mergedAt": "2026-07-03T23:54:13Z",
+          "number": 4847,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4847"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T22:06:05Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tvXIw",
+          "number": 4831,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4831"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4830,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][pr] Repair pr watch owner-binary fallback",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4830",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4830.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "76dfb36e7f4f24560f2081ceb12655e7833b1018",
+          "mergedAt": "2026-07-03T22:06:04Z",
+          "number": 4831,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4831"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T19:50:06Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACqDUPZg",
+          "name": "tooling",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACqDUPjQ",
+          "name": "unity",
+          "description": "",
+          "color": "ededed"
+        }
+      ],
+      "number": 4825,
+      "state": "CLOSED",
+      "title": "[v0.91.7][unity][tools] Free disk/preserve dirty #4703 Unity worktree before rebind",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4825",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4825.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-03T20:48:35Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7ttwrg",
+          "number": 4821,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4821"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3J_yQ",
+          "name": "area:provider",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4819,
+      "state": "CLOSED",
+      "title": "[v0.91.7][provider][adapter] Add portable output-token budgets to provider invocations",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4819",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4819.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "85d808b47b54b7d6c17ce0af179674da7a063bce",
+          "mergedAt": "2026-07-03T20:48:34Z",
+          "number": 4821,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4821"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T20:03:20Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7ttioC",
+          "number": 4820,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4820"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3J_yQ",
+          "name": "area:provider",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4817,
+      "state": "CLOSED",
+      "title": "[v0.91.7][provider][anthropic] Set up Fable 5 suitability test",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4817",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4817.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "d2ae3636939bb8df2f38a6209eb0a977f756789c",
+          "mergedAt": "2026-07-03T20:03:19Z",
+          "number": 4820,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4820"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T23:28:53Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7twNdp",
+          "number": 4840,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4840"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4815,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][finish] Publish registered multi-command validation lanes",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4815",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4815.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "790d428bbfd33036df8898e7b76d4751e5096f9d",
+          "mergedAt": "2026-07-03T23:28:52Z",
+          "number": 4840,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4840"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T16:45:26Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tjxVF",
+          "number": 4808,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4808"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4807,
+      "state": "CLOSED",
+      "title": "[v0.91.7][chronosense][closeout] Repair Chronosense closeout truth and continuity proof artifact",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4807",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4807.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "a691ceef7d83969d4ba1c52aeff43e65e982b37a",
+          "mergedAt": "2026-07-03T16:45:26Z",
+          "number": 4808,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4808"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-04T00:00:07Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4806,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][sprint] Complete repo-native workflow stabilization wave",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4806",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4806.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-03T18:10:38Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7trJuG",
+          "number": 4810,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4810"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4804,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][pr] Repair PR help and owner-binary discovery regressions",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4804",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4804.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "d21a74860180cfd4b53a5bc35dfce175278740a1",
+          "mergedAt": "2026-07-03T18:10:37Z",
+          "number": 4810,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4810"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T22:34:59Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tvZjh",
+          "number": 4832,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4832"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DCw",
+          "name": "wp:WP-06",
+          "description": "v0.91.5 work package 06 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4800,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-06][validation] Split full validation into fast lane plus fanned slow families",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4800",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4800.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "2e0874ab45cb5c5567d2abfee194d976ae158f55",
+          "mergedAt": "2026-07-03T22:34:58Z",
+          "number": 4832,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4832"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T09:53:57Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tgy5c",
+          "number": 4801,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4801"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4796,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][finish] Repair pr_cmd fast-lane validation-profile failures",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4796",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4796.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "0668fc0ebde21a8c61a172448e62720b8b5b0213",
+          "mergedAt": "2026-07-03T09:53:56Z",
+          "number": 4801,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4801"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T22:49:00Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tvt3T",
+          "number": 4833,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4833"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4795,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][closeout] Stop closeout from dirtying unrelated tracked card paths before worktree prune",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4795",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4795.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "dbec0dc29deeb8e08c8a34d7e91d6a5e8e942e9c",
+          "mergedAt": "2026-07-03T22:48:59Z",
+          "number": 4833,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4833"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T07:00:56Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tdXqu",
+          "number": 4793,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4793"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4792,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][ci] Restore fast bounded Rust PR validation",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4792",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4792.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "43bb7102fe4eb6b72cae995b50e4a68196b3cbaf",
+          "mergedAt": "2026-07-03T07:00:55Z",
+          "number": 4793,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4793"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T03:48:55Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7takMS",
+          "number": 4791,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4791"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4790,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][ci] Install required coverage tools before CI path-policy contract",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4790",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4790.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "2962137b82365d645227374973241bf2b2d93be2",
+          "mergedAt": "2026-07-03T03:48:54Z",
+          "number": 4791,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4791"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T21:53:10Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tt3Vc",
+          "number": 4822,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4822"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4789,
+      "state": "CLOSED",
+      "title": "[v0.91.7][unity][tools] Fix Unity-MCP project binding and screenshot proof reliability",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4789",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4789.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "955d53a385283b4f843661ec70b2725a110b33b0",
+          "mergedAt": "2026-07-03T21:53:10Z",
+          "number": 4822,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4822"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T19:41:09Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7ttY8Q",
+          "number": 4818,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4818"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4788,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][rust-cache] Make warm-cache setup universal across Rust validation runners",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4788",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4788.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "940041273e58487849b30b79321492ec652c1f0b",
+          "mergedAt": "2026-07-03T19:41:08Z",
+          "number": 4818,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4818"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T21:03:01Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tuL53",
+          "number": 4826,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4826"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4787,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][pr-finish] Add first-class release-gate disposition support",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4787",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4787.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "bb7db33bea3703d9e252565da7222cf6c56b618c",
+          "mergedAt": "2026-07-03T21:03:00Z",
+          "number": 4826,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4826"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T03:20:46Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tZ6JL",
+          "number": 4786,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4786"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4785,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][coverage] Simplify adl-coverage and restore sub-5-minute PR path",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4785",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4785.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "7178edd71b8746415b2eee0c7d4555e63ab72825",
+          "mergedAt": "2026-07-03T03:20:45Z",
+          "number": 4786,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4786"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-04T23:13:22Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7t0uX8",
+          "number": 4871,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4871"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4784,
+      "state": "CLOSED",
+      "title": "[v0.91.7][resilience][soak] Prove integrated resilience failure injection",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4784",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4784.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "573307379d3e487c05ccd974eb5b29942128d8db",
+          "mergedAt": "2026-07-04T23:13:21Z",
+          "number": 4871,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4871"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-05T03:03:29Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6C9g",
+          "name": "wp:WP-05",
+          "description": "v0.91.5 work package 05 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4783,
+      "state": "CLOSED",
+      "title": "[v0.91.7][resilience][runtime] Integrate scheduler watcher and AEE resilience middleware",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4783",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4783.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-06T02:54:11Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uKOAw",
+          "number": 4935,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4935"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DCw",
+          "name": "wp:WP-06",
+          "description": "v0.91.5 work package 06 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DVg",
+          "name": "wp:WP-08",
+          "description": "v0.91.5 work package 08 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4782,
+      "state": "CLOSED",
+      "title": "[v0.91.7][resilience][remote] Integrate AWS SSM EC2 and remote-builder resilience",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4782",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4782.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "cf678812a08a67c444e4152053419e3f8247d58b",
+          "mergedAt": "2026-07-06T02:54:10Z",
+          "number": 4935,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4935"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-07T04:18:38Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7upNyA",
+          "number": 5014,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5014"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6C9g",
+          "name": "wp:WP-05",
+          "description": "v0.91.5 work package 05 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3J_yQ",
+          "name": "area:provider",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4781,
+      "state": "CLOSED",
+      "title": "[v0.91.7][resilience][provider] Integrate provider and model call resilience",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4781",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4781.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "3c785df4cd1dea640476d4ac472e4ceece41b258",
+          "mergedAt": "2026-07-07T04:18:37Z",
+          "number": 5014,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5014"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-07T03:50:34Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uogGG",
+          "number": 5008,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5008"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6Cbg",
+          "name": "wp:WP-03",
+          "description": "v0.91.5 work package 03 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4780,
+      "state": "CLOSED",
+      "title": "[v0.91.7][resilience][workflow] Implement PR and CI shepherding resilience",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4780",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4780.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "5f2510dc085c8868cdc20f8a30b13e945c756b1e",
+          "mergedAt": "2026-07-07T03:50:33Z",
+          "number": 5008,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5008"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-07T04:24:20Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7upzUR",
+          "number": 5018,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5018"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoBXnHQ",
+          "name": "type:mini-sprint",
+          "description": "Mini-sprint umbrella issue",
+          "color": "BFD4F2"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4778,
+      "state": "CLOSED",
+      "title": "[v0.91.7][resilience] Integrate resilience into runtime and workflow paths",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4778",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4778.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "91bf2248fe6af32e4c34839c8aaebceb85ca624a",
+          "mergedAt": "2026-07-07T04:24:19Z",
+          "number": 5018,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5018"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T02:47:58Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tZbjR",
+          "number": 4779,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4779"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4777,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][ci] Repair adl-ci required toolchain without fake fixtures",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4777",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4777.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "8cd8f9f01815b8b0c2648912bb0665564fbe5137",
+          "mergedAt": "2026-07-03T02:47:57Z",
+          "number": 4779,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4779"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T07:07:51Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4773,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools] Fix pr finish Rustls CryptoProvider panic",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4773",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4773.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-03T10:30:14Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tiin1",
+          "number": 4805,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4805"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4771,
+      "state": "CLOSED",
+      "title": "[v0.91.7][chronosense][proof] Prove long-running context continuity end to end",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4771",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4771.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "ab0f0982bb059907febf068a4d3df7488fd3920c",
+          "mergedAt": "2026-07-03T10:30:13Z",
+          "number": 4805,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4805"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T10:00:44Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7th19E",
+          "number": 4803,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4803"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4770,
+      "state": "CLOSED",
+      "title": "[v0.91.7][chronosense][causality] Integrate temporal causality and explanation with trace review",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4770",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4770.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "21ca941562fb1d2ceddc323c21a1b299347ccc1f",
+          "mergedAt": "2026-07-03T10:00:43Z",
+          "number": 4803,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4803"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T09:46:19Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7thP-Q",
+          "number": 4802,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4802"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3J_yQ",
+          "name": "area:provider",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4769,
+      "state": "CLOSED",
+      "title": "[v0.91.7][chronosense][scheduler] Integrate commitments and deadlines with scheduler",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4769",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4769.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "f9110a807a6bb63310b85759dd5e7e58daaa0182",
+          "mergedAt": "2026-07-03T09:46:18Z",
+          "number": 4802,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4802"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T08:52:00Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tflMJ",
+          "number": 4798,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4798"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4768,
+      "state": "CLOSED",
+      "title": "[v0.91.7][chronosense][memory] Implement temporal query index for ObsMem and Memory Palace",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4768",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4768.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "f8695e3a6a7ed73b40af38148b5629837be81837",
+          "mergedAt": "2026-07-03T08:51:59Z",
+          "number": 4798,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4798"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T07:05:43Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tdk7T",
+          "number": 4794,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4794"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4767,
+      "state": "CLOSED",
+      "title": "[v0.91.7][chronosense][trace] Integrate temporal anchors into runtime events",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4767",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4767.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "49364783e2eace8beed06da50cd4dd158a9ab1ec",
+          "mergedAt": "2026-07-03T07:05:42Z",
+          "number": 4794,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4794"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T06:13:30Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tYWAg",
+          "number": 4775,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4775"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3KBPw",
+          "name": "area:architecture",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4766,
+      "state": "CLOSED",
+      "title": "[v0.91.7][chronosense][runtime] Implement Chronosense runtime service and clock stack",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4766",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4766.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "5c04c5906d91faa9f4599cfd120b2070098f6b7f",
+          "mergedAt": "2026-07-03T06:13:29Z",
+          "number": 4775,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4775"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T10:31:58Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvJk7g",
+          "name": "type:epic",
+          "description": "Umbrella issue grouping related work",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3KBPw",
+          "name": "area:architecture",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4765,
+      "state": "CLOSED",
+      "title": "[v0.91.7][chronosense][sprint] Implement full Chronosense integration before v0.92",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4765",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4765.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-11T19:47:03Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wmpfR",
+          "number": 5197,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5197"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6ENg",
+          "name": "wp:WP-13",
+          "description": "v0.91.5 work package 13 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACntpjPQ",
+          "name": "area:planning",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4757,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-13][publication] Implement publication and paper delivery surfaces",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4757",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4757.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "e7a5f40fc8d74d8d07248de8bd09bf155069bf65",
+          "mergedAt": "2026-07-11T19:47:03Z",
+          "number": 5197,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5197"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-11T19:18:20Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wl8V-",
+          "number": 5193,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5193"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6ENg",
+          "name": "wp:WP-13",
+          "description": "v0.91.5 work package 13 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACntpjPQ",
+          "name": "area:planning",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4756,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-13][codefriend] Implement CodeFriend v1 and adapter v2 proof path",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4756",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4756.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "e177e96dfe8764e8b0136e6c1455dc511e77f0db",
+          "mergedAt": "2026-07-11T19:18:19Z",
+          "number": 5193,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5193"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-11T18:15:19Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wllYp",
+          "number": 5189,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5189"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6ENg",
+          "name": "wp:WP-13",
+          "description": "v0.91.5 work package 13 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACntpjPQ",
+          "name": "area:planning",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4755,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-13][guild] Implement MVP guild foundation",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4755",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4755.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "18af58ca7dfbdb8e55a0e1405df3a5a233706a4f",
+          "mergedAt": "2026-07-11T18:15:18Z",
+          "number": 5189,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5189"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-11T17:13:38Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wg56f",
+          "number": 5185,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5185"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6ENg",
+          "name": "wp:WP-13",
+          "description": "v0.91.5 work package 13 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACntpjPQ",
+          "name": "area:planning",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4754,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-13][economics] Implement MVP economics and civilization model",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4754",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4754.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "c988409aa2a92d8a7de66bf561af44847c342954",
+          "mergedAt": "2026-07-11T17:13:37Z",
+          "number": 5185,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5185"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-11T10:44:07Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wgLFU",
+          "number": 5171,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5171"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6ENg",
+          "name": "wp:WP-13",
+          "description": "v0.91.5 work package 13 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACntpjPQ",
+          "name": "area:planning",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4753,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-13][godel] Implement Godel constructability mechanics in full",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4753",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4753.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "c010dea2c92309f7b8e3eda614bde57c196a20e4",
+          "mergedAt": "2026-07-11T10:44:06Z",
+          "number": 5171,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5171"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-11T11:10:01Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7weqlM",
+          "number": 5165,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5165"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6ENg",
+          "name": "wp:WP-13",
+          "description": "v0.91.5 work package 13 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACntpjPQ",
+          "name": "area:planning",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4752,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-13][affect] Implement integrated affect model",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4752",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4752.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "051ab7e522a07d2a12a56b26b6d1e31488735b55",
+          "mergedAt": "2026-07-11T11:10:01Z",
+          "number": 5165,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5165"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T04:17:39Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4751,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][github] Fix rustls CryptoProvider init for repo-native owner binaries",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4751",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4751.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-03T00:27:23Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tWy2h",
+          "number": 4750,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4750"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4749,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools] Wire warm Rust dependency cache into authoritative coverage lane",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4749",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4749.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "62e39b4bdeb20708d144ffdb7a45f93bc156eb4b",
+          "mergedAt": "2026-07-03T00:27:23Z",
+          "number": 4750,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4750"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T00:13:21Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tWrgf",
+          "number": 4748,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4748"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6CrA",
+          "name": "wp:WP-04",
+          "description": "v0.91.5 work package 04 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4747,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-04][review] Resolve WP-04 closeout review findings",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4747",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4747.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "37e6a99783ba9f604b89babb18c47d37dadc4409",
+          "mergedAt": "2026-07-03T00:13:20Z",
+          "number": 4748,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4748"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-11T00:25:02Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4745,
+      "state": "CLOSED",
+      "title": "[v0.91.7][unity][demo] Resolve observatory asset publication and MCP dependency policy",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4745",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4745.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-02T23:08:01Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tVm_U",
+          "number": 4744,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4744"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6CrA",
+          "name": "wp:WP-04",
+          "description": "v0.91.5 work package 04 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4743,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-04][prediction] Implement execution metrics prediction engine",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4743",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4743.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "fa6a7b74ab64eeb38d2435561a0eb12ecd70ca20",
+          "mergedAt": "2026-07-02T23:08:00Z",
+          "number": 4744,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4744"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T05:18:39Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tY5tg",
+          "number": 4776,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4776"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW1JCAg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACneI3-Q",
+          "name": "tools",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4740,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools] Fix process status false unbound for reachable localhost services",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4740",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4740.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "6e3f74cef7975761a1d041b4dc45046b05e9c527",
+          "mergedAt": "2026-07-03T05:18:38Z",
+          "number": 4776,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4776"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T19:11:09Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7ttAE4",
+          "number": 4816,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4816"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4738,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools] Implement workflow-conductor helper without gh fallback",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4738",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4738.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "123f9f218e9752317aeaef46ec141d7feb15e8b9",
+          "mergedAt": "2026-07-03T19:11:08Z",
+          "number": 4816,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4816"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T18:53:19Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tsm4B",
+          "number": 4814,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4814"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4737,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][conductor] Remove gh dependency from conductor helper tracker inference",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4737",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4737.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "08f91e9ef33fe0c742f1693bc746d6d9440cb751",
+          "mergedAt": "2026-07-03T18:53:18Z",
+          "number": 4814,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4814"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T10:51:13Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tePlJ",
+          "number": 4797,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4797"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4736,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][closeout] Fix closeout deleting unrelated VPP before prune",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4736",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4736.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "9fde8a9ecb692f93d9bee2ecaf12cdaf6b85a746",
+          "mergedAt": "2026-07-03T10:51:12Z",
+          "number": 4797,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4797"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-02T22:49:03Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tSZCR",
+          "number": 4731,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4731"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4730,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools] Review and repair adl-coverage check truth",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4730",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4730.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "9c78f77160f92e156a497fe08c22abc686b82b48",
+          "mergedAt": "2026-07-02T22:49:02Z",
+          "number": 4731,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4731"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-02T19:22:33Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tSFqz",
+          "number": 4729,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4729"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4728,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools] Fix Rust cache warmup dep-info and path-policy contract truth",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4728",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4728.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "ca5f288ad294136f43500955eb691888f6ca369a",
+          "mergedAt": "2026-07-02T19:22:32Z",
+          "number": 4729,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4729"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-04T02:02:02Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tw8HR",
+          "number": 4852,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4852"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DCw",
+          "name": "wp:WP-06",
+          "description": "v0.91.5 work package 06 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4726,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-06][tools][binaries] Decompose monolithic adl binary into command-owned tools",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4726",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4726.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "f0842610ebd68ce066e96a5e4c0e10b1358a69f3",
+          "mergedAt": "2026-07-04T02:02:01Z",
+          "number": 4852,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4852"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T01:25:46Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tXu5y",
+          "number": 4772,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4772"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4724,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools] Add ADL-owned CI step log capture and artifact fallback",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4724",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4724.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "c829cf69a01f692e07ea7017d75354eb4cdbf3a9",
+          "mergedAt": "2026-07-03T01:25:45Z",
+          "number": 4772,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4772"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T01:50:07Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tYUNo",
+          "number": 4774,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4774"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4723,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][pr] Fix worktree owner-binary discovery for finish and validation",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4723",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4723.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "915e7d29bca587afb91fab519741309ffa03bc8f",
+          "mergedAt": "2026-07-03T01:50:06Z",
+          "number": 4774,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4774"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T18:49:33Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tsMw9",
+          "number": 4813,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4813"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6Cbg",
+          "name": "wp:WP-03",
+          "description": "v0.91.5 work package 03 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4721,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][github] Add repo-native label ensure command",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4721",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4721.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "9698439dd32d4d29c4a1c122b805395e4aca5546",
+          "mergedAt": "2026-07-03T18:49:32Z",
+          "number": 4813,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4813"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-02T19:01:31Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tQA9L",
+          "number": 4722,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4722"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4720,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][rust-build] Add hardlinked Rust dependency cache warmup for issue worktrees",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4720",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4720.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "746c8104e6339058a6ae0807618fa76d913c9d1a",
+          "mergedAt": "2026-07-02T19:01:30Z",
+          "number": 4722,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4722"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-02T18:05:18Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tQKgp",
+          "number": 4725,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4725"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACntpjPQ",
+          "name": "area:planning",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4719,
+      "state": "CLOSED",
+      "title": "[v0.91.7][planning] Sync issue wave and WBS to implementation-proof standard",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4719",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4719.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "49542c3bc805d1df50afa3a68fc9cdf1c01449d4",
+          "mergedAt": "2026-07-02T18:05:17Z",
+          "number": 4725,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4725"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-04T06:58:42Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tx74Q",
+          "number": 4862,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4862"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn0KQxg",
+          "name": "area:observability",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4718,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][observability] Implement integrated logging and OTel proof",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4718",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4718.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "7cc378d8b79ae8c37aed89b6f06c9f613827aadd",
+          "mergedAt": "2026-07-04T06:58:41Z",
+          "number": 4862,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4862"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T22:07:36Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tvGx9",
+          "number": 4829,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4829"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6Cbg",
+          "name": "wp:WP-03",
+          "description": "v0.91.5 work package 03 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4713,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][watcher] Implement Rust closeout watcher attach",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4713",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4713.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "a1783096ea0408864e3c698361ab93bfea88343f",
+          "mergedAt": "2026-07-03T22:07:35Z",
+          "number": 4829,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4829"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-02T16:49:31Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7s4nik",
+          "number": 4712,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4712"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4711,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][sessions] Emit repo-local session-claim remediation commands",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4711",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4711.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "9cfd716d52df3e868e95b172657d7ba956e6100e",
+          "mergedAt": "2026-07-02T16:49:30Z",
+          "number": 4712,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4712"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T18:11:23Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7trxuf",
+          "number": 4811,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4811"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6Cbg",
+          "name": "wp:WP-03",
+          "description": "v0.91.5 work package 03 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4709,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][worktree] Prevent issue edits from dirtying root main",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4709",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4709.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "7d7ca85e1c89124832dec9c589c3e324bbaf1405",
+          "mergedAt": "2026-07-03T18:11:22Z",
+          "number": 4811,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4811"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-02T16:38:34Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7szlII",
+          "number": 4707,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4707"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q-dA",
+          "name": "type:bug",
+          "description": "Bug or correctness issue",
+          "color": "D73A4A"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4706,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][pr] Add lightweight PR-ready promotion path for green unchanged PRs",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4706",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4706.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "cd017a34100487ee095de46cbd45c824accbc422",
+          "mergedAt": "2026-07-02T16:38:33Z",
+          "number": 4707,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4707"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T08:24:13Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tfmhE",
+          "number": 4799,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4799"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXNRw",
+          "name": "area:demo",
+          "description": "",
+          "color": "FBCA04"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4704,
+      "state": "CLOSED",
+      "title": "[v0.91.7][unity][demo] Capture reproducible Unity observatory proof and operator walkthrough surfaces",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4704",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4704.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "de7bcfa2a76b7ec469c5d71d4f752dceb3bc86ed",
+          "mergedAt": "2026-07-03T08:24:12Z",
+          "number": 4799,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4799"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-11T01:38:06Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXNRw",
+          "name": "area:demo",
+          "description": "",
+          "color": "FBCA04"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4703,
+      "state": "CLOSED",
+      "title": "[v0.91.7][unity][demo] Stage flagship observatory environment from imported asset packs",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4703",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4703.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-11T02:24:12Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wa1wR",
+          "number": 5155,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5155"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXNRw",
+          "name": "area:demo",
+          "description": "",
+          "color": "FBCA04"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoBXnHQ",
+          "name": "type:mini-sprint",
+          "description": "Mini-sprint umbrella issue",
+          "color": "BFD4F2"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4702,
+      "state": "CLOSED",
+      "title": "[v0.91.7][unity][sprint] Build flagship Unity observatory demo mini-sprint",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4702",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4702.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "594de682df5c4f45b59eadb88748fad88756dd61",
+          "mergedAt": "2026-07-11T02:24:11Z",
+          "number": 5155,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5155"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-06-30T19:26:18Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4701,
+      "state": "CLOSED",
+      "title": "[v0.91.7][aws][billing] Grant Agent Logic billing-read access",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4701",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4701.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-02T16:49:01Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7s4-VQ",
+          "number": 4715,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4715"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4700,
+      "state": "CLOSED",
+      "title": "[v0.91.7][docs][aws] Require business AWS account for ADL AWS work",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4700",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4700.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "534f6cd0846a56bbeba29dbdd26b227ff3f6c4ad",
+          "mergedAt": "2026-07-02T16:49:00Z",
+          "number": 4715,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4715"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-01T23:14:45Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoBXlrg",
+          "name": "type:sprint",
+          "description": "Sprint umbrella issue",
+          "color": "BFD4F2"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4699,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-02][sprint] Complete v0.91.6 carryover cleanup mini-sprint",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4699",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4699.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-03T23:17:11Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7twDRv",
+          "number": 4839,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4839"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DCw",
+          "name": "wp:WP-06",
+          "description": "v0.91.5 work package 06 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4698,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-06][tests] Reduce long-test fanout",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4698",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4698.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "8046c7fe01ab6e199bcbc2e0779089a89ff55374",
+          "mergedAt": "2026-07-03T23:17:10Z",
+          "number": 4839,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4839"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T19:23:51Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wF6m6",
+          "number": 5101,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5101"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6D2w",
+          "name": "wp:WP-11",
+          "description": "v0.91.5 work package 11 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3KBPw",
+          "name": "area:architecture",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4697,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-11][AEE-ObsMem] Implement AEE ObsMem and PVF trace handoff in full",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4697",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4697.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "c2df53ad695c855caf40971fdbe9018b733d12f2",
+          "mergedAt": "2026-07-10T19:23:50Z",
+          "number": 5101,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5101"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T08:36:42Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wFDYh",
+          "number": 5099,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5099"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6D2w",
+          "name": "wp:WP-11",
+          "description": "v0.91.5 work package 11 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3KBPw",
+          "name": "area:architecture",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4696,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-11][skill-standard] Implement adl.skill.v1 in full",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4696",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4696.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "44fad3afaeea3814e82e1a9c26807bd6871b2171",
+          "mergedAt": "2026-07-10T08:36:41Z",
+          "number": 5099,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5099"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T15:59:31Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wHfYP",
+          "number": 5104,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5104"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6D2w",
+          "name": "wp:WP-11",
+          "description": "v0.91.5 work package 11 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3KBPw",
+          "name": "area:architecture",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4695,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-11][loops] Implement loop runtime in full",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4695",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4695.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "b6fd9d930a7703cd732b09b11b03c8c360fef535",
+          "mergedAt": "2026-07-10T15:59:30Z",
+          "number": 5104,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5104"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T05:36:42Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wAdjc",
+          "number": 5091,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5091"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6D2w",
+          "name": "wp:WP-11",
+          "description": "v0.91.5 work package 11 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3KBPw",
+          "name": "area:architecture",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4694,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-11][reasoning-graph] Implement reasoning graph runtime in full",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4694",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4694.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "30d79edbbc2fc91847c09cdb3baaaf970b815869",
+          "mergedAt": "2026-07-10T05:36:41Z",
+          "number": 5091,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5091"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-11T08:00:44Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wejVR",
+          "number": 5163,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5163"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DwA",
+          "name": "wp:WP-10",
+          "description": "v0.91.5 work package 10 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3KBPw",
+          "name": "area:architecture",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4693,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-10][constructability] Implement constructability anchor validator",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4693",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4693.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "90091fd16b4da026849592bdbc38e8a6ef5d51da",
+          "mergedAt": "2026-07-11T08:00:43Z",
+          "number": 5163,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5163"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-11T05:25:53Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wb1HY",
+          "number": 5161,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5161"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DwA",
+          "name": "wp:WP-10",
+          "description": "v0.91.5 work package 10 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3KBPw",
+          "name": "area:architecture",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4692,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-10][curiosity] Implement curiosity engine in full",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4692",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4692.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "e63762b5780e5576aefe039cbf4063686efeb0aa",
+          "mergedAt": "2026-07-11T05:25:52Z",
+          "number": 5161,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5161"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-11T02:22:03Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wavE_",
+          "number": 5154,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5154"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXNRw",
+          "name": "area:demo",
+          "description": "",
+          "color": "FBCA04"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DiA",
+          "name": "wp:WP-09",
+          "description": "v0.91.5 work package 09 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4691,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-09][demo-matrix] Deliver birthday-visible demo matrix",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4691",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4691.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "c076a44ed9d055cfce180ef9ea37e36382bd10e5",
+          "mergedAt": "2026-07-11T02:22:02Z",
+          "number": 5154,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5154"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-07T14:43:13Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7ugKdB",
+          "number": 4991,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4991"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXNRw",
+          "name": "area:demo",
+          "description": "",
+          "color": "FBCA04"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DiA",
+          "name": "wp:WP-09",
+          "description": "v0.91.5 work package 09 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4690,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-09][html] Deliver HTML Observatory integrated proof",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4690",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4690.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "aabea7bc9108c3ccfae338a2cb5d1db60df8ae7b",
+          "mergedAt": "2026-07-07T14:43:11Z",
+          "number": 4991,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4991"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-11T02:16:32Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wadzj",
+          "number": 5152,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5152"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXNRw",
+          "name": "area:demo",
+          "description": "",
+          "color": "FBCA04"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DiA",
+          "name": "wp:WP-09",
+          "description": "v0.91.5 work package 09 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4689,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-09][unity] Deliver Unity Observatory integrated proof",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4689",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4689.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "8dbeaefe225844645098bd6021ad1dd1157ac64a",
+          "mergedAt": "2026-07-11T02:16:31Z",
+          "number": 5152,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5152"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T19:14:22Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7ueEl0",
+          "number": 4982,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4982"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DVg",
+          "name": "wp:WP-08",
+          "description": "v0.91.5 work package 08 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn0KQxg",
+          "name": "area:observability",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4688,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-08][archive] Finalize S3 ObsMem community-memory archive policy",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4688",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4688.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "fcf4e4120b5b0bae09d5009c33c5263560ec0d12",
+          "mergedAt": "2026-07-06T19:14:21Z",
+          "number": 4982,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4982"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T18:42:18Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7udr3e",
+          "number": 4978,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4978"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DVg",
+          "name": "wp:WP-08",
+          "description": "v0.91.5 work package 08 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn0KQxg",
+          "name": "area:observability",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4687,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-08][SSM] Implement local polis SSM operations",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4687",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4687.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "d0a21cd49ddc8bad7e049eef970fdc5d79185240",
+          "mergedAt": "2026-07-06T18:42:17Z",
+          "number": 4978,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4978"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T19:42:09Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uewir",
+          "number": 4984,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4984"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DVg",
+          "name": "wp:WP-08",
+          "description": "v0.91.5 work package 08 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn0KQxg",
+          "name": "area:observability",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4686,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-08][AWS] Implement AWS signal integration in full",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4686",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4686.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "4f1c8e52ab699f2150644bd24999b738bd8e3163",
+          "mergedAt": "2026-07-06T19:42:08Z",
+          "number": 4984,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4984"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T17:40:17Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7udQmH",
+          "number": 4975,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4975"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DVg",
+          "name": "wp:WP-08",
+          "description": "v0.91.5 work package 08 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn0KQxg",
+          "name": "area:observability",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4685,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-08][ACIP-SNS] Implement ACIP to SNS integration in full",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4685",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4685.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "713db307285af08d7b1b08d263cd0e67505beba6",
+          "mergedAt": "2026-07-06T17:40:16Z",
+          "number": 4975,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4975"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T11:28:00Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uQ1UI",
+          "number": 4966,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4966"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DVg",
+          "name": "wp:WP-08",
+          "description": "v0.91.5 work package 08 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn0KQxg",
+          "name": "area:observability",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4684,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-08][heartbeat] Implement heartbeat publisher",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4684",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4684.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "1f5a55159049cab845ccf8b11865182d53ba624b",
+          "mergedAt": "2026-07-06T11:27:59Z",
+          "number": 4966,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4966"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-04T23:23:32Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7t1V9U",
+          "number": 4872,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4872"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3KBPw",
+          "name": "area:architecture",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4683,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][architecture] Execute runtime module diet map",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4683",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4683.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "2c12e31bcf8d72dfd6cdf3ea8ac553e0abda9f0b",
+          "mergedAt": "2026-07-04T23:23:32Z",
+          "number": 4872,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4872"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-04T22:54:05Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7t1fNa",
+          "number": 4873,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4873"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4682,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][soak] Run runtime Soak 2",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4682",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4682.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "ef91a1f8d2c3a4bcbfc332760e28a0da053da7f7",
+          "mergedAt": "2026-07-04T22:54:04Z",
+          "number": 4873,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4873"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-05T03:03:07Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7t0HxZ",
+          "number": 4868,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4868"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4681,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07][runtime] Assemble minimal integrated runtime path",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4681",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4681.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "9ac3aaada4a7efdba496b26ff8030b4ec72c676e",
+          "mergedAt": "2026-07-05T03:03:06Z",
+          "number": 4868,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4868"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T05:05:13Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uKnUi",
+          "number": 4942,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4942"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DCw",
+          "name": "wp:WP-06",
+          "description": "v0.91.5 work package 06 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4680,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-06][cache] Improve sccache linker and target-dir setup",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4680",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4680.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "82f8f0a18ddd41803d32aa51d75348426b74224d",
+          "mergedAt": "2026-07-06T05:05:12Z",
+          "number": 4942,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4942"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-06T05:14:56Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uMW_U",
+          "number": 4944,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4944"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DCw",
+          "name": "wp:WP-06",
+          "description": "v0.91.5 work package 06 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4679,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-06][aws] Prove EC2 Spot or alternate remote builder",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4679",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4679.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "85cd22b50687a5452d7ad75a1069893b66887fe0",
+          "mergedAt": "2026-07-06T05:14:55Z",
+          "number": 4944,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4944"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-04T02:02:55Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7txNsS",
+          "number": 4857,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4857"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DCw",
+          "name": "wp:WP-06",
+          "description": "v0.91.5 work package 06 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4678,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-06][remote] Consume Nessus remote validation lane",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4678",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4678.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "c87e18fc5604cbfcc6c77600ea93a99021e0d3e0",
+          "mergedAt": "2026-07-04T02:02:54Z",
+          "number": 4857,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4857"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-04T02:02:27Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7txGqK",
+          "number": 4856,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4856"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DCw",
+          "name": "wp:WP-06",
+          "description": "v0.91.5 work package 06 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4677,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-06][archive] Implement CI log archive to S3",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4677",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4677.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "5844b7a4eaeb7301b7589c3231fe6d26eb91d3cf",
+          "mergedAt": "2026-07-04T02:02:27Z",
+          "number": 4856,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4856"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T21:54:10Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tu3Q1",
+          "number": 4828,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4828"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DCw",
+          "name": "wp:WP-06",
+          "description": "v0.91.5 work package 06 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4676,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-06][validation-manager] Implement validation manager",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4676",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4676.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "c6ae6551ea2293d920cbde67a544dc4327e14624",
+          "mergedAt": "2026-07-03T21:54:10Z",
+          "number": 4828,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4828"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T22:50:24Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tvvHM",
+          "number": 4834,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4834"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6C9g",
+          "name": "wp:WP-05",
+          "description": "v0.91.5 work package 05 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3J_yQ",
+          "name": "area:provider",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4675,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-05][delegation] Implement local-agent delegation readiness",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4675",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4675.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "d46e5b3d739c0c5ea2ba1f73d55f682471f0e593",
+          "mergedAt": "2026-07-03T22:50:23Z",
+          "number": 4834,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4834"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T21:53:39Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tuzFU",
+          "number": 4827,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4827"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6C9g",
+          "name": "wp:WP-05",
+          "description": "v0.91.5 work package 05 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3J_yQ",
+          "name": "area:provider",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4674,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-05][policy] Implement cheapest validated outcome policy",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4674",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4674.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "751ec08b9d0d8f3056bc71f3521a4739b6d51cfd",
+          "mergedAt": "2026-07-03T21:53:38Z",
+          "number": 4827,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4827"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T20:47:19Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tt3fV",
+          "number": 4823,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4823"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6C9g",
+          "name": "wp:WP-05",
+          "description": "v0.91.5 work package 05 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3J_yQ",
+          "name": "area:provider",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4673,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-05][models] Implement model suitability selection proof",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4673",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4673.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "0e020ded18a0ea463dd2ad67b729e67c679e41ce",
+          "mergedAt": "2026-07-03T20:47:18Z",
+          "number": 4823,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4823"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T19:44:19Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tr76S",
+          "number": 4812,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4812"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6C9g",
+          "name": "wp:WP-05",
+          "description": "v0.91.5 work package 05 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3J_yQ",
+          "name": "area:provider",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4672,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-05][providers] Implement provider profile selection",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4672",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4672.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "8c624841e1fcc832729de0b1bef8356d5576ef29",
+          "mergedAt": "2026-07-03T19:44:19Z",
+          "number": 4812,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4812"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T17:28:08Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7trFHv",
+          "number": 4809,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4809"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6C9g",
+          "name": "wp:WP-05",
+          "description": "v0.91.5 work package 05 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3J_yQ",
+          "name": "area:provider",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4671,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-05][scheduler] Implement cognitive scheduler v1",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4671",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4671.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "daefb6f9433e40243b3bf1449322b7e4d4b50e0d",
+          "mergedAt": "2026-07-03T17:28:07Z",
+          "number": 4809,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4809"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-02T22:06:32Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tUvir",
+          "number": 4735,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4735"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6CrA",
+          "name": "wp:WP-04",
+          "description": "v0.91.5 work package 04 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4670,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-04][outliers] Implement execution outlier analysis",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4670",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4670.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "f7ceb66215bc437017011b9cceb13eb6bccb6256",
+          "mergedAt": "2026-07-02T22:06:31Z",
+          "number": 4735,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4735"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-02T21:42:47Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tUehd",
+          "number": 4734,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4734"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6CrA",
+          "name": "wp:WP-04",
+          "description": "v0.91.5 work package 04 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4669,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-04][backfill] Execute bounded v0.91.6 metrics backfill",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4669",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4669.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "7156340dcd8ec3d6775f22b352e97e97534c461d",
+          "mergedAt": "2026-07-02T21:42:46Z",
+          "number": 4734,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4734"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-02T21:42:20Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tUG5H",
+          "number": 4733,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4733"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6CrA",
+          "name": "wp:WP-04",
+          "description": "v0.91.5 work package 04 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4668,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-04][telemetry] Implement Codex session telemetry harvesting",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4668",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4668.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "c49a54185e7ce28e30c88fef22dbd761a7c49eb0",
+          "mergedAt": "2026-07-02T21:42:19Z",
+          "number": 4733,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4733"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-02T21:41:54Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tTxpT",
+          "number": 4732,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4732"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6CrA",
+          "name": "wp:WP-04",
+          "description": "v0.91.5 work package 04 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4667,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-04][metrics] Implement SOR time-token-resource accounting",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4667",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4667.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "09e1b142c9f1d894eb3fbd6f1c2019f56051af6c",
+          "mergedAt": "2026-07-02T21:41:53Z",
+          "number": 4732,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4732"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-02T20:11:53Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tRNYU",
+          "number": 4727,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4727"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6CrA",
+          "name": "wp:WP-04",
+          "description": "v0.91.5 work package 04 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4666,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-04][goals] Implement nested issue and sprint goal accounting",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4666",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4666.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "d0bef50500af163ea49c999bf2379993e6b6924c",
+          "mergedAt": "2026-07-02T20:11:52Z",
+          "number": 4727,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4727"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-01T23:13:25Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4665,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-02][github] Implement PR inventory closure path",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4665",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4665.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-01T23:13:25Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4664,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-02][C-SDLC] Complete v0.91.6 control-plane input disposition",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4664",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4664.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-01T23:13:25Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4663,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-02][observatory] Resolve Observatory carryover",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4663",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4663.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-01T23:13:25Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4662,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-02][ADR] Complete ADR release-tail closure",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4662",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4662.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-01T23:14:15Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7s5Hwv",
+          "number": 4716,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4716"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4661,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-02][closeout] Consume v0.91.6 closeout truth",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4661",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4661.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "58dbce111ae930fefd1df9da89eb4cbb006a69e1",
+          "mergedAt": "2026-07-01T23:14:14Z",
+          "number": 4716,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4716"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-11T02:27:42Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7waEKR",
+          "number": 5151,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5151"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q4Pw",
+          "name": "area:security",
+          "description": "Security-related changes",
+          "color": "d93f0b"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6EAQ",
+          "name": "wp:WP-12",
+          "description": "v0.91.5 work package 12 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4660,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-12][access] Finalize access rules and activation blockers",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4660",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4660.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "4f35ea9e02d42ef394de942797e2c9d468a2c6f5",
+          "mergedAt": "2026-07-11T02:27:41Z",
+          "number": 5151,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5151"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-11T00:30:21Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wYvpV",
+          "number": 5146,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5146"
+        },
+        {
+          "id": "PR_kwDORHPd2M7yQU0q",
+          "number": 5417,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5417"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q4Pw",
+          "name": "area:security",
+          "description": "Security-related changes",
+          "color": "d93f0b"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6EAQ",
+          "name": "wp:WP-12",
+          "description": "v0.91.5 work package 12 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4659,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-12][A2A] Prove WebSocket transport path",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4659",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4659.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "71b1e9e3dab654beb4cb95c4a93dccf33a5c6228",
+          "mergedAt": "2026-07-11T00:30:20Z",
+          "number": 5146,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5146"
+        },
+        {
+          "baseRefName": "main",
+          "headRefOid": "fc761b2a8a170426d3cd42f837b912ba8ba7ab06",
+          "mergedAt": "2026-07-18T02:23:31Z",
+          "number": 5417,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5417"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T20:30:26Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wU7d7",
+          "number": 5137,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5137"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q4Pw",
+          "name": "area:security",
+          "description": "Security-related changes",
+          "color": "d93f0b"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6EAQ",
+          "name": "wp:WP-12",
+          "description": "v0.91.5 work package 12 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4658,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-12][ACIP] Finalize ACIP schema and protobuf projection",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4658",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4658.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "eb8c989d89368439bf31195f960dc2d9fd1c5684",
+          "mergedAt": "2026-07-10T20:30:25Z",
+          "number": 5137,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5137"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T19:22:12Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wTeYy",
+          "number": 5132,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5132"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q4Pw",
+          "name": "area:security",
+          "description": "Security-related changes",
+          "color": "d93f0b"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6EAQ",
+          "name": "wp:WP-12",
+          "description": "v0.91.5 work package 12 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4657,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-12][ops] Prove SSM readiness",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4657",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4657.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "e38427b725b6ca6343eb4ce39caed1c6dcc58ceb",
+          "mergedAt": "2026-07-10T19:22:11Z",
+          "number": 5132,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5132"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T18:18:51Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wS_gB",
+          "number": 5129,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5129"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q4Pw",
+          "name": "area:security",
+          "description": "Security-related changes",
+          "color": "d93f0b"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6EAQ",
+          "name": "wp:WP-12",
+          "description": "v0.91.5 work package 12 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4656,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-12][security] Implement security and CAV pre-v0.92 requirements in full",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4656",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4656.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "9b4d97892c23c095d887605e3d6a73c68ec52605",
+          "mergedAt": "2026-07-10T18:18:50Z",
+          "number": 5129,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5129"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-09T22:58:49Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7vCbDT",
+          "number": 5052,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5052"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3J_yQ",
+          "name": "area:provider",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4654,
+      "state": "CLOSED",
+      "title": "[v0.91.7][aws][gpu][dspark] Smoke test deepseek-v4-flash-dspark on ephemeral 2xH100 EC2",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4654",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4654.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "885dfd046a9ed05421e09427135a618fad628579",
+          "mergedAt": "2026-07-09T22:58:48Z",
+          "number": 5052,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5052"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-09T23:37:44Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7vCNR8",
+          "number": 5051,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5051"
+        },
+        {
+          "id": "PR_kwDORHPd2M7v9MOp",
+          "number": 5077,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5077"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3J_yQ",
+          "name": "area:provider",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4653,
+      "state": "CLOSED",
+      "title": "[v0.91.7][models][dspark] Evaluate dspark speculative decoding with Qwen and Gemma",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4653",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4653.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "e9ae6c7ec9a847bba65859ba564563aee77b7924",
+          "mergedAt": "2026-07-09T23:37:44Z",
+          "number": 5051,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5051"
+        },
+        {
+          "baseRefName": "main",
+          "headRefOid": "60ed756e9aa524098f9e21ca7f24d52f97985056",
+          "mergedAt": "2026-07-10T00:10:38Z",
+          "number": 5077,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5077"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T20:49:25Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tt5bA",
+          "number": 4824,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4824"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXNRw",
+          "name": "area:demo",
+          "description": "",
+          "color": "FBCA04"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4652,
+      "state": "CLOSED",
+      "title": "[v0.91.7][unity][demo] Build and validate Unity demo surfaces",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4652",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4652.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "9e7b566f7d00683fa92d08e3d29556957739f81a",
+          "mergedAt": "2026-07-03T20:49:24Z",
+          "number": 4824,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4824"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-10T08:29:04Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3KBPw",
+          "name": "area:architecture",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4651,
+      "state": "CLOSED",
+      "title": "[v0.91.7][rust][refactor] Refactor Rust surfaces by ownership and validation cost",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4651",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4651.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-10T22:55:13Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wYHiC",
+          "number": 5142,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5142"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACntpjPQ",
+          "name": "area:planning",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACp4tWew",
+          "name": "wp:WP-22",
+          "description": "v0.91.7 work package WP-22",
+          "color": "5319e7"
+        }
+      ],
+      "number": 4649,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-22][planning] Next milestone review pass",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4649",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4649.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "367d1bd85a9e66645679ed472642148a19e1b62b",
+          "mergedAt": "2026-07-10T22:55:12Z",
+          "number": 5142,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5142"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-05T06:56:44Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7t_qN_",
+          "number": 4901,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4901"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6GUg",
+          "name": "wp:WP-21",
+          "description": "v0.91.5 work package 21 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACntpjPQ",
+          "name": "area:planning",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4648,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-21][planning] Next milestone planning",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4648",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4648.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "a74fee042cea6b120b3f76e3b1303c2374dc51a7",
+          "mergedAt": "2026-07-05T06:56:43Z",
+          "number": 4901,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4901"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-19T01:40:53Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zbucE",
+          "number": 5543,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5543"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6Feg",
+          "name": "wp:WP-18",
+          "description": "v0.91.5 work package 18 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4645,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-18][review] Internal review",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4645",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/4645/index.json",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4645.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "403fc9ec7668d1218ca2cc350d55b180af554005",
+          "mergedAt": "2026-07-19T01:40:52Z",
+          "number": 5543,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5543"
+        }
+      ],
+      "disposition": "typed_receipt_required",
+      "evidence": "tracked typed projection exists; receipt and terminal parity must be checked"
+    },
+    {
+      "closedAt": "2026-07-18T23:52:18Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zboIr",
+          "number": 5539,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5539"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6FRA",
+          "name": "wp:WP-17",
+          "description": "v0.91.5 work package 17 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4644,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-17][docs] Docs and adoption review pass",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4644",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/4644/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/4644.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "c4eec3e7c572f9bb58aa9eae915dad8f335d76a8",
+          "mergedAt": "2026-07-18T23:52:17Z",
+          "number": 5539,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5539"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-18T23:13:51Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zbTZ2",
+          "number": 5524,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5524"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6E2Q",
+          "name": "wp:WP-16",
+          "description": "v0.91.5 work package 16 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4643,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-16][quality] Coverage and quality gate",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4643",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/4643/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/4643.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "5c356ff5f7cf95d9545726a55b99fc826f7972d7",
+          "mergedAt": "2026-07-18T23:13:50Z",
+          "number": 5524,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5524"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-18T22:57:47Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zSoBN",
+          "number": 5503,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5503"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXNRw",
+          "name": "area:demo",
+          "description": "",
+          "color": "FBCA04"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6Epg",
+          "name": "wp:WP-15",
+          "description": "v0.91.5 work package 15 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4642,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-15][demo] Demo matrix and proof coverage",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4642",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/4642/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/4642.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "60d9070863afc9b394d46eba5984529243464642",
+          "mergedAt": "2026-07-18T22:57:47Z",
+          "number": 5503,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5503"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-18T08:14:57Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7zSNl2",
+          "number": 5493,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5493"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6EZg",
+          "name": "wp:WP-14",
+          "description": "v0.91.5 work package 14 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACntpjPQ",
+          "name": "area:planning",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4641,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-14] Launch and v0.92 birthday handoff",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4641",
+      "class": "typed_projection",
+      "typed_projection": true,
+      "tracked_record": ".csdlc/issues/4641/index.json",
+      "shared_receipt": true,
+      "receipt_path": ".git/csdlc-v2/closeout/4641.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "d0ded4ef1c22f07b9bf57dcff80630270fa14af7",
+          "mergedAt": "2026-07-18T08:14:56Z",
+          "number": 5493,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5493"
+        }
+      ],
+      "disposition": "typed_receipt_present",
+      "evidence": "tracked typed projection and retained shared terminal receipt exist"
+    },
+    {
+      "closedAt": "2026-07-11T20:31:36Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wm92P",
+          "number": 5199,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5199"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6ENg",
+          "name": "wp:WP-13",
+          "description": "v0.91.5 work package 13 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACntpjPQ",
+          "name": "area:planning",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4640,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-13] Implement affect, Godel, economics, guild, CodeFriend, and publication surfaces",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4640",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4640.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "5540f8faad3bb40b151086af18673187376a6a2b",
+          "mergedAt": "2026-07-11T20:31:35Z",
+          "number": 5199,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5199"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-11T06:09:19Z",
+      "closedByPullRequestsReferences": [],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q4Pw",
+          "name": "area:security",
+          "description": "Security-related changes",
+          "color": "d93f0b"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6EAQ",
+          "name": "wp:WP-12",
+          "description": "v0.91.5 work package 12 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4639,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-12] Implement security and protocol requirements umbrella",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4639",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4639.json",
+      "linked_prs": [],
+      "disposition": "legacy_closed_without_linked_pr",
+      "evidence": "GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated"
+    },
+    {
+      "closedAt": "2026-07-10T23:56:59Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wY0sV",
+          "number": 5147,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5147"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6D2w",
+          "name": "wp:WP-11",
+          "description": "v0.91.5 work package 11 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3KBPw",
+          "name": "area:architecture",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4638,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-11] Implement reasoning graphs loops and adl.skill.v1 in full",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4638",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4638.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "0b39e122b49d0f839884e3b5393618f4f4927c1a",
+          "mergedAt": "2026-07-10T23:56:58Z",
+          "number": 5147,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5147"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-11T08:37:03Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wfG7e",
+          "number": 5168,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5168"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DwA",
+          "name": "wp:WP-10",
+          "description": "v0.91.5 work package 10 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3KBPw",
+          "name": "area:architecture",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4637,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-10] Implement Curiosity and Constructability in full",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4637",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4637.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "1f769c1c1eee915c517a5672fc44aa2d6ef6b8cb",
+          "mergedAt": "2026-07-11T08:37:02Z",
+          "number": 5168,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5168"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-11T02:38:29Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7wbLF8",
+          "number": 5157,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5157"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXNRw",
+          "name": "area:demo",
+          "description": "",
+          "color": "FBCA04"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DiA",
+          "name": "wp:WP-09",
+          "description": "v0.91.5 work package 09 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4636,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-09] Observatory demos and birthday-visible proof",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4636",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4636.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "353c2fbe2bd64d971417fc2496d3de394c0e2aaf",
+          "mergedAt": "2026-07-11T02:38:28Z",
+          "number": 5157,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5157"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-07T02:35:41Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7uoKYj",
+          "number": 5004,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5004"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DVg",
+          "name": "wp:WP-08",
+          "description": "v0.91.5 work package 08 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn0KQxg",
+          "name": "area:observability",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4635,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-08] Implement runtime AWS and signal operations in full",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4635",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4635.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "50352f48601467d27017b68093279ece51062104",
+          "mergedAt": "2026-07-07T02:35:40Z",
+          "number": 5004,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/5004"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-05T05:38:50Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7t-7ti",
+          "number": 4889,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4889"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DOQ",
+          "name": "wp:WP-07",
+          "description": "v0.91.5 work package 07 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4634,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-07] Runtime integration fire-up and Soak 2",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4634",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4634.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "14886066f3d950077e68ec935db014a57f274211",
+          "mergedAt": "2026-07-05T05:38:49Z",
+          "number": 4889,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4889"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-04T02:03:29Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7txRzW",
+          "number": 4860,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4860"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6DCw",
+          "name": "wp:WP-06",
+          "description": "v0.91.5 work package 06 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4633,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-06] Build throughput and validation-cost reduction",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4633",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4633.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "f8919caa483d0dea86d200d0f386590479231ed5",
+          "mergedAt": "2026-07-04T02:03:28Z",
+          "number": 4860,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4860"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-03T23:18:51Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7twQcw",
+          "number": 4841,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4841"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6C9g",
+          "name": "wp:WP-05",
+          "description": "v0.91.5 work package 05 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACn3J_yQ",
+          "name": "area:provider",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4632,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-05] Cognitive scheduler and provider local-agent execution",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4632",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4632.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "66041834ef6a8bef8dccc7ac71f9b0aae32f2d00",
+          "mergedAt": "2026-07-03T23:18:51Z",
+          "number": 4841,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4841"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-02T23:37:05Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tWW5F",
+          "number": 4746,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4746"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6CrA",
+          "name": "wp:WP-04",
+          "description": "v0.91.5 work package 04 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4631,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-04] Goal state nested goals and execution metrics",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4631",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4631.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "58847052645a839659f3d5feae17dcc65439159f",
+          "mergedAt": "2026-07-02T23:37:04Z",
+          "number": 4746,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4746"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-02T21:32:49Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7s4-RF",
+          "number": 4714,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4714"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6Cbg",
+          "name": "wp:WP-03",
+          "description": "v0.91.5 work package 03 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4630,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-03][tools] Implement lifecycle shepherd command",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4630",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4630.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "8247e309c160bb217944c64af8c9a32143150840",
+          "mergedAt": "2026-07-02T21:32:48Z",
+          "number": 4714,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4714"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-01T20:27:47Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7s2UUh",
+          "number": 4710,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4710"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4629,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-02] v0.91.6 closeout truth ADR release-tail C-SDLC control-plane sprint and cleanup",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4629",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4629.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "f46c68d3879c38485fc96e1c1c6cc72dddf0002d",
+          "mergedAt": "2026-07-01T20:27:46Z",
+          "number": 4710,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4710"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-06-30T17:16:12Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7rlMWF",
+          "number": 4655,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4655"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JYRw",
+          "name": "area:docs",
+          "description": "Documentation",
+          "color": "c2e0c6"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4628,
+      "state": "CLOSED",
+      "title": "[v0.91.7][WP-01][planning] Promote planning package and open issue wave",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4628",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4628.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "82f6ceda0e58843349db178cab1d8570a5edf35b",
+          "mergedAt": "2026-06-30T17:16:11Z",
+          "number": 4655,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4655"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-02T22:42:39Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tVVsw",
+          "number": 4742,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4742"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAAClp6CrA",
+          "name": "wp:WP-04",
+          "description": "v0.91.5 work package 04 ordering label",
+          "color": "5319E7"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4617,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][metrics] Harvest Codex session telemetry for reporting and prediction",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4617",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4617.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "27576f40e27a04259c53f2426173e361a89c0d50",
+          "mergedAt": "2026-07-02T22:42:38Z",
+          "number": 4742,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4742"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-07-02T23:57:28Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7tOpcH",
+          "number": 4717,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4717"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4603,
+      "state": "CLOSED",
+      "title": "[v0.91.7][aws][spot] Build Spot manager and remote validation lane",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4603",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4603.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "7ef5b07ec7831948595c16d201a5a3a8573db5a9",
+          "mergedAt": "2026-07-02T23:57:27Z",
+          "number": 4717,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4717"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-06-26T22:59:33Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7rJFh5",
+          "number": 4580,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4580"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACneI3-Q",
+          "name": "tools",
+          "description": "",
+          "color": "ededed"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4562,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools] Fix pr finish focused-validation rejection for chained selector commands",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4562",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4562.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "ca808511638fceba467d736dcc9867733699eca0",
+          "mergedAt": "2026-06-26T22:59:33Z",
+          "number": 4580,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4580"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-06-26T20:03:08Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7rFSVK",
+          "number": 4573,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4573"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYKxGnA",
+          "name": "area:runtime",
+          "description": "Runtime library issues",
+          "color": "0052cc"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4549,
+      "state": "CLOSED",
+      "title": "[v0.91.7][runtime][soak] Prepare Soak #2 full feature-list integration gate",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4549",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4549.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "0edad48543b60b6d7aaea63fb3ce1383ede5ddc1",
+          "mergedAt": "2026-06-26T20:03:07Z",
+          "number": 4573,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4573"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-06-24T20:20:12Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7qQ23r",
+          "number": 4514,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4514"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACayMBng",
+          "name": "area:review",
+          "description": "Review and triage work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4511,
+      "state": "CLOSED",
+      "title": "[v0.91.7][csdlc][review-fix] Repair closure truth for #4442 and #4457 after retained review #4504",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4511",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4511.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "09fa76f0ca5cb0d64dc1f0dc5a0b3fa3e8db7d01",
+          "mergedAt": "2026-06-24T20:20:11Z",
+          "number": 4514,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4514"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-06-24T20:50:08Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7qQ4SX",
+          "number": 4515,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4515"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7Q4Pw",
+          "name": "area:security",
+          "description": "Security-related changes",
+          "color": "d93f0b"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4512,
+      "state": "CLOSED",
+      "title": "[v0.91.7][google-workspace][security] Narrow native Drive sync default scopes to least privilege after retained review #4505",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4512",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4512.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "980ebd113f8b1117213db4f8fe9b4fa5610f516d",
+          "mergedAt": "2026-06-24T20:50:07Z",
+          "number": 4515,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4515"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    },
+    {
+      "closedAt": "2026-06-24T20:56:00Z",
+      "closedByPullRequestsReferences": [
+        {
+          "id": "PR_kwDORHPd2M7qSCfn",
+          "number": 4519,
+          "repository": {
+            "id": "R_kgDORHPd2A",
+            "name": "agent-design-language",
+            "owner": {
+              "id": "MDQ6VXNlcjYwNTc3Mw==",
+              "login": "danielbaustin"
+            }
+          },
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4519"
+        }
+      ],
+      "labels": [
+        {
+          "id": "LA_kwDORHPd2M8AAAACW7JWng",
+          "name": "track:roadmap",
+          "description": "Roadmap-level work",
+          "color": "0e8a16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXDuUvw",
+          "name": "area:tools",
+          "description": "Tooling / automation scripts",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACXvK6OQ",
+          "name": "type:task",
+          "description": "Implementation task under a feature",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACYtXtDg",
+          "name": "area:quality",
+          "description": "",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORHPd2M8AAAACoIPTeg",
+          "name": "version:v0.91.7",
+          "description": "Targeted for ADL v0.91.7",
+          "color": "1f883d"
+        }
+      ],
+      "number": 4498,
+      "state": "CLOSED",
+      "title": "[v0.91.7][tools][metrics] Capture readiness-prep time and token accounting before execution bind",
+      "url": "https://github.com/danielbaustin/agent-design-language/issues/4498",
+      "class": "legacy",
+      "typed_projection": false,
+      "tracked_record": "",
+      "shared_receipt": false,
+      "receipt_path": ".git/csdlc-v2/closeout/4498.json",
+      "linked_prs": [
+        {
+          "baseRefName": "main",
+          "headRefOid": "b462a4ec239b7995bdbd61a5a8997bf79785f198",
+          "mergedAt": "2026-06-24T20:55:59Z",
+          "number": 4519,
+          "state": "MERGED",
+          "url": "https://github.com/danielbaustin/agent-design-language/pull/4519"
+        }
+      ],
+      "disposition": "legacy_merged_pr",
+      "evidence": "GitHub closedByPullRequestsReferences includes a merged PR"
+    }
+  ]
+}

--- a/docs/milestones/v0.91.7/review/V0917_CLOSED_ISSUE_CLOSEOUT_REGISTER.md
+++ b/docs/milestones/v0.91.7/review/V0917_CLOSED_ISSUE_CLOSEOUT_REGISTER.md
@@ -1,0 +1,439 @@
+# v0.91.7 Closed-Issue Closeout Register
+
+Generated from live GitHub closed issues labeled `version:v0.91.7` and local typed C-SDLC v2 projections/receipts. Legacy issues remain legacy; this register does not fabricate typed cards.
+
+- Total closed issues: 427
+- Typed projections: 46
+- Orphaned valid typed receipts: 3
+- Legacy/pre-v2 closures: 378
+- Valid shared receipts: 48
+
+| Issue | Class | Disposition | Evidence | Linked PRs |
+|---:|---|---|---|---|
+| [#5551](https://github.com/danielbaustin/agent-design-language/issues/5551) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5555 |
+| [#5547](https://github.com/danielbaustin/agent-design-language/issues/5547) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5554 |
+| [#5546](https://github.com/danielbaustin/agent-design-language/issues/5546) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5559 |
+| [#5545](https://github.com/danielbaustin/agent-design-language/issues/5545) | orphaned_typed_receipt | orphaned_typed_receipt | valid csdlc.terminal_receipt.v1 exists with closed_out record, but no tracked projection exists; no cards are fabricated | #5557 |
+| [#5544](https://github.com/danielbaustin/agent-design-language/issues/5544) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5553 |
+| [#5542](https://github.com/danielbaustin/agent-design-language/issues/5542) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5549, #5552 |
+| [#5521](https://github.com/danielbaustin/agent-design-language/issues/5521) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5522 |
+| [#5518](https://github.com/danielbaustin/agent-design-language/issues/5518) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5519 |
+| [#5516](https://github.com/danielbaustin/agent-design-language/issues/5516) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5517 |
+| [#5514](https://github.com/danielbaustin/agent-design-language/issues/5514) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5515 |
+| [#5512](https://github.com/danielbaustin/agent-design-language/issues/5512) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5513 |
+| [#5509](https://github.com/danielbaustin/agent-design-language/issues/5509) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5511 |
+| [#5506](https://github.com/danielbaustin/agent-design-language/issues/5506) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5507 |
+| [#5495](https://github.com/danielbaustin/agent-design-language/issues/5495) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5525 |
+| [#5494](https://github.com/danielbaustin/agent-design-language/issues/5494) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5504 |
+| [#5489](https://github.com/danielbaustin/agent-design-language/issues/5489) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5564 |
+| [#5487](https://github.com/danielbaustin/agent-design-language/issues/5487) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5491 |
+| [#5468](https://github.com/danielbaustin/agent-design-language/issues/5468) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5471, #5473 |
+| [#5467](https://github.com/danielbaustin/agent-design-language/issues/5467) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5485 |
+| [#5466](https://github.com/danielbaustin/agent-design-language/issues/5466) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5472 |
+| [#5464](https://github.com/danielbaustin/agent-design-language/issues/5464) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5490 |
+| [#5463](https://github.com/danielbaustin/agent-design-language/issues/5463) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5483 |
+| [#5461](https://github.com/danielbaustin/agent-design-language/issues/5461) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5462 |
+| [#5455](https://github.com/danielbaustin/agent-design-language/issues/5455) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5460 |
+| [#5453](https://github.com/danielbaustin/agent-design-language/issues/5453) | orphaned_typed_receipt | orphaned_typed_receipt | valid csdlc.terminal_receipt.v1 exists with closed_out record, but no tracked projection exists; no cards are fabricated | #5454 |
+| [#5452](https://github.com/danielbaustin/agent-design-language/issues/5452) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5465 |
+| [#5450](https://github.com/danielbaustin/agent-design-language/issues/5450) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5451 |
+| [#5448](https://github.com/danielbaustin/agent-design-language/issues/5448) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5449 |
+| [#5446](https://github.com/danielbaustin/agent-design-language/issues/5446) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5447 |
+| [#5440](https://github.com/danielbaustin/agent-design-language/issues/5440) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5441 |
+| [#5427](https://github.com/danielbaustin/agent-design-language/issues/5427) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5456 |
+| [#5426](https://github.com/danielbaustin/agent-design-language/issues/5426) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5430 |
+| [#5423](https://github.com/danielbaustin/agent-design-language/issues/5423) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5435 |
+| [#5415](https://github.com/danielbaustin/agent-design-language/issues/5415) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5469 |
+| [#5413](https://github.com/danielbaustin/agent-design-language/issues/5413) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5477 |
+| [#5412](https://github.com/danielbaustin/agent-design-language/issues/5412) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5459 |
+| [#5411](https://github.com/danielbaustin/agent-design-language/issues/5411) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5442 |
+| [#5410](https://github.com/danielbaustin/agent-design-language/issues/5410) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5437 |
+| [#5409](https://github.com/danielbaustin/agent-design-language/issues/5409) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist |  |
+| [#5408](https://github.com/danielbaustin/agent-design-language/issues/5408) | orphaned_typed_receipt | orphaned_typed_receipt | valid csdlc.terminal_receipt.v1 exists with closed_out record, but no tracked projection exists; no cards are fabricated |  |
+| [#5407](https://github.com/danielbaustin/agent-design-language/issues/5407) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5424 |
+| [#5406](https://github.com/danielbaustin/agent-design-language/issues/5406) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5416, #5421, #5422 |
+| [#5405](https://github.com/danielbaustin/agent-design-language/issues/5405) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5445 |
+| [#5404](https://github.com/danielbaustin/agent-design-language/issues/5404) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5417 |
+| [#5403](https://github.com/danielbaustin/agent-design-language/issues/5403) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5414 |
+| [#5390](https://github.com/danielbaustin/agent-design-language/issues/5390) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5396 |
+| [#5385](https://github.com/danielbaustin/agent-design-language/issues/5385) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5388 |
+| [#5383](https://github.com/danielbaustin/agent-design-language/issues/5383) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5389 |
+| [#5375](https://github.com/danielbaustin/agent-design-language/issues/5375) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5377 |
+| [#5371](https://github.com/danielbaustin/agent-design-language/issues/5371) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5386 |
+| [#5373](https://github.com/danielbaustin/agent-design-language/issues/5373) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5378 |
+| [#5372](https://github.com/danielbaustin/agent-design-language/issues/5372) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5379 |
+| [#5370](https://github.com/danielbaustin/agent-design-language/issues/5370) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5386 |
+| [#5369](https://github.com/danielbaustin/agent-design-language/issues/5369) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#5368](https://github.com/danielbaustin/agent-design-language/issues/5368) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5376 |
+| [#5367](https://github.com/danielbaustin/agent-design-language/issues/5367) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5398 |
+| [#5366](https://github.com/danielbaustin/agent-design-language/issues/5366) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5387 |
+| [#5365](https://github.com/danielbaustin/agent-design-language/issues/5365) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5381 |
+| [#5364](https://github.com/danielbaustin/agent-design-language/issues/5364) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5382 |
+| [#5353](https://github.com/danielbaustin/agent-design-language/issues/5353) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5374 |
+| [#5330](https://github.com/danielbaustin/agent-design-language/issues/5330) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5397 |
+| [#5328](https://github.com/danielbaustin/agent-design-language/issues/5328) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#5327](https://github.com/danielbaustin/agent-design-language/issues/5327) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5334 |
+| [#5325](https://github.com/danielbaustin/agent-design-language/issues/5325) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5334 |
+| [#5323](https://github.com/danielbaustin/agent-design-language/issues/5323) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5329 |
+| [#5322](https://github.com/danielbaustin/agent-design-language/issues/5322) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5324 |
+| [#5307](https://github.com/danielbaustin/agent-design-language/issues/5307) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#5308](https://github.com/danielbaustin/agent-design-language/issues/5308) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#5306](https://github.com/danielbaustin/agent-design-language/issues/5306) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist |  |
+| [#5305](https://github.com/danielbaustin/agent-design-language/issues/5305) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5316 |
+| [#5296](https://github.com/danielbaustin/agent-design-language/issues/5296) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5309 |
+| [#5295](https://github.com/danielbaustin/agent-design-language/issues/5295) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#5294](https://github.com/danielbaustin/agent-design-language/issues/5294) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5304 |
+| [#5293](https://github.com/danielbaustin/agent-design-language/issues/5293) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5301 |
+| [#5292](https://github.com/danielbaustin/agent-design-language/issues/5292) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5298 |
+| [#5286](https://github.com/danielbaustin/agent-design-language/issues/5286) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5317 |
+| [#5287](https://github.com/danielbaustin/agent-design-language/issues/5287) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5289 |
+| [#5285](https://github.com/danielbaustin/agent-design-language/issues/5285) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5315 |
+| [#5284](https://github.com/danielbaustin/agent-design-language/issues/5284) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5288 |
+| [#5283](https://github.com/danielbaustin/agent-design-language/issues/5283) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5314 |
+| [#5282](https://github.com/danielbaustin/agent-design-language/issues/5282) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5313 |
+| [#5281](https://github.com/danielbaustin/agent-design-language/issues/5281) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5310 |
+| [#5280](https://github.com/danielbaustin/agent-design-language/issues/5280) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5302 |
+| [#5279](https://github.com/danielbaustin/agent-design-language/issues/5279) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5299 |
+| [#5278](https://github.com/danielbaustin/agent-design-language/issues/5278) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5297 |
+| [#5277](https://github.com/danielbaustin/agent-design-language/issues/5277) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5291 |
+| [#5276](https://github.com/danielbaustin/agent-design-language/issues/5276) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#5267](https://github.com/danielbaustin/agent-design-language/issues/5267) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5300 |
+| [#5260](https://github.com/danielbaustin/agent-design-language/issues/5260) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5333 |
+| [#5256](https://github.com/danielbaustin/agent-design-language/issues/5256) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5258 |
+| [#5254](https://github.com/danielbaustin/agent-design-language/issues/5254) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5271 |
+| [#5253](https://github.com/danielbaustin/agent-design-language/issues/5253) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5269 |
+| [#5252](https://github.com/danielbaustin/agent-design-language/issues/5252) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5266 |
+| [#5251](https://github.com/danielbaustin/agent-design-language/issues/5251) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5264 |
+| [#5250](https://github.com/danielbaustin/agent-design-language/issues/5250) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5262 |
+| [#5249](https://github.com/danielbaustin/agent-design-language/issues/5249) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5261 |
+| [#5248](https://github.com/danielbaustin/agent-design-language/issues/5248) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5259 |
+| [#5247](https://github.com/danielbaustin/agent-design-language/issues/5247) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#5246](https://github.com/danielbaustin/agent-design-language/issues/5246) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5303 |
+| [#5243](https://github.com/danielbaustin/agent-design-language/issues/5243) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#5240](https://github.com/danielbaustin/agent-design-language/issues/5240) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#5239](https://github.com/danielbaustin/agent-design-language/issues/5239) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5290 |
+| [#5238](https://github.com/danielbaustin/agent-design-language/issues/5238) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5275 |
+| [#5237](https://github.com/danielbaustin/agent-design-language/issues/5237) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5274 |
+| [#5236](https://github.com/danielbaustin/agent-design-language/issues/5236) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5272 |
+| [#5235](https://github.com/danielbaustin/agent-design-language/issues/5235) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5270 |
+| [#5234](https://github.com/danielbaustin/agent-design-language/issues/5234) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5268 |
+| [#5233](https://github.com/danielbaustin/agent-design-language/issues/5233) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5263 |
+| [#5232](https://github.com/danielbaustin/agent-design-language/issues/5232) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5257 |
+| [#5229](https://github.com/danielbaustin/agent-design-language/issues/5229) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5244 |
+| [#5228](https://github.com/danielbaustin/agent-design-language/issues/5228) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5231 |
+| [#5227](https://github.com/danielbaustin/agent-design-language/issues/5227) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#5225](https://github.com/danielbaustin/agent-design-language/issues/5225) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5230 |
+| [#5224](https://github.com/danielbaustin/agent-design-language/issues/5224) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#5222](https://github.com/danielbaustin/agent-design-language/issues/5222) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5245 |
+| [#5221](https://github.com/danielbaustin/agent-design-language/issues/5221) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#5220](https://github.com/danielbaustin/agent-design-language/issues/5220) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5273 |
+| [#5219](https://github.com/danielbaustin/agent-design-language/issues/5219) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5242 |
+| [#5218](https://github.com/danielbaustin/agent-design-language/issues/5218) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5223 |
+| [#5215](https://github.com/danielbaustin/agent-design-language/issues/5215) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5311 |
+| [#5214](https://github.com/danielbaustin/agent-design-language/issues/5214) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5326 |
+| [#5211](https://github.com/danielbaustin/agent-design-language/issues/5211) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#5200](https://github.com/danielbaustin/agent-design-language/issues/5200) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#5194](https://github.com/danielbaustin/agent-design-language/issues/5194) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5196 |
+| [#5191](https://github.com/danielbaustin/agent-design-language/issues/5191) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5319 |
+| [#5184](https://github.com/danielbaustin/agent-design-language/issues/5184) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5321 |
+| [#5177](https://github.com/danielbaustin/agent-design-language/issues/5177) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5198 |
+| [#5178](https://github.com/danielbaustin/agent-design-language/issues/5178) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5203 |
+| [#5180](https://github.com/danielbaustin/agent-design-language/issues/5180) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5201 |
+| [#5181](https://github.com/danielbaustin/agent-design-language/issues/5181) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5195 |
+| [#5182](https://github.com/danielbaustin/agent-design-language/issues/5182) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5192 |
+| [#5183](https://github.com/danielbaustin/agent-design-language/issues/5183) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5207 |
+| [#5175](https://github.com/danielbaustin/agent-design-language/issues/5175) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5213 |
+| [#5176](https://github.com/danielbaustin/agent-design-language/issues/5176) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5188 |
+| [#5179](https://github.com/danielbaustin/agent-design-language/issues/5179) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5209 |
+| [#5174](https://github.com/danielbaustin/agent-design-language/issues/5174) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#5170](https://github.com/danielbaustin/agent-design-language/issues/5170) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5173 |
+| [#5169](https://github.com/danielbaustin/agent-design-language/issues/5169) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5216 |
+| [#5164](https://github.com/danielbaustin/agent-design-language/issues/5164) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5210 |
+| [#5150](https://github.com/danielbaustin/agent-design-language/issues/5150) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5153 |
+| [#5143](https://github.com/danielbaustin/agent-design-language/issues/5143) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5145 |
+| [#5136](https://github.com/danielbaustin/agent-design-language/issues/5136) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5138 |
+| [#5135](https://github.com/danielbaustin/agent-design-language/issues/5135) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5140 |
+| [#5134](https://github.com/danielbaustin/agent-design-language/issues/5134) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5141 |
+| [#5130](https://github.com/danielbaustin/agent-design-language/issues/5130) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5133 |
+| [#5126](https://github.com/danielbaustin/agent-design-language/issues/5126) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5241 |
+| [#5124](https://github.com/danielbaustin/agent-design-language/issues/5124) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5162 |
+| [#5123](https://github.com/danielbaustin/agent-design-language/issues/5123) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5158 |
+| [#5125](https://github.com/danielbaustin/agent-design-language/issues/5125) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5255 |
+| [#5122](https://github.com/danielbaustin/agent-design-language/issues/5122) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5156 |
+| [#5121](https://github.com/danielbaustin/agent-design-language/issues/5121) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5131 |
+| [#5120](https://github.com/danielbaustin/agent-design-language/issues/5120) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5265 |
+| [#5118](https://github.com/danielbaustin/agent-design-language/issues/5118) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5212 |
+| [#5117](https://github.com/danielbaustin/agent-design-language/issues/5117) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5205 |
+| [#5119](https://github.com/danielbaustin/agent-design-language/issues/5119) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5206 |
+| [#5114](https://github.com/danielbaustin/agent-design-language/issues/5114) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5190 |
+| [#5115](https://github.com/danielbaustin/agent-design-language/issues/5115) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5202 |
+| [#5116](https://github.com/danielbaustin/agent-design-language/issues/5116) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5204 |
+| [#5111](https://github.com/danielbaustin/agent-design-language/issues/5111) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5172 |
+| [#5112](https://github.com/danielbaustin/agent-design-language/issues/5112) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5186 |
+| [#5113](https://github.com/danielbaustin/agent-design-language/issues/5113) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5187 |
+| [#5110](https://github.com/danielbaustin/agent-design-language/issues/5110) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5148 |
+| [#5100](https://github.com/danielbaustin/agent-design-language/issues/5100) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5108 |
+| [#5098](https://github.com/danielbaustin/agent-design-language/issues/5098) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5102 |
+| [#5097](https://github.com/danielbaustin/agent-design-language/issues/5097) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5318 |
+| [#5096](https://github.com/danielbaustin/agent-design-language/issues/5096) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5127 |
+| [#5086](https://github.com/danielbaustin/agent-design-language/issues/5086) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5087 |
+| [#5083](https://github.com/danielbaustin/agent-design-language/issues/5083) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5085 |
+| [#5082](https://github.com/danielbaustin/agent-design-language/issues/5082) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5084 |
+| [#5079](https://github.com/danielbaustin/agent-design-language/issues/5079) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5080 |
+| [#5076](https://github.com/danielbaustin/agent-design-language/issues/5076) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5208 |
+| [#5075](https://github.com/danielbaustin/agent-design-language/issues/5075) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5077 |
+| [#5070](https://github.com/danielbaustin/agent-design-language/issues/5070) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5073 |
+| [#5068](https://github.com/danielbaustin/agent-design-language/issues/5068) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5109 |
+| [#5062](https://github.com/danielbaustin/agent-design-language/issues/5062) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5069 |
+| [#5053](https://github.com/danielbaustin/agent-design-language/issues/5053) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5090 |
+| [#5045](https://github.com/danielbaustin/agent-design-language/issues/5045) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#5044](https://github.com/danielbaustin/agent-design-language/issues/5044) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5050 |
+| [#5042](https://github.com/danielbaustin/agent-design-language/issues/5042) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5049 |
+| [#5041](https://github.com/danielbaustin/agent-design-language/issues/5041) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5093 |
+| [#5040](https://github.com/danielbaustin/agent-design-language/issues/5040) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5063 |
+| [#5039](https://github.com/danielbaustin/agent-design-language/issues/5039) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5064 |
+| [#5037](https://github.com/danielbaustin/agent-design-language/issues/5037) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5046 |
+| [#5036](https://github.com/danielbaustin/agent-design-language/issues/5036) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#5035](https://github.com/danielbaustin/agent-design-language/issues/5035) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#5034](https://github.com/danielbaustin/agent-design-language/issues/5034) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5056 |
+| [#5032](https://github.com/danielbaustin/agent-design-language/issues/5032) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5058 |
+| [#5031](https://github.com/danielbaustin/agent-design-language/issues/5031) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5060 |
+| [#5028](https://github.com/danielbaustin/agent-design-language/issues/5028) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5030 |
+| [#5025](https://github.com/danielbaustin/agent-design-language/issues/5025) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5047 |
+| [#5026](https://github.com/danielbaustin/agent-design-language/issues/5026) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5061 |
+| [#5027](https://github.com/danielbaustin/agent-design-language/issues/5027) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5078 |
+| [#5024](https://github.com/danielbaustin/agent-design-language/issues/5024) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5048 |
+| [#5022](https://github.com/danielbaustin/agent-design-language/issues/5022) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5023 |
+| [#5020](https://github.com/danielbaustin/agent-design-language/issues/5020) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5021 |
+| [#5017](https://github.com/danielbaustin/agent-design-language/issues/5017) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5019 |
+| [#5012](https://github.com/danielbaustin/agent-design-language/issues/5012) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5029 |
+| [#5009](https://github.com/danielbaustin/agent-design-language/issues/5009) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5015 |
+| [#5006](https://github.com/danielbaustin/agent-design-language/issues/5006) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5011 |
+| [#5005](https://github.com/danielbaustin/agent-design-language/issues/5005) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5043 |
+| [#5003](https://github.com/danielbaustin/agent-design-language/issues/5003) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5065 |
+| [#5002](https://github.com/danielbaustin/agent-design-language/issues/5002) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5066 |
+| [#5001](https://github.com/danielbaustin/agent-design-language/issues/5001) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5010 |
+| [#4999](https://github.com/danielbaustin/agent-design-language/issues/4999) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5071 |
+| [#4998](https://github.com/danielbaustin/agent-design-language/issues/4998) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5016 |
+| [#4997](https://github.com/danielbaustin/agent-design-language/issues/4997) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5000 |
+| [#4995](https://github.com/danielbaustin/agent-design-language/issues/4995) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5074 |
+| [#4990](https://github.com/danielbaustin/agent-design-language/issues/4990) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5149 |
+| [#4989](https://github.com/danielbaustin/agent-design-language/issues/4989) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4996 |
+| [#4987](https://github.com/danielbaustin/agent-design-language/issues/4987) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5103 |
+| [#4986](https://github.com/danielbaustin/agent-design-language/issues/4986) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4992 |
+| [#4985](https://github.com/danielbaustin/agent-design-language/issues/4985) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5089 |
+| [#4983](https://github.com/danielbaustin/agent-design-language/issues/4983) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5038 |
+| [#4980](https://github.com/danielbaustin/agent-design-language/issues/4980) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5013 |
+| [#4979](https://github.com/danielbaustin/agent-design-language/issues/4979) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5055 |
+| [#4977](https://github.com/danielbaustin/agent-design-language/issues/4977) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5054 |
+| [#4976](https://github.com/danielbaustin/agent-design-language/issues/4976) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4981 |
+| [#4974](https://github.com/danielbaustin/agent-design-language/issues/4974) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5059 |
+| [#4972](https://github.com/danielbaustin/agent-design-language/issues/4972) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4973 |
+| [#4961](https://github.com/danielbaustin/agent-design-language/issues/4961) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4963 |
+| [#4960](https://github.com/danielbaustin/agent-design-language/issues/4960) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4965 |
+| [#4959](https://github.com/danielbaustin/agent-design-language/issues/4959) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4962 |
+| [#4955](https://github.com/danielbaustin/agent-design-language/issues/4955) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4957 |
+| [#4953](https://github.com/danielbaustin/agent-design-language/issues/4953) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4956 |
+| [#4952](https://github.com/danielbaustin/agent-design-language/issues/4952) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4954 |
+| [#4950](https://github.com/danielbaustin/agent-design-language/issues/4950) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4988 |
+| [#4946](https://github.com/danielbaustin/agent-design-language/issues/4946) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4951 |
+| [#4945](https://github.com/danielbaustin/agent-design-language/issues/4945) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4948 |
+| [#4938](https://github.com/danielbaustin/agent-design-language/issues/4938) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5128 |
+| [#4936](https://github.com/danielbaustin/agent-design-language/issues/4936) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4939 |
+| [#4933](https://github.com/danielbaustin/agent-design-language/issues/4933) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4964 |
+| [#4932](https://github.com/danielbaustin/agent-design-language/issues/4932) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4937 |
+| [#4929](https://github.com/danielbaustin/agent-design-language/issues/4929) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4967 |
+| [#4928](https://github.com/danielbaustin/agent-design-language/issues/4928) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4930 |
+| [#4927](https://github.com/danielbaustin/agent-design-language/issues/4927) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#4924](https://github.com/danielbaustin/agent-design-language/issues/4924) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4947 |
+| [#4922](https://github.com/danielbaustin/agent-design-language/issues/4922) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4968 |
+| [#4921](https://github.com/danielbaustin/agent-design-language/issues/4921) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4971 |
+| [#4920](https://github.com/danielbaustin/agent-design-language/issues/4920) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5144 |
+| [#4919](https://github.com/danielbaustin/agent-design-language/issues/4919) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4970 |
+| [#4918](https://github.com/danielbaustin/agent-design-language/issues/4918) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4969 |
+| [#4917](https://github.com/danielbaustin/agent-design-language/issues/4917) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5139 |
+| [#4916](https://github.com/danielbaustin/agent-design-language/issues/4916) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4941 |
+| [#4915](https://github.com/danielbaustin/agent-design-language/issues/4915) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4994 |
+| [#4914](https://github.com/danielbaustin/agent-design-language/issues/4914) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5160 |
+| [#4913](https://github.com/danielbaustin/agent-design-language/issues/4913) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4993 |
+| [#4912](https://github.com/danielbaustin/agent-design-language/issues/4912) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5106 |
+| [#4911](https://github.com/danielbaustin/agent-design-language/issues/4911) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4949 |
+| [#4910](https://github.com/danielbaustin/agent-design-language/issues/4910) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4940 |
+| [#4909](https://github.com/danielbaustin/agent-design-language/issues/4909) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4926 |
+| [#4908](https://github.com/danielbaustin/agent-design-language/issues/4908) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#4907](https://github.com/danielbaustin/agent-design-language/issues/4907) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4931 |
+| [#4906](https://github.com/danielbaustin/agent-design-language/issues/4906) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5105 |
+| [#4905](https://github.com/danielbaustin/agent-design-language/issues/4905) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4943 |
+| [#4904](https://github.com/danielbaustin/agent-design-language/issues/4904) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4925 |
+| [#4903](https://github.com/danielbaustin/agent-design-language/issues/4903) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4923 |
+| [#4899](https://github.com/danielbaustin/agent-design-language/issues/4899) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5095 |
+| [#4898](https://github.com/danielbaustin/agent-design-language/issues/4898) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5072 |
+| [#4897](https://github.com/danielbaustin/agent-design-language/issues/4897) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5094 |
+| [#4896](https://github.com/danielbaustin/agent-design-language/issues/4896) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5092 |
+| [#4895](https://github.com/danielbaustin/agent-design-language/issues/4895) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5088 |
+| [#4894](https://github.com/danielbaustin/agent-design-language/issues/4894) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5081 |
+| [#4893](https://github.com/danielbaustin/agent-design-language/issues/4893) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5067 |
+| [#4892](https://github.com/danielbaustin/agent-design-language/issues/4892) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5057 |
+| [#4890](https://github.com/danielbaustin/agent-design-language/issues/4890) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4891 |
+| [#4885](https://github.com/danielbaustin/agent-design-language/issues/4885) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4887 |
+| [#4882](https://github.com/danielbaustin/agent-design-language/issues/4882) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4934 |
+| [#4880](https://github.com/danielbaustin/agent-design-language/issues/4880) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4888 |
+| [#4879](https://github.com/danielbaustin/agent-design-language/issues/4879) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4881 |
+| [#4877](https://github.com/danielbaustin/agent-design-language/issues/4877) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4884 |
+| [#4876](https://github.com/danielbaustin/agent-design-language/issues/4876) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4878 |
+| [#4864](https://github.com/danielbaustin/agent-design-language/issues/4864) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4866 |
+| [#4859](https://github.com/danielbaustin/agent-design-language/issues/4859) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#4858](https://github.com/danielbaustin/agent-design-language/issues/4858) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#4854](https://github.com/danielbaustin/agent-design-language/issues/4854) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4886 |
+| [#4853](https://github.com/danielbaustin/agent-design-language/issues/4853) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4867 |
+| [#4850](https://github.com/danielbaustin/agent-design-language/issues/4850) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4861 |
+| [#4849](https://github.com/danielbaustin/agent-design-language/issues/4849) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4855 |
+| [#4848](https://github.com/danielbaustin/agent-design-language/issues/4848) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4958 |
+| [#4845](https://github.com/danielbaustin/agent-design-language/issues/4845) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4875 |
+| [#4844](https://github.com/danielbaustin/agent-design-language/issues/4844) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4874 |
+| [#4843](https://github.com/danielbaustin/agent-design-language/issues/4843) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4870 |
+| [#4842](https://github.com/danielbaustin/agent-design-language/issues/4842) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4851 |
+| [#4838](https://github.com/danielbaustin/agent-design-language/issues/4838) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4865 |
+| [#4837](https://github.com/danielbaustin/agent-design-language/issues/4837) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4863 |
+| [#4836](https://github.com/danielbaustin/agent-design-language/issues/4836) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4846 |
+| [#4835](https://github.com/danielbaustin/agent-design-language/issues/4835) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4847 |
+| [#4830](https://github.com/danielbaustin/agent-design-language/issues/4830) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4831 |
+| [#4825](https://github.com/danielbaustin/agent-design-language/issues/4825) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#4819](https://github.com/danielbaustin/agent-design-language/issues/4819) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4821 |
+| [#4817](https://github.com/danielbaustin/agent-design-language/issues/4817) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4820 |
+| [#4815](https://github.com/danielbaustin/agent-design-language/issues/4815) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4840 |
+| [#4807](https://github.com/danielbaustin/agent-design-language/issues/4807) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4808 |
+| [#4806](https://github.com/danielbaustin/agent-design-language/issues/4806) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#4804](https://github.com/danielbaustin/agent-design-language/issues/4804) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4810 |
+| [#4800](https://github.com/danielbaustin/agent-design-language/issues/4800) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4832 |
+| [#4796](https://github.com/danielbaustin/agent-design-language/issues/4796) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4801 |
+| [#4795](https://github.com/danielbaustin/agent-design-language/issues/4795) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4833 |
+| [#4792](https://github.com/danielbaustin/agent-design-language/issues/4792) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4793 |
+| [#4790](https://github.com/danielbaustin/agent-design-language/issues/4790) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4791 |
+| [#4789](https://github.com/danielbaustin/agent-design-language/issues/4789) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4822 |
+| [#4788](https://github.com/danielbaustin/agent-design-language/issues/4788) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4818 |
+| [#4787](https://github.com/danielbaustin/agent-design-language/issues/4787) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4826 |
+| [#4785](https://github.com/danielbaustin/agent-design-language/issues/4785) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4786 |
+| [#4784](https://github.com/danielbaustin/agent-design-language/issues/4784) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4871 |
+| [#4783](https://github.com/danielbaustin/agent-design-language/issues/4783) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#4782](https://github.com/danielbaustin/agent-design-language/issues/4782) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4935 |
+| [#4781](https://github.com/danielbaustin/agent-design-language/issues/4781) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5014 |
+| [#4780](https://github.com/danielbaustin/agent-design-language/issues/4780) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5008 |
+| [#4778](https://github.com/danielbaustin/agent-design-language/issues/4778) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5018 |
+| [#4777](https://github.com/danielbaustin/agent-design-language/issues/4777) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4779 |
+| [#4773](https://github.com/danielbaustin/agent-design-language/issues/4773) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#4771](https://github.com/danielbaustin/agent-design-language/issues/4771) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4805 |
+| [#4770](https://github.com/danielbaustin/agent-design-language/issues/4770) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4803 |
+| [#4769](https://github.com/danielbaustin/agent-design-language/issues/4769) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4802 |
+| [#4768](https://github.com/danielbaustin/agent-design-language/issues/4768) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4798 |
+| [#4767](https://github.com/danielbaustin/agent-design-language/issues/4767) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4794 |
+| [#4766](https://github.com/danielbaustin/agent-design-language/issues/4766) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4775 |
+| [#4765](https://github.com/danielbaustin/agent-design-language/issues/4765) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#4757](https://github.com/danielbaustin/agent-design-language/issues/4757) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5197 |
+| [#4756](https://github.com/danielbaustin/agent-design-language/issues/4756) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5193 |
+| [#4755](https://github.com/danielbaustin/agent-design-language/issues/4755) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5189 |
+| [#4754](https://github.com/danielbaustin/agent-design-language/issues/4754) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5185 |
+| [#4753](https://github.com/danielbaustin/agent-design-language/issues/4753) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5171 |
+| [#4752](https://github.com/danielbaustin/agent-design-language/issues/4752) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5165 |
+| [#4751](https://github.com/danielbaustin/agent-design-language/issues/4751) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#4749](https://github.com/danielbaustin/agent-design-language/issues/4749) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4750 |
+| [#4747](https://github.com/danielbaustin/agent-design-language/issues/4747) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4748 |
+| [#4745](https://github.com/danielbaustin/agent-design-language/issues/4745) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#4743](https://github.com/danielbaustin/agent-design-language/issues/4743) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4744 |
+| [#4740](https://github.com/danielbaustin/agent-design-language/issues/4740) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4776 |
+| [#4738](https://github.com/danielbaustin/agent-design-language/issues/4738) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4816 |
+| [#4737](https://github.com/danielbaustin/agent-design-language/issues/4737) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4814 |
+| [#4736](https://github.com/danielbaustin/agent-design-language/issues/4736) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4797 |
+| [#4730](https://github.com/danielbaustin/agent-design-language/issues/4730) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4731 |
+| [#4728](https://github.com/danielbaustin/agent-design-language/issues/4728) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4729 |
+| [#4726](https://github.com/danielbaustin/agent-design-language/issues/4726) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4852 |
+| [#4724](https://github.com/danielbaustin/agent-design-language/issues/4724) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4772 |
+| [#4723](https://github.com/danielbaustin/agent-design-language/issues/4723) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4774 |
+| [#4721](https://github.com/danielbaustin/agent-design-language/issues/4721) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4813 |
+| [#4720](https://github.com/danielbaustin/agent-design-language/issues/4720) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4722 |
+| [#4719](https://github.com/danielbaustin/agent-design-language/issues/4719) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4725 |
+| [#4718](https://github.com/danielbaustin/agent-design-language/issues/4718) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4862 |
+| [#4713](https://github.com/danielbaustin/agent-design-language/issues/4713) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4829 |
+| [#4711](https://github.com/danielbaustin/agent-design-language/issues/4711) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4712 |
+| [#4709](https://github.com/danielbaustin/agent-design-language/issues/4709) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4811 |
+| [#4706](https://github.com/danielbaustin/agent-design-language/issues/4706) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4707 |
+| [#4704](https://github.com/danielbaustin/agent-design-language/issues/4704) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4799 |
+| [#4703](https://github.com/danielbaustin/agent-design-language/issues/4703) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#4702](https://github.com/danielbaustin/agent-design-language/issues/4702) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5155 |
+| [#4701](https://github.com/danielbaustin/agent-design-language/issues/4701) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#4700](https://github.com/danielbaustin/agent-design-language/issues/4700) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4715 |
+| [#4699](https://github.com/danielbaustin/agent-design-language/issues/4699) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#4698](https://github.com/danielbaustin/agent-design-language/issues/4698) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4839 |
+| [#4697](https://github.com/danielbaustin/agent-design-language/issues/4697) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5101 |
+| [#4696](https://github.com/danielbaustin/agent-design-language/issues/4696) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5099 |
+| [#4695](https://github.com/danielbaustin/agent-design-language/issues/4695) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5104 |
+| [#4694](https://github.com/danielbaustin/agent-design-language/issues/4694) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5091 |
+| [#4693](https://github.com/danielbaustin/agent-design-language/issues/4693) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5163 |
+| [#4692](https://github.com/danielbaustin/agent-design-language/issues/4692) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5161 |
+| [#4691](https://github.com/danielbaustin/agent-design-language/issues/4691) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5154 |
+| [#4690](https://github.com/danielbaustin/agent-design-language/issues/4690) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4991 |
+| [#4689](https://github.com/danielbaustin/agent-design-language/issues/4689) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5152 |
+| [#4688](https://github.com/danielbaustin/agent-design-language/issues/4688) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4982 |
+| [#4687](https://github.com/danielbaustin/agent-design-language/issues/4687) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4978 |
+| [#4686](https://github.com/danielbaustin/agent-design-language/issues/4686) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4984 |
+| [#4685](https://github.com/danielbaustin/agent-design-language/issues/4685) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4975 |
+| [#4684](https://github.com/danielbaustin/agent-design-language/issues/4684) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4966 |
+| [#4683](https://github.com/danielbaustin/agent-design-language/issues/4683) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4872 |
+| [#4682](https://github.com/danielbaustin/agent-design-language/issues/4682) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4873 |
+| [#4681](https://github.com/danielbaustin/agent-design-language/issues/4681) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4868 |
+| [#4680](https://github.com/danielbaustin/agent-design-language/issues/4680) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4942 |
+| [#4679](https://github.com/danielbaustin/agent-design-language/issues/4679) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4944 |
+| [#4678](https://github.com/danielbaustin/agent-design-language/issues/4678) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4857 |
+| [#4677](https://github.com/danielbaustin/agent-design-language/issues/4677) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4856 |
+| [#4676](https://github.com/danielbaustin/agent-design-language/issues/4676) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4828 |
+| [#4675](https://github.com/danielbaustin/agent-design-language/issues/4675) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4834 |
+| [#4674](https://github.com/danielbaustin/agent-design-language/issues/4674) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4827 |
+| [#4673](https://github.com/danielbaustin/agent-design-language/issues/4673) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4823 |
+| [#4672](https://github.com/danielbaustin/agent-design-language/issues/4672) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4812 |
+| [#4671](https://github.com/danielbaustin/agent-design-language/issues/4671) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4809 |
+| [#4670](https://github.com/danielbaustin/agent-design-language/issues/4670) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4735 |
+| [#4669](https://github.com/danielbaustin/agent-design-language/issues/4669) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4734 |
+| [#4668](https://github.com/danielbaustin/agent-design-language/issues/4668) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4733 |
+| [#4667](https://github.com/danielbaustin/agent-design-language/issues/4667) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4732 |
+| [#4666](https://github.com/danielbaustin/agent-design-language/issues/4666) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4727 |
+| [#4665](https://github.com/danielbaustin/agent-design-language/issues/4665) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#4664](https://github.com/danielbaustin/agent-design-language/issues/4664) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#4663](https://github.com/danielbaustin/agent-design-language/issues/4663) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#4662](https://github.com/danielbaustin/agent-design-language/issues/4662) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#4661](https://github.com/danielbaustin/agent-design-language/issues/4661) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4716 |
+| [#4660](https://github.com/danielbaustin/agent-design-language/issues/4660) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5151 |
+| [#4659](https://github.com/danielbaustin/agent-design-language/issues/4659) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5146, #5417 |
+| [#4658](https://github.com/danielbaustin/agent-design-language/issues/4658) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5137 |
+| [#4657](https://github.com/danielbaustin/agent-design-language/issues/4657) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5132 |
+| [#4656](https://github.com/danielbaustin/agent-design-language/issues/4656) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5129 |
+| [#4654](https://github.com/danielbaustin/agent-design-language/issues/4654) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5052 |
+| [#4653](https://github.com/danielbaustin/agent-design-language/issues/4653) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5051, #5077 |
+| [#4652](https://github.com/danielbaustin/agent-design-language/issues/4652) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4824 |
+| [#4651](https://github.com/danielbaustin/agent-design-language/issues/4651) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#4649](https://github.com/danielbaustin/agent-design-language/issues/4649) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5142 |
+| [#4648](https://github.com/danielbaustin/agent-design-language/issues/4648) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4901 |
+| [#4645](https://github.com/danielbaustin/agent-design-language/issues/4645) | typed_projection | typed_receipt_required | tracked typed projection exists; receipt and terminal parity must be checked | #5543 |
+| [#4644](https://github.com/danielbaustin/agent-design-language/issues/4644) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5539 |
+| [#4643](https://github.com/danielbaustin/agent-design-language/issues/4643) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5524 |
+| [#4642](https://github.com/danielbaustin/agent-design-language/issues/4642) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5503 |
+| [#4641](https://github.com/danielbaustin/agent-design-language/issues/4641) | typed_projection | typed_receipt_present | tracked typed projection and retained shared terminal receipt exist | #5493 |
+| [#4640](https://github.com/danielbaustin/agent-design-language/issues/4640) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5199 |
+| [#4639](https://github.com/danielbaustin/agent-design-language/issues/4639) | legacy | legacy_closed_without_linked_pr | GitHub issue has no closedByPullRequestsReferences; no typed lifecycle record is fabricated |  |
+| [#4638](https://github.com/danielbaustin/agent-design-language/issues/4638) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5147 |
+| [#4637](https://github.com/danielbaustin/agent-design-language/issues/4637) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5168 |
+| [#4636](https://github.com/danielbaustin/agent-design-language/issues/4636) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5157 |
+| [#4635](https://github.com/danielbaustin/agent-design-language/issues/4635) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #5004 |
+| [#4634](https://github.com/danielbaustin/agent-design-language/issues/4634) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4889 |
+| [#4633](https://github.com/danielbaustin/agent-design-language/issues/4633) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4860 |
+| [#4632](https://github.com/danielbaustin/agent-design-language/issues/4632) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4841 |
+| [#4631](https://github.com/danielbaustin/agent-design-language/issues/4631) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4746 |
+| [#4630](https://github.com/danielbaustin/agent-design-language/issues/4630) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4714 |
+| [#4629](https://github.com/danielbaustin/agent-design-language/issues/4629) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4710 |
+| [#4628](https://github.com/danielbaustin/agent-design-language/issues/4628) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4655 |
+| [#4617](https://github.com/danielbaustin/agent-design-language/issues/4617) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4742 |
+| [#4603](https://github.com/danielbaustin/agent-design-language/issues/4603) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4717 |
+| [#4562](https://github.com/danielbaustin/agent-design-language/issues/4562) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4580 |
+| [#4549](https://github.com/danielbaustin/agent-design-language/issues/4549) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4573 |
+| [#4511](https://github.com/danielbaustin/agent-design-language/issues/4511) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4514 |
+| [#4512](https://github.com/danielbaustin/agent-design-language/issues/4512) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4515 |
+| [#4498](https://github.com/danielbaustin/agent-design-language/issues/4498) | legacy | legacy_merged_pr | GitHub closedByPullRequestsReferences includes a merged PR | #4519 |


### PR DESCRIPTION
Adds the exhaustive live closeout register for all 427 closed v0.91.7 issues.

Partition: 46 tracked typed projections, 3 orphaned valid typed receipts, and 378 legacy/pre-v2 closures. Legacy rows use GitHub linked-PR evidence or explicit no-linked-PR evidence; no legacy cards are fabricated. Candidate shared receipts are schema- and terminal-state validated.

Subagent review passed with zero findings. The sole typed projection still lacking a receipt is #4645, blocked by hosted coverage failures tracked in #5575. No AWS or Spot execution.

Relates to #5573.