### PR TITLE
[v0.91.8][ci] Route ADL v2 crates to focused validation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,6 +54,7 @@ jobs:
       validation_profile_escalation_lanes: ${{ steps.path-policy.outputs.validation_profile_escalation_lanes }}
       runtime_v3_fast_required: ${{ steps.path-policy.outputs.runtime_v3_fast_required }}
       csdlc_v2_standalone_required: ${{ steps.path-policy.outputs.csdlc_v2_standalone_required }}
+      adl_v2_standalone_required: ${{ steps.path-policy.outputs.adl_v2_standalone_required }}
       heavy_ci_backend: ${{ steps.path-policy.outputs.heavy_ci_backend }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -107,6 +108,18 @@ jobs:
               ;;
           esac
 
+      - name: Validate standalone ADL v2 selector
+        env:
+          ADL_V2_STANDALONE_REQUIRED: ${{ steps.path-policy.outputs.adl_v2_standalone_required }}
+        run: |
+          case "$ADL_V2_STANDALONE_REQUIRED" in
+            true|false) ;;
+            *)
+              echo "::error::adl_v2_standalone_required must be exactly true or false"
+              exit 1
+              ;;
+          esac
+
   csdlc_v2_standalone:
     name: csdlc-v2-standalone
     needs: adl_path_policy
@@ -138,6 +151,30 @@ jobs:
 
       - name: C-SDLC v2 strict Clippy
         run: bash adl/tools/run_cargo_validation.sh cargo clippy --locked --manifest-path csdlc-v2/Cargo.toml --all-targets -- -D warnings
+
+  adl_v2_standalone:
+    name: adl-v2-standalone
+    needs: adl_path_policy
+    if: needs.adl_path_policy.outputs.adl_v2_standalone_required == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Prepare external Cargo build root
+        run: |
+          build_root="$RUNNER_TEMP/adl-v2"
+          mkdir -p "$build_root"
+          echo "ADL_CARGO_BUILD_ROOT=$build_root" >> "$GITHUB_ENV"
+
+      - name: ADL v2 standalone validation
+        run: bash adl/tools/run_adl_v2_standalone.sh
 
   adl_tooling_contracts:
     name: adl-tooling-contracts
@@ -559,6 +596,7 @@ jobs:
     needs:
       - adl_path_policy
       - csdlc_v2_standalone
+      - adl_v2_standalone
       - adl_tooling_contracts
       - adl_runtime_v3_fast
       - adl_rust_fmt_clippy
@@ -583,6 +621,8 @@ jobs:
           RUST_REQUIRED: ${{ needs.adl_path_policy.outputs.rust_required == 'true' }}
           CSDLC_V2_STANDALONE_REQUIRED: ${{ needs.adl_path_policy.outputs.csdlc_v2_standalone_required }}
           CSDLC_V2_STANDALONE_RESULT: ${{ needs.csdlc_v2_standalone.result }}
+          ADL_V2_STANDALONE_REQUIRED: ${{ needs.adl_path_policy.outputs.adl_v2_standalone_required }}
+          ADL_V2_STANDALONE_RESULT: ${{ needs.adl_v2_standalone.result }}
           DEMO_REQUIRED: ${{ needs.adl_path_policy.outputs.demo_smoke_required == 'true' || needs.adl_path_policy.outputs.v0913_proof_required == 'true' }}
         run: |
           set -euo pipefail
@@ -601,6 +641,24 @@ jobs:
               ;;
             *)
               echo "::error::csdlc_v2_standalone_required must be exactly true or false"
+              exit 1
+              ;;
+          esac
+          case "$ADL_V2_STANDALONE_REQUIRED" in
+            true)
+              if [ "$ADL_V2_STANDALONE_RESULT" != success ]; then
+                echo "::error::selected ADL v2 standalone lane is $ADL_V2_STANDALONE_RESULT; expected success"
+                exit 1
+              fi
+              ;;
+            false)
+              if [ "$ADL_V2_STANDALONE_RESULT" != skipped ]; then
+                echo "::error::unselected ADL v2 standalone lane is $ADL_V2_STANDALONE_RESULT; expected skipped"
+                exit 1
+              fi
+              ;;
+            *)
+              echo "::error::adl_v2_standalone_required must be exactly true or false"
               exit 1
               ;;
           esac
