### PR TITLE
[v0.91.8][adl-v2][ci] Prove focused standalone validation

### DIFF
--- a/adl-v2/crates/adl-records/README.md
+++ b/adl-v2/crates/adl-records/README.md
@@ -6,3 +6,5 @@ an external trust policy and an external replay guard.
 
 The crate performs no filesystem, network, clock, environment, key-store, or
 runtime operations. Callers supply keys, logical time, trust, and replay state.
+
+ADL v2 crates use the focused standalone CI lane for tests, formatting, and Clippy.


### PR DESCRIPTION
CI routing proof for #5342.

This one-line README clarification intentionally changes only adl-v2/** to prove the focused lane. Expected: adl-v2-standalone, path/tooling, and stable aggregates run; legacy workspace/runtime coverage, demo, and slow-proof remain skipped.