@@ -623,6 +681,7 @@ jobs:
           for lane in \
             "adl_path_policy:${{ needs.adl_path_policy.result }}" \
             "csdlc_v2_standalone:${{ needs.csdlc_v2_standalone.result }}" \
+            "adl_v2_standalone:${{ needs.adl_v2_standalone.result }}" \
             "adl_tooling_contracts:${{ needs.adl_tooling_contracts.result }}" \
             "adl_runtime_v3_fast:${{ needs.adl_runtime_v3_fast.result }}" \
             "adl_rust_fmt_clippy:${{ needs.adl_rust_fmt_clippy.result }}" \
@@ -648,6 +707,7 @@ jobs:
             echo "|---|---|"
             echo "| adl_path_policy | \`${{ needs.adl_path_policy.result }}\` |"
             echo "| csdlc_v2_standalone | \`${{ needs.csdlc_v2_standalone.result }}\` |"
+            echo "| adl_v2_standalone | \`${{ needs.adl_v2_standalone.result }}\` |"
             echo "| adl_tooling_contracts | \`${{ needs.adl_tooling_contracts.result }}\` |"
             echo "| adl_runtime_v3_fast | \`${{ needs.adl_runtime_v3_fast.result }}\` |"
             echo "| adl_rust_fmt_clippy | \`${{ needs.adl_rust_fmt_clippy.result }}\` |"

--- a/adl/config/validation_lane_selector.v0.91.6.json
+++ b/adl/config/validation_lane_selector.v0.91.6.json
@@ -95,6 +95,25 @@
       "reason": "standalone_csdlc_v2_surface_requires_only_its_independent_focused_suite"
     },
     {
+      "id": "adl_v2_standalone",
+      "lane_class": "rust_unit",
+      "default_surface": "tooling",
+      "owner": "adl-v2",
+      "proof_role": "standalone_regression",
+      "requirement_ids": [
+        "adl_v2_standalone"
+      ],
+      "path_selectors": [
+        "adl-v2/**"
+      ],
+      "path_hints": [
+        "adl-v2/**"
+      ],
+      "command": "bash adl/tools/run_adl_v2_standalone.sh",
+      "run_command": "bash adl/tools/run_adl_v2_standalone.sh",
+      "reason": "standalone_adl_v2_surface_requires_only_its_independent_focused_suite"
+    },
+    {
       "id": "prompt_template_contracts",
       "lane_class": "cli_workflow",
       "default_surface": "tooling",

--- a/adl/tools/ci_path_policy.sh
+++ b/adl/tools/ci_path_policy.sh
@@ -89,6 +89,7 @@ validation_profile_report=""
 validation_profile_contract_lanes_selected="$bool_false"
 runtime_v3_fast_required="$bool_false"
 csdlc_v2_standalone_required="$bool_false"
+adl_v2_standalone_required="$bool_false"
 large_file_lines="${COVERAGE_IMPACT_LARGE_FILE_LINES:-200}"
 large_file_delta="${COVERAGE_IMPACT_LARGE_FILE_DELTA:-80}"
 pvf_slow_proof_policy_change=false
@@ -1238,14 +1239,18 @@ apply_validation_manager_routing() {
   if [ "$validation_profile_status" = "ready_to_run" ] \
     && [ "$validation_profile_escalation_required" = "false" ]; then
     selected_csdlc_v2=false
+    selected_adl_v2=false
     selected_runtime_kernel=false
     case ",$validation_profile_run_lanes," in
       *,csdlc_v2_standalone,*) selected_csdlc_v2=true ;;
     esac
     case ",$validation_profile_run_lanes," in
+      *,adl_v2_standalone,*) selected_adl_v2=true ;;
+    esac
+    case ",$validation_profile_run_lanes," in
       *,runtime_kernel_contracts,*) selected_runtime_kernel=true ;;
     esac
-    if [ "$selected_csdlc_v2" = true ] || [ "$selected_runtime_kernel" = true ]; then
+    if [ "$selected_csdlc_v2" = true ] || [ "$selected_adl_v2" = true ] || [ "$selected_runtime_kernel" = true ]; then
       coverage_lane="skip"
       coverage_authority="not_required"
       coverage_execution_state="skipped_by_path_policy"
@@ -1253,10 +1258,15 @@ apply_validation_manager_routing() {
         csdlc_v2_standalone_required=true
         ci_contracts_required=true
       fi
+      if [ "$selected_adl_v2" = true ]; then
+        adl_v2_standalone_required=true
+      fi
       if [ "$selected_runtime_kernel" = true ]; then
         runtime_v3_fast_required=true
       fi
-      if [ "$selected_csdlc_v2" = true ] && [ "$selected_runtime_kernel" = true ]; then
+      if [ "$selected_adl_v2" = true ] && [ "$selected_csdlc_v2" != true ] && [ "$selected_runtime_kernel" != true ]; then
+        reason="standalone_adl_v2_surface_requires_only_its_independent_focused_suite"
+      elif [ "$selected_csdlc_v2" = true ] && [ "$selected_runtime_kernel" = true ]; then
         reason="csdlc_v2_and_runtime_v3_surfaces_run_both_independent_focused_lanes"
       elif [ "$selected_csdlc_v2" = true ]; then
         reason="standalone_csdlc_v2_surface_requires_only_its_independent_focused_suite"
@@ -1432,6 +1442,9 @@ else
       case "$path" in
         csdlc-v2/*)
           csdlc_v2_standalone_required=true
+          ;;
+        adl-v2/*)
+          adl_v2_standalone_required=true
           ;;
       esac
     done <<EOF
@@ -1663,6 +1676,7 @@ emit "skill_author_contracts_required" "$skill_author_contracts_required"
 emit "validation_profile_contract_lanes_selected" "$validation_profile_contract_lanes_selected"
 emit "runtime_v3_fast_required" "$runtime_v3_fast_required"
 emit "csdlc_v2_standalone_required" "$csdlc_v2_standalone_required"
+emit "adl_v2_standalone_required" "$adl_v2_standalone_required"
 emit "fail_closed" "$fail_closed"
 emit "coverage_lane" "$coverage_lane"
 emit "coverage_authority" "$coverage_authority"

--- a/adl/tools/run_adl_v2_standalone.sh
+++ b/adl/tools/run_adl_v2_standalone.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+shopt -s nullglob
+manifests=("$root"/adl-v2/crates/*/Cargo.toml)
+
+if [ "${#manifests[@]}" -eq 0 ]; then
+  echo "no ADL v2 crate manifests found" >&2
+  exit 2
+fi
+
+for manifest in "${manifests[@]}"; do
+  relative_manifest="${manifest#"$root/"}"
+  echo "Validating $relative_manifest"
+  bash "$root/adl/tools/run_cargo_validation.sh" cargo test --locked --manifest-path "$manifest"
+  bash "$root/adl/tools/run_cargo_validation.sh" cargo fmt --manifest-path "$manifest" --all -- --check
+  bash "$root/adl/tools/run_cargo_validation.sh" cargo clippy --locked --manifest-path "$manifest" --all-targets -- -D warnings
+done

--- a/adl/tools/test_ci_path_policy.sh
+++ b/adl/tools/test_ci_path_policy.sh
@@ -95,6 +95,12 @@ assert_current_coverage_workflow_contract() {
   assert_file_has "$workflow" 'selected C-SDLC v2 standalone lane is $CSDLC_V2_STANDALONE_RESULT; expected success'
   assert_file_has "$workflow" 'unselected C-SDLC v2 standalone lane is $CSDLC_V2_STANDALONE_RESULT; expected skipped'
   assert_file_has "$workflow" 'csdlc_v2_standalone_required must be exactly true or false'
+  assert_file_has "$workflow" 'name: adl-v2-standalone'
+  assert_file_has "$workflow" "if: needs.adl_path_policy.outputs.adl_v2_standalone_required == 'true'"
+  assert_file_has "$workflow" 'adl_v2_standalone:${{ needs.adl_v2_standalone.result }}'
+  assert_file_has "$workflow" 'selected ADL v2 standalone lane is $ADL_V2_STANDALONE_RESULT; expected success'
+  assert_file_has "$workflow" 'unselected ADL v2 standalone lane is $ADL_V2_STANDALONE_RESULT; expected skipped'
+  assert_file_has "$workflow" 'adl_v2_standalone_required must be exactly true or false'
   assert_file_has "$workflow" 'Full workspace coverage gate deferred for PR'
   assert_file_has "$workflow" 'adl/target/coverage-impact-summary.json'
   assert_file_not_has "$workflow" '--authority "adl_coverage_always_on"'
@@ -254,6 +260,22 @@ PY
   assert_has "$csdlc_v2_output" "coverage_required=false"
   assert_has "$csdlc_v2_output" "full_coverage_required=false"
   assert_has "$csdlc_v2_output" "reason=standalone_csdlc_v2_surface_requires_only_its_independent_focused_suite"
+
+  git checkout -q -b adl-v2-standalone "$base_sha"
+  mkdir -p adl-v2/crates/adl-records/src
+  printf 'pub fn signed_record() {}\n' > adl-v2/crates/adl-records/src/lib.rs
+  git add adl-v2/crates/adl-records/src/lib.rs
+  git commit -q -m adl-v2-standalone
+  adl_v2_head="$(git rev-parse HEAD)"
+  adl_v2_output="$($POLICY --event-name pull_request --base "$base_sha" --head "$adl_v2_head" --ref "refs/pull/1/merge")"
+  assert_has "$adl_v2_output" "validation_profile_run_lanes=adl_v2_standalone"
+  assert_has "$adl_v2_output" "adl_v2_standalone_required=true"
+  assert_has "$adl_v2_output" "csdlc_v2_standalone_required=false"
+  assert_has "$adl_v2_output" "rust_required=false"
+  assert_has "$adl_v2_output" "coverage_required=false"
+  assert_has "$adl_v2_output" "full_coverage_required=false"
+  assert_has "$adl_v2_output" "demo_smoke_required=false"
+  assert_has "$adl_v2_output" "reason=standalone_adl_v2_surface_requires_only_its_independent_focused_suite"
 
   git checkout -q -b csdlc-v2-operator-surface "$base_sha"
   mkdir -p csdlc-v2/operator/skills/example

--- a/adl/tools/test_ci_runtime_contracts.sh
+++ b/adl/tools/test_ci_runtime_contracts.sh
@@ -235,6 +235,7 @@ for required_fragment in (
 for required_fragment in (
     "adl_path_policy:",
     "csdlc_v2_standalone:",
+    "adl_v2_standalone:",
     "adl_tooling_contracts:",
     "adl_rust_fmt_clippy:",
     "adl_rust_tests:",


### PR DESCRIPTION
Corrective integration for #5342.

Routes `adl-v2/**` changes to one focused standalone test/fmt/Clippy lane and keeps legacy ADL workspace coverage, Runtime coverage, demos, and slow-proof shards out of independent ADL v2 PRs. Stable `adl-ci` and `adl-coverage` checks remain fail-closed.

Local proof: CI path-policy contracts pass, CI runtime contracts pass, shell syntax and diff hygiene pass, and all four ADL v2 crates pass tests, formatting, and strict Clippy using FastWork. No AWS or nested Cargo builds.