### PR TITLE
[v0.91.8][tools][ci] Add proportional fast lane for small fixes

### DIFF
--- a/.csdlc/issues/5666/audit.jsonl
+++ b/.csdlc/issues/5666/audit.jsonl
@@ -5,3 +5,4 @@
 {"sequence":5,"generation":3,"actor":"operator:5666","reason":"reapprove changed issue design","operation":"approve_design"}
 {"sequence":6,"generation":4,"actor":"codex:issue-5666-slot-1","reason":"atomically record exact review evidence and reviewed phase","operation":"record_review"}
 {"sequence":7,"generation":5,"actor":"codex:issue-5666-slot-1","reason":"atomically record observed GitHub publication and SOR projection","operation":"record_publication"}
+{"sequence":8,"generation":6,"actor":"codex:issue-5666-slot-1","reason":"record exact existing PR ready-for-review after remote success","operation":"record_ready_publication"}

--- a/.csdlc/issues/5666/audit.jsonl
+++ b/.csdlc/issues/5666/audit.jsonl
@@ -4,3 +4,4 @@
 {"sequence":4,"generation":2,"actor":"codex:issue-5666-slot-1","reason":"atomically record execution, validation, and implemented phase","operation":"finalize_implementation"}
 {"sequence":5,"generation":3,"actor":"operator:5666","reason":"reapprove changed issue design","operation":"approve_design"}
 {"sequence":6,"generation":4,"actor":"codex:issue-5666-slot-1","reason":"atomically record exact review evidence and reviewed phase","operation":"record_review"}
+{"sequence":7,"generation":5,"actor":"codex:issue-5666-slot-1","reason":"atomically record observed GitHub publication and SOR projection","operation":"record_publication"}

--- a/.csdlc/issues/5666/audit.jsonl
+++ b/.csdlc/issues/5666/audit.jsonl
@@ -2,3 +2,4 @@
 {"sequence":2,"generation":1,"actor":"operator:5666","reason":"approve completed issue design","operation":"approve_design"}
 {"sequence":3,"generation":1,"actor":"codex:issue-5666-slot-1","reason":"bind branch/worktree and activate claim","operation":"bind"}
 {"sequence":4,"generation":2,"actor":"codex:issue-5666-slot-1","reason":"atomically record execution, validation, and implemented phase","operation":"finalize_implementation"}
+{"sequence":5,"generation":3,"actor":"operator:5666","reason":"reapprove changed issue design","operation":"approve_design"}

--- a/.csdlc/issues/5666/audit.jsonl
+++ b/.csdlc/issues/5666/audit.jsonl
@@ -3,3 +3,4 @@
 {"sequence":3,"generation":1,"actor":"codex:issue-5666-slot-1","reason":"bind branch/worktree and activate claim","operation":"bind"}
 {"sequence":4,"generation":2,"actor":"codex:issue-5666-slot-1","reason":"atomically record execution, validation, and implemented phase","operation":"finalize_implementation"}
 {"sequence":5,"generation":3,"actor":"operator:5666","reason":"reapprove changed issue design","operation":"approve_design"}
+{"sequence":6,"generation":4,"actor":"codex:issue-5666-slot-1","reason":"atomically record exact review evidence and reviewed phase","operation":"record_review"}

--- a/.csdlc/issues/5666/audit.jsonl
+++ b/.csdlc/issues/5666/audit.jsonl
@@ -1,0 +1,4 @@
+{"sequence":1,"generation":0,"actor":"codex:issue-5666-slot-1","reason":"initialize issue record and all six cards","operation":"bootstrap"}
+{"sequence":2,"generation":1,"actor":"operator:5666","reason":"approve completed issue design","operation":"approve_design"}
+{"sequence":3,"generation":1,"actor":"codex:issue-5666-slot-1","reason":"bind branch/worktree and activate claim","operation":"bind"}
+{"sequence":4,"generation":2,"actor":"codex:issue-5666-slot-1","reason":"atomically record execution, validation, and implemented phase","operation":"finalize_implementation"}

--- a/.csdlc/issues/5666/cards/sip.md
+++ b/.csdlc/issues/5666/cards/sip.md
@@ -1,0 +1,44 @@
+# Structured Intent Prompt
+
+Template: 1.0.0
+
+Issue: 5666
+
+Repository: danielbaustin/agent-design-language
+
+Card: sip
+
+Status: ready
+
+## Goal
+
+Reduce development latency by making validation, review, PR watching, and lifecycle effort proportional to issue risk.
+
+## Required Outcome
+
+A checked-in fast-lane policy and focused contract proof define how tiny tool/docs/test fixes move quickly without weakening typed C-SDLC v2 authority or exact-head truth.
+
+## Scope
+
+- developer throughput fast-lane policy
+- validation routing documentation link and policy reference to the validation selector
+- small focused shell contract test for policy invariants
+- issue-local C-SDLC v2 lifecycle records
+
+## Authority
+
+- typed C-SDLC v2 remains the lifecycle authority
+- fast lane changes validation selection and operator behavior, not product/runtime semantics
+- GitHub wait states must be changed-state/blocker reporting only
+
+## Assumptions
+
+- none
+
+## Operator Constraints
+
+- Use FastWork for worktree, temp, and Rust build output
+- Do not write on root main
+- No AWS execution
+- No raw GitHub CLI or connector fallback for issue lifecycle
+- Keep the implementation small

--- a/.csdlc/issues/5666/cards/sip.values.json
+++ b/.csdlc/issues/5666/cards/sip.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][tools][ci] Add proportional fast lane for small fixes",
     "slug": "v0-91-8-tools-ci-throughput-fast-lane",
     "version": "v0.91.8",
-    "generation": 4
+    "generation": 5
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5666/cards/sip.values.json
+++ b/.csdlc/issues/5666/cards/sip.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][tools][ci] Add proportional fast lane for small fixes",
     "slug": "v0-91-8-tools-ci-throughput-fast-lane",
     "version": "v0.91.8",
-    "generation": 2
+    "generation": 3
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5666/cards/sip.values.json
+++ b/.csdlc/issues/5666/cards/sip.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][tools][ci] Add proportional fast lane for small fixes",
     "slug": "v0-91-8-tools-ci-throughput-fast-lane",
     "version": "v0.91.8",
-    "generation": 5
+    "generation": 6
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5666/cards/sip.values.json
+++ b/.csdlc/issues/5666/cards/sip.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][tools][ci] Add proportional fast lane for small fixes",
     "slug": "v0-91-8-tools-ci-throughput-fast-lane",
     "version": "v0.91.8",
-    "generation": 3
+    "generation": 4
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5666/cards/sip.values.json
+++ b/.csdlc/issues/5666/cards/sip.values.json
@@ -1,0 +1,39 @@
+{
+  "identity": {
+    "schema_version": "1.0.0",
+    "template_version": "1.0.0",
+    "issue": 5666,
+    "repository": "danielbaustin/agent-design-language",
+    "title": "[v0.91.8][tools][ci] Add proportional fast lane for small fixes",
+    "slug": "v0-91-8-tools-ci-throughput-fast-lane",
+    "version": "v0.91.8",
+    "generation": 2
+  },
+  "status": "ready",
+  "content": {
+    "card_kind": "sip",
+    "values": {
+      "goal": "Reduce development latency by making validation, review, PR watching, and lifecycle effort proportional to issue risk.",
+      "required_outcome": "A checked-in fast-lane policy and focused contract proof define how tiny tool/docs/test fixes move quickly without weakening typed C-SDLC v2 authority or exact-head truth.",
+      "declared_scope": [
+        "developer throughput fast-lane policy",
+        "validation routing documentation link and policy reference to the validation selector",
+        "small focused shell contract test for policy invariants",
+        "issue-local C-SDLC v2 lifecycle records"
+      ],
+      "authority_boundary": [
+        "typed C-SDLC v2 remains the lifecycle authority",
+        "fast lane changes validation selection and operator behavior, not product/runtime semantics",
+        "GitHub wait states must be changed-state/blocker reporting only"
+      ],
+      "initial_assumptions": [],
+      "operator_constraints": [
+        "Use FastWork for worktree, temp, and Rust build output",
+        "Do not write on root main",
+        "No AWS execution",
+        "No raw GitHub CLI or connector fallback for issue lifecycle",
+        "Keep the implementation small"
+      ]
+    }
+  }
+}

--- a/.csdlc/issues/5666/cards/sor.md
+++ b/.csdlc/issues/5666/cards/sor.md
@@ -56,7 +56,7 @@ pr_open
 
 ## Publication
 
-Publication: draft
+Publication: ready
 
 Merge: not_merged
 

--- a/.csdlc/issues/5666/cards/sor.md
+++ b/.csdlc/issues/5666/cards/sor.md
@@ -1,0 +1,69 @@
+# Structured Output Record
+
+Template: 1.0.0
+
+Issue: 5666
+
+Repository: danielbaustin/agent-design-language
+
+Card: sor
+
+Status: pre_phase
+
+## Summary
+
+Implemented a proportional developer throughput fast-lane policy, linked it from validation platform routing, and added focused contract proof for the required invariants.
+
+## Artifacts
+
+- docs/tooling/DEVELOPER_THROUGHPUT_FAST_LANE.md
+- docs/tooling/VALIDATION_PLATFORM_ROUTING.md
+- adl/tools/test_developer_throughput_fast_lane.sh
+
+## Execution
+
+- Added docs/tooling/DEVELOPER_THROUGHPUT_FAST_LANE.md with proportional issue classes, FastWork-required behavior, changed-state-only PR watching, escalation rules, and non-claims.
+- Linked the fast-lane policy from docs/tooling/VALIDATION_PLATFORM_ROUTING.md.
+- Added adl/tools/test_developer_throughput_fast_lane.sh to prove required policy language and routing linkage.
+
+## Validation
+
+[
+  {
+    "command": [
+      "git",
+      "diff",
+      "--check"
+    ],
+    "purpose": "Verify changed files have no whitespace or patch hygiene errors.",
+    "outcome": "passed",
+    "evidence_ref": "diff-hygiene.log"
+  },
+  {
+    "command": [
+      "bash",
+      "adl/tools/test_developer_throughput_fast_lane.sh"
+    ],
+    "purpose": "Prove the throughput fast-lane policy, selector reference, no-local-fallback rule, changed-state watching rule, and routing link exist.",
+    "outcome": "passed",
+    "evidence_ref": "throughput-fast-lane-contract.log"
+  }
+]
+
+## Integration
+
+not_started
+
+## Publication
+
+Publication: not_published
+
+Merge: not_merged
+
+## Closeout
+
+not_started
+
+## Follow Ups
+
+- none

--- a/.csdlc/issues/5666/cards/sor.md
+++ b/.csdlc/issues/5666/cards/sor.md
@@ -52,11 +52,11 @@ Implemented a proportional developer throughput fast-lane policy, linked it from
 
 ## Integration
 
-not_started
+pr_open
 
 ## Publication
 
-Publication: not_published
+Publication: draft
 
 Merge: not_merged
 

--- a/.csdlc/issues/5666/cards/sor.values.json
+++ b/.csdlc/issues/5666/cards/sor.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][tools][ci] Add proportional fast lane for small fixes",
     "slug": "v0-91-8-tools-ci-throughput-fast-lane",
     "version": "v0.91.8",
-    "generation": 2
+    "generation": 3
   },
   "status": "pre_phase",
   "content": {

--- a/.csdlc/issues/5666/cards/sor.values.json
+++ b/.csdlc/issues/5666/cards/sor.values.json
@@ -1,0 +1,55 @@
+{
+  "identity": {
+    "schema_version": "1.0.0",
+    "template_version": "1.0.0",
+    "issue": 5666,
+    "repository": "danielbaustin/agent-design-language",
+    "title": "[v0.91.8][tools][ci] Add proportional fast lane for small fixes",
+    "slug": "v0-91-8-tools-ci-throughput-fast-lane",
+    "version": "v0.91.8",
+    "generation": 2
+  },
+  "status": "pre_phase",
+  "content": {
+    "card_kind": "sor",
+    "values": {
+      "summary": "Implemented a proportional developer throughput fast-lane policy, linked it from validation platform routing, and added focused contract proof for the required invariants.",
+      "actual_changes": [
+        "Added docs/tooling/DEVELOPER_THROUGHPUT_FAST_LANE.md with proportional issue classes, FastWork-required behavior, changed-state-only PR watching, escalation rules, and non-claims.",
+        "Linked the fast-lane policy from docs/tooling/VALIDATION_PLATFORM_ROUTING.md.",
+        "Added adl/tools/test_developer_throughput_fast_lane.sh to prove required policy language and routing linkage."
+      ],
+      "artifacts": [
+        "docs/tooling/DEVELOPER_THROUGHPUT_FAST_LANE.md",
+        "docs/tooling/VALIDATION_PLATFORM_ROUTING.md",
+        "adl/tools/test_developer_throughput_fast_lane.sh"
+      ],
+      "actual_validation": [
+        {
+          "command": [
+            "git",
+            "diff",
+            "--check"
+          ],
+          "purpose": "Verify changed files have no whitespace or patch hygiene errors.",
+          "outcome": "passed",
+          "evidence_ref": "diff-hygiene.log"
+        },
+        {
+          "command": [
+            "bash",
+            "adl/tools/test_developer_throughput_fast_lane.sh"
+          ],
+          "purpose": "Prove the throughput fast-lane policy, selector reference, no-local-fallback rule, changed-state watching rule, and routing link exist.",
+          "outcome": "passed",
+          "evidence_ref": "throughput-fast-lane-contract.log"
+        }
+      ],
+      "integration_state": "not_started",
+      "publication_state": "not_published",
+      "merge_state": "not_merged",
+      "closeout_state": "not_started",
+      "follow_ups": []
+    }
+  }
+}

--- a/.csdlc/issues/5666/cards/sor.values.json
+++ b/.csdlc/issues/5666/cards/sor.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][tools][ci] Add proportional fast lane for small fixes",
     "slug": "v0-91-8-tools-ci-throughput-fast-lane",
     "version": "v0.91.8",
-    "generation": 4
+    "generation": 5
   },
   "status": "pre_phase",
   "content": {
@@ -45,8 +45,8 @@
           "evidence_ref": "throughput-fast-lane-contract.log"
         }
       ],
-      "integration_state": "not_started",
-      "publication_state": "not_published",
+      "integration_state": "pr_open",
+      "publication_state": "draft",
       "merge_state": "not_merged",
       "closeout_state": "not_started",
       "follow_ups": []

--- a/.csdlc/issues/5666/cards/sor.values.json
+++ b/.csdlc/issues/5666/cards/sor.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][tools][ci] Add proportional fast lane for small fixes",
     "slug": "v0-91-8-tools-ci-throughput-fast-lane",
     "version": "v0.91.8",
-    "generation": 3
+    "generation": 4
   },
   "status": "pre_phase",
   "content": {

--- a/.csdlc/issues/5666/cards/sor.values.json
+++ b/.csdlc/issues/5666/cards/sor.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][tools][ci] Add proportional fast lane for small fixes",
     "slug": "v0-91-8-tools-ci-throughput-fast-lane",
     "version": "v0.91.8",
-    "generation": 5
+    "generation": 6
   },
   "status": "pre_phase",
   "content": {
@@ -46,7 +46,7 @@
         }
       ],
       "integration_state": "pr_open",
-      "publication_state": "draft",
+      "publication_state": "ready",
       "merge_state": "not_merged",
       "closeout_state": "not_started",
       "follow_ups": []

--- a/.csdlc/issues/5666/cards/spp.md
+++ b/.csdlc/issues/5666/cards/spp.md
@@ -1,0 +1,99 @@
+# Structured Planning Prompt
+
+Template: 1.0.0
+
+Issue: 5666
+
+Repository: danielbaustin/agent-design-language
+
+Card: spp
+
+Status: ready
+
+## Summary
+
+Add a small policy plus contract test that turns the operator's ten speed improvements into enforceable ADL guidance for small fixes.
+
+## Plan
+
+Revision 1
+
+## Steps
+
+[
+  {
+    "id": "S1",
+    "action": "Write the proportional fast-lane policy",
+    "acceptance_ids": [
+      "AC-1",
+      "AC-3",
+      "AC-4"
+    ],
+    "status": "pending"
+  },
+  {
+    "id": "S2",
+    "action": "Link routing docs, reference the selector policy, and add focused contract test",
+    "acceptance_ids": [
+      "AC-2",
+      "AC-5"
+    ],
+    "status": "pending"
+  },
+  {
+    "id": "S3",
+    "action": "Validate, review, publish, and close out",
+    "acceptance_ids": [
+      "AC-1",
+      "AC-2",
+      "AC-3",
+      "AC-4",
+      "AC-5"
+    ],
+    "status": "pending"
+  }
+]
+
+## Invariants
+
+- small fixes do not bypass typed lifecycle
+- focused proof must be selected and truthful
+- runtime/product changes remain full proof
+- no waiting on unchanged GitHub states
+
+## Risks
+
+- fast lane could be mistaken for weaker proof
+- policy-only work might not change behavior unless linked to contract tests
+- local disk fallback could reappear if not explicitly forbidden
+
+## Estimates
+
+{
+  "elapsed_seconds": 7200,
+  "total_tokens": 40000,
+  "validation_seconds": 1200
+}
+
+## Design
+
+.csdlc/prepared/issues/5666/design.md
+
+Digest: 17e9330bc8371335f7a79046ba2b93a9832c9bef55da76e3e1844f62d7610e3a
+
+## Diagram
+
+.csdlc/prepared/issues/5666/diagram.mmd
+
+Digest: 436c059b2c761ddbf14fbd15316810433a64125802cd93ae85f734f58e3d592a
+
+## Stop Conditions
+
+- FastWork is unavailable
+- scope expands into CI workflow rewrite or runtime/product code
+- typed lifecycle state cannot be initialized or validated
+- review finds unresolved actionables
+
+## Handoff
+
+Proceed only after doctor readiness.

--- a/.csdlc/issues/5666/cards/spp.md
+++ b/.csdlc/issues/5666/cards/spp.md
@@ -79,13 +79,13 @@ Revision 1
 
 .csdlc/prepared/issues/5666/design.md
 
-Digest: 17e9330bc8371335f7a79046ba2b93a9832c9bef55da76e3e1844f62d7610e3a
+Digest: 8e91e0e05de23a42793864d2157b414bb57513677bdde465f6d3cb85a375a9c4
 
 ## Diagram
 
 .csdlc/prepared/issues/5666/diagram.mmd
 
-Digest: 436c059b2c761ddbf14fbd15316810433a64125802cd93ae85f734f58e3d592a
+Digest: 452333c61b11f5e59c24daf708d4637f640cd7f5e8204ffa1d4e2d1447fefc4e
 
 ## Stop Conditions
 

--- a/.csdlc/issues/5666/cards/spp.values.json
+++ b/.csdlc/issues/5666/cards/spp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][tools][ci] Add proportional fast lane for small fixes",
     "slug": "v0-91-8-tools-ci-throughput-fast-lane",
     "version": "v0.91.8",
-    "generation": 4
+    "generation": 5
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5666/cards/spp.values.json
+++ b/.csdlc/issues/5666/cards/spp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][tools][ci] Add proportional fast lane for small fixes",
     "slug": "v0-91-8-tools-ci-throughput-fast-lane",
     "version": "v0.91.8",
-    "generation": 2
+    "generation": 3
   },
   "status": "ready",
   "content": {
@@ -73,9 +73,9 @@
       ],
       "replan_triggers": [],
       "design_ref": ".csdlc/prepared/issues/5666/design.md",
-      "design_digest": "17e9330bc8371335f7a79046ba2b93a9832c9bef55da76e3e1844f62d7610e3a",
+      "design_digest": "8e91e0e05de23a42793864d2157b414bb57513677bdde465f6d3cb85a375a9c4",
       "diagram_ref": ".csdlc/prepared/issues/5666/diagram.mmd",
-      "diagram_digest": "436c059b2c761ddbf14fbd15316810433a64125802cd93ae85f734f58e3d592a"
+      "diagram_digest": "452333c61b11f5e59c24daf708d4637f640cd7f5e8204ffa1d4e2d1447fefc4e"
     }
   }
 }

--- a/.csdlc/issues/5666/cards/spp.values.json
+++ b/.csdlc/issues/5666/cards/spp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][tools][ci] Add proportional fast lane for small fixes",
     "slug": "v0-91-8-tools-ci-throughput-fast-lane",
     "version": "v0.91.8",
-    "generation": 5
+    "generation": 6
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5666/cards/spp.values.json
+++ b/.csdlc/issues/5666/cards/spp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][tools][ci] Add proportional fast lane for small fixes",
     "slug": "v0-91-8-tools-ci-throughput-fast-lane",
     "version": "v0.91.8",
-    "generation": 3
+    "generation": 4
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5666/cards/spp.values.json
+++ b/.csdlc/issues/5666/cards/spp.values.json
@@ -1,0 +1,81 @@
+{
+  "identity": {
+    "schema_version": "1.0.0",
+    "template_version": "1.0.0",
+    "issue": 5666,
+    "repository": "danielbaustin/agent-design-language",
+    "title": "[v0.91.8][tools][ci] Add proportional fast lane for small fixes",
+    "slug": "v0-91-8-tools-ci-throughput-fast-lane",
+    "version": "v0.91.8",
+    "generation": 2
+  },
+  "status": "ready",
+  "content": {
+    "card_kind": "spp",
+    "values": {
+      "plan_revision": 1,
+      "summary": "Add a small policy plus contract test that turns the operator's ten speed improvements into enforceable ADL guidance for small fixes.",
+      "steps": [
+        {
+          "id": "S1",
+          "action": "Write the proportional fast-lane policy",
+          "acceptance_ids": [
+            "AC-1",
+            "AC-3",
+            "AC-4"
+          ],
+          "status": "pending"
+        },
+        {
+          "id": "S2",
+          "action": "Link routing docs, reference the selector policy, and add focused contract test",
+          "acceptance_ids": [
+            "AC-2",
+            "AC-5"
+          ],
+          "status": "pending"
+        },
+        {
+          "id": "S3",
+          "action": "Validate, review, publish, and close out",
+          "acceptance_ids": [
+            "AC-1",
+            "AC-2",
+            "AC-3",
+            "AC-4",
+            "AC-5"
+          ],
+          "status": "pending"
+        }
+      ],
+      "affected_areas": [],
+      "invariants": [
+        "small fixes do not bypass typed lifecycle",
+        "focused proof must be selected and truthful",
+        "runtime/product changes remain full proof",
+        "no waiting on unchanged GitHub states"
+      ],
+      "risks": [
+        "fast lane could be mistaken for weaker proof",
+        "policy-only work might not change behavior unless linked to contract tests",
+        "local disk fallback could reappear if not explicitly forbidden"
+      ],
+      "execution_estimates": {
+        "elapsed_seconds": 7200,
+        "total_tokens": 40000,
+        "validation_seconds": 1200
+      },
+      "stop_conditions": [
+        "FastWork is unavailable",
+        "scope expands into CI workflow rewrite or runtime/product code",
+        "typed lifecycle state cannot be initialized or validated",
+        "review finds unresolved actionables"
+      ],
+      "replan_triggers": [],
+      "design_ref": ".csdlc/prepared/issues/5666/design.md",
+      "design_digest": "17e9330bc8371335f7a79046ba2b93a9832c9bef55da76e3e1844f62d7610e3a",
+      "diagram_ref": ".csdlc/prepared/issues/5666/diagram.mmd",
+      "diagram_digest": "436c059b2c761ddbf14fbd15316810433a64125802cd93ae85f734f58e3d592a"
+    }
+  }
+}

--- a/.csdlc/issues/5666/cards/srp.md
+++ b/.csdlc/issues/5666/cards/srp.md
@@ -1,0 +1,43 @@
+# Structured Review Prompt
+
+Template: 1.0.0
+
+Issue: 5666
+
+Repository: danielbaustin/agent-design-language
+
+Card: srp
+
+Status: pre_phase
+
+## Scope
+
+Review the fast-lane policy doc, routing link, selector reference, focused contract test, and issue-local lifecycle truth.
+
+## Prompts
+
+- Does the policy make lifecycle and validation proportional without weakening typed C-SDLC v2?
+- Does it clearly separate tiny fixes from runtime/product work?
+- Does it prevent local-disk fallback when FastWork is required?
+- Does it stop unchanged GitHub waiting and require blocker-only updates?
+- Is the implementation intentionally small?
+
+## Findings
+
+[]
+
+## Dispositions
+
+Every actionable finding requires a terminal disposition.
+
+## Residual Risk
+
+- none
+
+## Review Result
+
+Revision: None
+
+Reviewer: None
+
+Result: pre_review

--- a/.csdlc/issues/5666/cards/srp.md
+++ b/.csdlc/issues/5666/cards/srp.md
@@ -12,7 +12,12 @@ Status: pre_phase
 
 ## Scope
 
-Review the fast-lane policy doc, routing link, selector reference, focused contract test, and issue-local lifecycle truth.
+.csdlc/evidence/5666
+.csdlc/issues/5666
+.csdlc/prepared/issues/5666
+adl/tools/test_developer_throughput_fast_lane.sh
+docs/tooling/DEVELOPER_THROUGHPUT_FAST_LANE.md
+docs/tooling/VALIDATION_PLATFORM_ROUTING.md
 
 ## Prompts
 
@@ -32,12 +37,12 @@ Every actionable finding requires a terminal disposition.
 
 ## Residual Risk
 
-- none
+- Review confirmed the initial placeholder design finding was fixed before this exact scoped revision; remaining lock file is untracked and outside HEAD.
 
 ## Review Result
 
-Revision: None
+Revision: Some("git-blake3:30e495fda450d10a4e29b0c57195f759224a7214:bf3cbab163693daa1084c8119b458a550c59032eea66798f753f22166e22d3e6")
 
-Reviewer: None
+Reviewer: Some("subagent:sagan")
 
-Result: pre_review
+Result: pass

--- a/.csdlc/issues/5666/cards/srp.values.json
+++ b/.csdlc/issues/5666/cards/srp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][tools][ci] Add proportional fast lane for small fixes",
     "slug": "v0-91-8-tools-ci-throughput-fast-lane",
     "version": "v0.91.8",
-    "generation": 4
+    "generation": 5
   },
   "status": "pre_phase",
   "content": {

--- a/.csdlc/issues/5666/cards/srp.values.json
+++ b/.csdlc/issues/5666/cards/srp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][tools][ci] Add proportional fast lane for small fixes",
     "slug": "v0-91-8-tools-ci-throughput-fast-lane",
     "version": "v0.91.8",
-    "generation": 2
+    "generation": 3
   },
   "status": "pre_phase",
   "content": {

--- a/.csdlc/issues/5666/cards/srp.values.json
+++ b/.csdlc/issues/5666/cards/srp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][tools][ci] Add proportional fast lane for small fixes",
     "slug": "v0-91-8-tools-ci-throughput-fast-lane",
     "version": "v0.91.8",
-    "generation": 5
+    "generation": 6
   },
   "status": "pre_phase",
   "content": {

--- a/.csdlc/issues/5666/cards/srp.values.json
+++ b/.csdlc/issues/5666/cards/srp.values.json
@@ -1,0 +1,31 @@
+{
+  "identity": {
+    "schema_version": "1.0.0",
+    "template_version": "1.0.0",
+    "issue": 5666,
+    "repository": "danielbaustin/agent-design-language",
+    "title": "[v0.91.8][tools][ci] Add proportional fast lane for small fixes",
+    "slug": "v0-91-8-tools-ci-throughput-fast-lane",
+    "version": "v0.91.8",
+    "generation": 2
+  },
+  "status": "pre_phase",
+  "content": {
+    "card_kind": "srp",
+    "values": {
+      "review_scope": "Review the fast-lane policy doc, routing link, selector reference, focused contract test, and issue-local lifecycle truth.",
+      "review_revision": null,
+      "reviewer": null,
+      "review_prompts": [
+        "Does the policy make lifecycle and validation proportional without weakening typed C-SDLC v2?",
+        "Does it clearly separate tiny fixes from runtime/product work?",
+        "Does it prevent local-disk fallback when FastWork is required?",
+        "Does it stop unchanged GitHub waiting and require blocker-only updates?",
+        "Is the implementation intentionally small?"
+      ],
+      "findings": [],
+      "residual_risk": [],
+      "review_result": "pre_review"
+    }
+  }
+}

--- a/.csdlc/issues/5666/cards/srp.values.json
+++ b/.csdlc/issues/5666/cards/srp.values.json
@@ -7,15 +7,15 @@
     "title": "[v0.91.8][tools][ci] Add proportional fast lane for small fixes",
     "slug": "v0-91-8-tools-ci-throughput-fast-lane",
     "version": "v0.91.8",
-    "generation": 3
+    "generation": 4
   },
   "status": "pre_phase",
   "content": {
     "card_kind": "srp",
     "values": {
-      "review_scope": "Review the fast-lane policy doc, routing link, selector reference, focused contract test, and issue-local lifecycle truth.",
-      "review_revision": null,
-      "reviewer": null,
+      "review_scope": ".csdlc/evidence/5666\n.csdlc/issues/5666\n.csdlc/prepared/issues/5666\nadl/tools/test_developer_throughput_fast_lane.sh\ndocs/tooling/DEVELOPER_THROUGHPUT_FAST_LANE.md\ndocs/tooling/VALIDATION_PLATFORM_ROUTING.md",
+      "review_revision": "git-blake3:30e495fda450d10a4e29b0c57195f759224a7214:bf3cbab163693daa1084c8119b458a550c59032eea66798f753f22166e22d3e6",
+      "reviewer": "subagent:sagan",
       "review_prompts": [
         "Does the policy make lifecycle and validation proportional without weakening typed C-SDLC v2?",
         "Does it clearly separate tiny fixes from runtime/product work?",
@@ -24,8 +24,10 @@
         "Is the implementation intentionally small?"
       ],
       "findings": [],
-      "residual_risk": [],
-      "review_result": "pre_review"
+      "residual_risk": [
+        "Review confirmed the initial placeholder design finding was fixed before this exact scoped revision; remaining lock file is untracked and outside HEAD."
+      ],
+      "review_result": "pass"
     }
   }
 }

--- a/.csdlc/issues/5666/cards/stp.md
+++ b/.csdlc/issues/5666/cards/stp.md
@@ -1,0 +1,49 @@
+# Structured Task Prompt
+
+Template: 1.0.0
+
+Issue: 5666
+
+Repository: danielbaustin/agent-design-language
+
+Card: stp
+
+Status: ready
+
+## Task
+
+Implement, validate, review, publish, merge, and close the bounded throughput fast-lane policy issue.
+
+## Deliverables
+
+- docs/tooling/DEVELOPER_THROUGHPUT_FAST_LANE.md
+- link from validation routing docs and selector reference in the policy
+- adl/tools/test_developer_throughput_fast_lane.sh
+
+## Acceptance
+
+1. AC-1: The policy names proportional issue classes, eligibility, escalation, stop conditions, and non-claims.
+2. AC-2: Validation routing docs link the policy, and the policy references the validation selector without editing paths claimed by another issue.
+3. AC-3: The policy requires FastWork or another declared external build root when the operator requires it, and forbids silent local-disk fallback.
+4. AC-4: PR watching guidance is changed-state/blocker-only and says not to wait on GitHub when no action is possible.
+5. AC-5: A focused contract test proves the required policy language and links exist.
+
+## Dependencies
+
+- GitHub issue #5666
+- existing validation lane selector
+- existing validation platform routing docs
+
+## Inputs
+
+- docs/architecture/VALIDATION_LANE_SELECTOR.md
+- docs/tooling/VALIDATION_PLATFORM_ROUTING.md
+- docs/milestones/v0.91.7/review/V0917_WP06_BUILD_THROUGHPUT_VALIDATION_COST_REDUCTION_4633.md
+
+## Non Goals
+
+- Runtime or product feature changes
+- AWS execution
+- broad CI workflow rewrite
+- replacement of typed C-SDLC v2
+- large test-classification migration

--- a/.csdlc/issues/5666/cards/stp.values.json
+++ b/.csdlc/issues/5666/cards/stp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][tools][ci] Add proportional fast lane for small fixes",
     "slug": "v0-91-8-tools-ci-throughput-fast-lane",
     "version": "v0.91.8",
-    "generation": 4
+    "generation": 5
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5666/cards/stp.values.json
+++ b/.csdlc/issues/5666/cards/stp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][tools][ci] Add proportional fast lane for small fixes",
     "slug": "v0-91-8-tools-ci-throughput-fast-lane",
     "version": "v0.91.8",
-    "generation": 2
+    "generation": 3
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5666/cards/stp.values.json
+++ b/.csdlc/issues/5666/cards/stp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][tools][ci] Add proportional fast lane for small fixes",
     "slug": "v0-91-8-tools-ci-throughput-fast-lane",
     "version": "v0.91.8",
-    "generation": 5
+    "generation": 6
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5666/cards/stp.values.json
+++ b/.csdlc/issues/5666/cards/stp.values.json
@@ -1,0 +1,48 @@
+{
+  "identity": {
+    "schema_version": "1.0.0",
+    "template_version": "1.0.0",
+    "issue": 5666,
+    "repository": "danielbaustin/agent-design-language",
+    "title": "[v0.91.8][tools][ci] Add proportional fast lane for small fixes",
+    "slug": "v0-91-8-tools-ci-throughput-fast-lane",
+    "version": "v0.91.8",
+    "generation": 2
+  },
+  "status": "ready",
+  "content": {
+    "card_kind": "stp",
+    "values": {
+      "task_boundary": "Implement, validate, review, publish, merge, and close the bounded throughput fast-lane policy issue.",
+      "deliverables": [
+        "docs/tooling/DEVELOPER_THROUGHPUT_FAST_LANE.md",
+        "link from validation routing docs and selector reference in the policy",
+        "adl/tools/test_developer_throughput_fast_lane.sh"
+      ],
+      "acceptance_criteria": [
+        "AC-1: The policy names proportional issue classes, eligibility, escalation, stop conditions, and non-claims.",
+        "AC-2: Validation routing docs link the policy, and the policy references the validation selector without editing paths claimed by another issue.",
+        "AC-3: The policy requires FastWork or another declared external build root when the operator requires it, and forbids silent local-disk fallback.",
+        "AC-4: PR watching guidance is changed-state/blocker-only and says not to wait on GitHub when no action is possible.",
+        "AC-5: A focused contract test proves the required policy language and links exist."
+      ],
+      "dependencies": [
+        "GitHub issue #5666",
+        "existing validation lane selector",
+        "existing validation platform routing docs"
+      ],
+      "repo_inputs": [
+        "docs/architecture/VALIDATION_LANE_SELECTOR.md",
+        "docs/tooling/VALIDATION_PLATFORM_ROUTING.md",
+        "docs/milestones/v0.91.7/review/V0917_WP06_BUILD_THROUGHPUT_VALIDATION_COST_REDUCTION_4633.md"
+      ],
+      "non_goals": [
+        "Runtime or product feature changes",
+        "AWS execution",
+        "broad CI workflow rewrite",
+        "replacement of typed C-SDLC v2",
+        "large test-classification migration"
+      ]
+    }
+  }
+}

--- a/.csdlc/issues/5666/cards/stp.values.json
+++ b/.csdlc/issues/5666/cards/stp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][tools][ci] Add proportional fast lane for small fixes",
     "slug": "v0-91-8-tools-ci-throughput-fast-lane",
     "version": "v0.91.8",
-    "generation": 3
+    "generation": 4
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5666/cards/vpp.md
+++ b/.csdlc/issues/5666/cards/vpp.md
@@ -1,0 +1,69 @@
+# Validation Planning Prompt
+
+Template: 1.0.0
+
+Issue: 5666
+
+Repository: danielbaustin/agent-design-language
+
+Card: vpp
+
+Status: ready
+
+## Summary
+
+Execute the smallest proving validation DAG.
+
+## Lane Inputs
+
+Design: .csdlc/prepared/issues/5666/design.md
+
+Diagram: .csdlc/prepared/issues/5666/diagram.mmd
+
+## Selected Lanes
+
+[
+  {
+    "lane": "throughput-fast-lane-contract",
+    "proof_role": "Run focused shell contract test and diff hygiene for policy links and required invariants.",
+    "acceptance_ids": [
+      "AC-1",
+      "AC-2",
+      "AC-3",
+      "AC-4",
+      "AC-5"
+    ],
+    "deterministic": true,
+    "resource_profile": "small",
+    "budget_seconds": 30,
+    "budget_tokens": 500,
+    "argv": [
+      "bash",
+      "adl/tools/test_developer_throughput_fast_lane.sh"
+    ],
+    "parallel_group": "docs-policy",
+    "defer_reason": null
+  }
+]
+
+## Parallelization
+
+Only declared parallel groups may overlap.
+
+## Budgets
+
+Seconds: 1200
+
+Tokens: 10000
+
+## Commands
+
+- `bash adl/tools/test_developer_throughput_fast_lane.sh`
+
+## Failure Semantics
+
+Fail closed on missing policy, broken links, absent FastWork/no-local-fallback language, broad CI/runtime scope, or unresolved review findings.
+
+## Handoff
+
+Retain typed evidence before convergence.

--- a/.csdlc/issues/5666/cards/vpp.values.json
+++ b/.csdlc/issues/5666/cards/vpp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][tools][ci] Add proportional fast lane for small fixes",
     "slug": "v0-91-8-tools-ci-throughput-fast-lane",
     "version": "v0.91.8",
-    "generation": 4
+    "generation": 5
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5666/cards/vpp.values.json
+++ b/.csdlc/issues/5666/cards/vpp.values.json
@@ -1,0 +1,49 @@
+{
+  "identity": {
+    "schema_version": "1.0.0",
+    "template_version": "1.0.0",
+    "issue": 5666,
+    "repository": "danielbaustin/agent-design-language",
+    "title": "[v0.91.8][tools][ci] Add proportional fast lane for small fixes",
+    "slug": "v0-91-8-tools-ci-throughput-fast-lane",
+    "version": "v0.91.8",
+    "generation": 2
+  },
+  "status": "ready",
+  "content": {
+    "card_kind": "vpp",
+    "values": {
+      "summary": "Execute the smallest proving validation DAG.",
+      "lanes": [
+        {
+          "lane": "throughput-fast-lane-contract",
+          "proof_role": "Run focused shell contract test and diff hygiene for policy links and required invariants.",
+          "acceptance_ids": [
+            "AC-1",
+            "AC-2",
+            "AC-3",
+            "AC-4",
+            "AC-5"
+          ],
+          "deterministic": true,
+          "resource_profile": "small",
+          "budget_seconds": 30,
+          "budget_tokens": 500,
+          "argv": [
+            "bash",
+            "adl/tools/test_developer_throughput_fast_lane.sh"
+          ],
+          "parallel_group": "docs-policy",
+          "defer_reason": null
+        }
+      ],
+      "planned_validation_seconds": 1200,
+      "planned_validation_tokens": 10000,
+      "failure_policy": "Fail closed on missing policy, broken links, absent FastWork/no-local-fallback language, broad CI/runtime scope, or unresolved review findings.",
+      "design_ref": ".csdlc/prepared/issues/5666/design.md",
+      "design_digest": "17e9330bc8371335f7a79046ba2b93a9832c9bef55da76e3e1844f62d7610e3a",
+      "diagram_ref": ".csdlc/prepared/issues/5666/diagram.mmd",
+      "diagram_digest": "436c059b2c761ddbf14fbd15316810433a64125802cd93ae85f734f58e3d592a"
+    }
+  }
+}

--- a/.csdlc/issues/5666/cards/vpp.values.json
+++ b/.csdlc/issues/5666/cards/vpp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][tools][ci] Add proportional fast lane for small fixes",
     "slug": "v0-91-8-tools-ci-throughput-fast-lane",
     "version": "v0.91.8",
-    "generation": 5
+    "generation": 6
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5666/cards/vpp.values.json
+++ b/.csdlc/issues/5666/cards/vpp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][tools][ci] Add proportional fast lane for small fixes",
     "slug": "v0-91-8-tools-ci-throughput-fast-lane",
     "version": "v0.91.8",
-    "generation": 3
+    "generation": 4
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5666/cards/vpp.values.json
+++ b/.csdlc/issues/5666/cards/vpp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][tools][ci] Add proportional fast lane for small fixes",
     "slug": "v0-91-8-tools-ci-throughput-fast-lane",
     "version": "v0.91.8",
-    "generation": 2
+    "generation": 3
   },
   "status": "ready",
   "content": {
@@ -41,9 +41,9 @@
       "planned_validation_tokens": 10000,
       "failure_policy": "Fail closed on missing policy, broken links, absent FastWork/no-local-fallback language, broad CI/runtime scope, or unresolved review findings.",
       "design_ref": ".csdlc/prepared/issues/5666/design.md",
-      "design_digest": "17e9330bc8371335f7a79046ba2b93a9832c9bef55da76e3e1844f62d7610e3a",
+      "design_digest": "8e91e0e05de23a42793864d2157b414bb57513677bdde465f6d3cb85a375a9c4",
       "diagram_ref": ".csdlc/prepared/issues/5666/diagram.mmd",
-      "diagram_digest": "436c059b2c761ddbf14fbd15316810433a64125802cd93ae85f734f58e3d592a"
+      "diagram_digest": "452333c61b11f5e59c24daf708d4637f640cd7f5e8204ffa1d4e2d1447fefc4e"
     }
   }
 }

--- a/.csdlc/issues/5666/index.json
+++ b/.csdlc/issues/5666/index.json
@@ -4,12 +4,12 @@
   "repository": "danielbaustin/agent-design-language",
   "initialization_digest": "8a868f7f1c699671b7c60dd6bcfe05caaacf4325c016d16985f480282293ebac",
   "phase": "published",
-  "generation": 5,
-  "digest": "8f0c172b2370de74b29290e99a265f72cd6a66fae432bb4f43e2d404fb9cbe16",
+  "generation": 6,
+  "digest": "59e792a5a95670a68207b37ce8f9f4f6b0170a6eb93abd85b2ff29167ddd653e",
   "claim": {
     "id": "claim-5666-throughput-fast-lane",
     "owner": "codex:issue-5666-slot-1",
-    "generation": 5,
+    "generation": 6,
     "acquired_unix_seconds": 1785024000,
     "expires_unix_seconds": 1785628800,
     "heartbeat_unix_seconds": 1785024000,
@@ -52,8 +52,8 @@
     "url": "https://github.com/danielbaustin/agent-design-language/pull/5668",
     "base": "main",
     "head": "codex/5666-throughput-fast-lane",
-    "revision": "git-blake3:977cdfcc2236cd87b40e6feaac38359d5629d208:3695fa5b85299175494d75012a680a4842fef2658b9f789fc7879c1e0dbe4612",
-    "draft": true,
+    "revision": "git-blake3:d5e1e48a5207481d4bd1b4a35b4c8e0d44281452:c03d4af05f94b148ba36e76abc1e31138572d8b883152bb9b728d2d24984dc16",
+    "draft": false,
     "observed_state": "open"
   },
   "readiness": null,
@@ -69,34 +69,34 @@
   },
   "cards": {
     "sip": {
-      "values_digest": "2527b43a15738b5e78b297c43d54f13e0abbc4bcd74050155d7069ac64a555a3",
+      "values_digest": "a45a05299c1e2ab970b93c35d314c2a143dbad6a41a6222685729283d4e75303",
       "rendered_digest": "2d53e4b1a319307fcce4afc1632f5afadeec20050c235d3e6da8a71ad40d896e",
       "ast_digest": "85f6117b94d62a7fd03bad16aa1c0c84fdcec16850e17fbdaa6f84481da00b76"
     },
     "stp": {
-      "values_digest": "d5794b3b1ef7b9fe8c46cc268c91f342b3342b93c56a4c8e62887ae9a4b8ed5e",
+      "values_digest": "55a883231c015f3c0e833bbd061e6eef0277b379bb8e6a771c1ae2a1d4ccb27f",
       "rendered_digest": "a4c0abe508c7bb29e28f63b0c2fdc92486301073de7e33060318a772bbfd9f92",
       "ast_digest": "02700ec02f2df43fc142b1e043e4e26227582ed0dc542d2b8637b5ac30078348"
     },
     "spp": {
-      "values_digest": "c59fce63967702904c5fee9942deec4877273a8e53cc202e1c7e05bcf60209db",
+      "values_digest": "b7bc502c5aa81c007bc523198b112abcf2b87218da4b5105e05c93c3d33d33f7",
       "rendered_digest": "cd4648f2df73491bc7b633be48d68db3c4ddbd010cea03fb5eb165f9eb56fbd6",
       "ast_digest": "622f57b394e1c0aaddf781eb1b01b4cd68f00d508f58d163a73b0ed440c60449"
     },
     "vpp": {
-      "values_digest": "1efa1e3cd167bba6b40c7a0fbca14d2263faa895ae51f90519b0500431f417db",
+      "values_digest": "e5a1eb15c4ea77ca90de2fd1b98d58d8d251c5901d228f886b5af21afe563da8",
       "rendered_digest": "969cb2176f0a1f54315d31479c4d7c14fbada32e603264652f1106a88fc5103e",
       "ast_digest": "72ac249f6b8d31d5714634abb4777ad71fbbbd222c476b5abbf7ced5b29acc09"
     },
     "srp": {
-      "values_digest": "3b02b2c67f24a05d757f3bee5885437e9512c4981b20253b68cb8046e6ad415b",
+      "values_digest": "c0b080e5ce8d4242d508e2386108be055e1c932682c22eacef31992bb05fc063",
       "rendered_digest": "df7b07152a8de8fec15e52f4168cb93d6c641f0e3d2a6150ff1f4ed150659d90",
       "ast_digest": "90cb3f6e0b5863227f3f41a5a5dac0afe778aa8a1acb94aae5771ace2951842a"
     },
     "sor": {
-      "values_digest": "d7b52dfd10f70eb7a37a7ec569278b662df632ec5995978149c00e6ad42d3a9b",
-      "rendered_digest": "1263eb5e4333d8efbcd72b9bf93c7bd664821b565a976e51ce5fd6e4c2ff07a9",
-      "ast_digest": "5c668cb8bac8a56cdab0e706b03d9869f5dfc03ba2a1f024e28b0c3ea182b86a"
+      "values_digest": "9cb8475b5ad82f145508b8d836e2fec2c468daf606f5052c3a37d3788b82c641",
+      "rendered_digest": "94a199105206278bb69f74d5272026b72a9eabf7274892e1a5baca5a65a85612",
+      "ast_digest": "d38c2f2308fc8a8c624e34f07eef9789f9879f9f5571fc3e3dcf3b8ee072c02d"
     }
   },
   "transitions": [
@@ -185,6 +185,13 @@
       "actor": "codex:issue-5666-slot-1",
       "reason": "atomically record observed GitHub publication and SOR projection",
       "operation": "record_publication"
+    },
+    {
+      "sequence": 8,
+      "generation": 6,
+      "actor": "codex:issue-5666-slot-1",
+      "reason": "record exact existing PR ready-for-review after remote success",
+      "operation": "record_ready_publication"
     }
   ]
 }

--- a/.csdlc/issues/5666/index.json
+++ b/.csdlc/issues/5666/index.json
@@ -3,13 +3,13 @@
   "issue": 5666,
   "repository": "danielbaustin/agent-design-language",
   "initialization_digest": "8a868f7f1c699671b7c60dd6bcfe05caaacf4325c016d16985f480282293ebac",
-  "phase": "reviewed",
-  "generation": 4,
-  "digest": "5c052b363c3a9b82df1ab2fe227174a6711a2242ffc3167f8205ceb046be71e0",
+  "phase": "published",
+  "generation": 5,
+  "digest": "8f0c172b2370de74b29290e99a265f72cd6a66fae432bb4f43e2d404fb9cbe16",
   "claim": {
     "id": "claim-5666-throughput-fast-lane",
     "owner": "codex:issue-5666-slot-1",
-    "generation": 4,
+    "generation": 5,
     "acquired_unix_seconds": 1785024000,
     "expires_unix_seconds": 1785628800,
     "heartbeat_unix_seconds": 1785024000,
@@ -45,7 +45,17 @@
     "completed": true,
     "non_substantive_proof": null
   },
-  "publication": null,
+  "publication": {
+    "repository": "danielbaustin/agent-design-language",
+    "issue": 5666,
+    "pull_request": 5668,
+    "url": "https://github.com/danielbaustin/agent-design-language/pull/5668",
+    "base": "main",
+    "head": "codex/5666-throughput-fast-lane",
+    "revision": "git-blake3:977cdfcc2236cd87b40e6feaac38359d5629d208:3695fa5b85299175494d75012a680a4842fef2658b9f789fc7879c1e0dbe4612",
+    "draft": true,
+    "observed_state": "open"
+  },
   "readiness": null,
   "terminal": null,
   "migration": null,
@@ -59,34 +69,34 @@
   },
   "cards": {
     "sip": {
-      "values_digest": "d3c26ed1839a271be7ea27106f198e451bea07322a5d5d8d1ce73996fecb02c2",
+      "values_digest": "2527b43a15738b5e78b297c43d54f13e0abbc4bcd74050155d7069ac64a555a3",
       "rendered_digest": "2d53e4b1a319307fcce4afc1632f5afadeec20050c235d3e6da8a71ad40d896e",
       "ast_digest": "85f6117b94d62a7fd03bad16aa1c0c84fdcec16850e17fbdaa6f84481da00b76"
     },
     "stp": {
-      "values_digest": "6bce762f7fcd0d29f3ae122d4af45b52c5576fa35cbc29901a991508f7a80507",
+      "values_digest": "d5794b3b1ef7b9fe8c46cc268c91f342b3342b93c56a4c8e62887ae9a4b8ed5e",
       "rendered_digest": "a4c0abe508c7bb29e28f63b0c2fdc92486301073de7e33060318a772bbfd9f92",
       "ast_digest": "02700ec02f2df43fc142b1e043e4e26227582ed0dc542d2b8637b5ac30078348"
     },
     "spp": {
-      "values_digest": "b305a71baab90d677b713948110cc5f11f5f48a4e4c996cea784e1a325ba2c96",
+      "values_digest": "c59fce63967702904c5fee9942deec4877273a8e53cc202e1c7e05bcf60209db",
       "rendered_digest": "cd4648f2df73491bc7b633be48d68db3c4ddbd010cea03fb5eb165f9eb56fbd6",
       "ast_digest": "622f57b394e1c0aaddf781eb1b01b4cd68f00d508f58d163a73b0ed440c60449"
     },
     "vpp": {
-      "values_digest": "b0a7cc749678681c336c559ce37f84b699863415c0f6a06b136ce6d182b5f3cb",
+      "values_digest": "1efa1e3cd167bba6b40c7a0fbca14d2263faa895ae51f90519b0500431f417db",
       "rendered_digest": "969cb2176f0a1f54315d31479c4d7c14fbada32e603264652f1106a88fc5103e",
       "ast_digest": "72ac249f6b8d31d5714634abb4777ad71fbbbd222c476b5abbf7ced5b29acc09"
     },
     "srp": {
-      "values_digest": "0fc775390db280e030aa3b7c779cf11ac2506dfa6858d9d078dd1c062d8519be",
+      "values_digest": "3b02b2c67f24a05d757f3bee5885437e9512c4981b20253b68cb8046e6ad415b",
       "rendered_digest": "df7b07152a8de8fec15e52f4168cb93d6c641f0e3d2a6150ff1f4ed150659d90",
       "ast_digest": "90cb3f6e0b5863227f3f41a5a5dac0afe778aa8a1acb94aae5771ace2951842a"
     },
     "sor": {
-      "values_digest": "33bab9e16a1d1c8668bab96fd05cf3d329732f3b9bb07d3d79988b20a26431b1",
-      "rendered_digest": "25298bd0591358dd514cfcfbfff4ed019e4e220f1b93bdb59eaf7fa182806669",
-      "ast_digest": "6984b90631575fad7062963427eed6389ebb2a0fb0e4829a3d2ac18fbf61fa5e"
+      "values_digest": "d7b52dfd10f70eb7a37a7ec569278b662df632ec5995978149c00e6ad42d3a9b",
+      "rendered_digest": "1263eb5e4333d8efbcd72b9bf93c7bd664821b565a976e51ce5fd6e4c2ff07a9",
+      "ast_digest": "5c668cb8bac8a56cdab0e706b03d9869f5dfc03ba2a1f024e28b0c3ea182b86a"
     }
   },
   "transitions": [
@@ -117,6 +127,13 @@
       "to": "reviewed",
       "actor": "codex:issue-5666-slot-1",
       "reason": "exact scoped review passed"
+    },
+    {
+      "sequence": 5,
+      "from": "reviewed",
+      "to": "published",
+      "actor": "codex:issue-5666-slot-1",
+      "reason": "observed exact PR after current review"
     }
   ],
   "audit": [
@@ -161,6 +178,13 @@
       "actor": "codex:issue-5666-slot-1",
       "reason": "atomically record exact review evidence and reviewed phase",
       "operation": "record_review"
+    },
+    {
+      "sequence": 7,
+      "generation": 5,
+      "actor": "codex:issue-5666-slot-1",
+      "reason": "atomically record observed GitHub publication and SOR projection",
+      "operation": "record_publication"
     }
   ]
 }

--- a/.csdlc/issues/5666/index.json
+++ b/.csdlc/issues/5666/index.json
@@ -4,12 +4,12 @@
   "repository": "danielbaustin/agent-design-language",
   "initialization_digest": "8a868f7f1c699671b7c60dd6bcfe05caaacf4325c016d16985f480282293ebac",
   "phase": "implemented",
-  "generation": 2,
-  "digest": "ec2d02a49ad30bad69ab1329e76acad631abf84e6ad3cce4325f4b9983f1eafa",
+  "generation": 3,
+  "digest": "186c33c496b2a27dda72ac1546ea01ad1316b857d35d77dddf2251bef7961d08",
   "claim": {
     "id": "claim-5666-throughput-fast-lane",
     "owner": "codex:issue-5666-slot-1",
-    "generation": 2,
+    "generation": 3,
     "acquired_unix_seconds": 1785024000,
     "expires_unix_seconds": 1785628800,
     "heartbeat_unix_seconds": 1785024000,
@@ -37,37 +37,37 @@
   "design_review": {
     "approved": {
       "reviewer": "operator:5666",
-      "revision": "17e9330bc8371335f7a79046ba2b93a9832c9bef55da76e3e1844f62d7610e3a"
+      "revision": "8e91e0e05de23a42793864d2157b414bb57513677bdde465f6d3cb85a375a9c4"
     }
   },
   "cards": {
     "sip": {
-      "values_digest": "6ec2bbec42662eb5543fa3b2d9e9d40e38007bab27b4a4eee09f0d7bc6ca7651",
+      "values_digest": "a99a2217dc3eaf44ffba3cc7565738e73a037d74e55e5c080b06f895287ed360",
       "rendered_digest": "2d53e4b1a319307fcce4afc1632f5afadeec20050c235d3e6da8a71ad40d896e",
       "ast_digest": "85f6117b94d62a7fd03bad16aa1c0c84fdcec16850e17fbdaa6f84481da00b76"
     },
     "stp": {
-      "values_digest": "0121cf97570a16f37328ea7fe76729544e16e33034fa583e522a90b043189ae4",
+      "values_digest": "6959e26561b1304b1465ed53e98925a49125ecc0ebee4226377331ac27df5d73",
       "rendered_digest": "a4c0abe508c7bb29e28f63b0c2fdc92486301073de7e33060318a772bbfd9f92",
       "ast_digest": "02700ec02f2df43fc142b1e043e4e26227582ed0dc542d2b8637b5ac30078348"
     },
     "spp": {
-      "values_digest": "9ac247a51a13e60c02cab7ed0e798f91759d2dbd55314464a9cf677d9517a700",
-      "rendered_digest": "3f13551e92310f9723ce7b87ce64557d919d133d1f190e9026cd5d65b8722fc2",
-      "ast_digest": "75101cdd62277658799c0c251aed209b3b8d2cf2ae1022e7995cb0e035e665c0"
+      "values_digest": "c660a64603e9e60d55a5d7e7b6ee4b0f4b2f697393500b4ef9a18e29b0d3c415",
+      "rendered_digest": "cd4648f2df73491bc7b633be48d68db3c4ddbd010cea03fb5eb165f9eb56fbd6",
+      "ast_digest": "622f57b394e1c0aaddf781eb1b01b4cd68f00d508f58d163a73b0ed440c60449"
     },
     "vpp": {
-      "values_digest": "8174040c199142900d72ff6d55aaee5890f44dafc903782f7cc514c377aefda3",
+      "values_digest": "fa366876cdaa97e4892f94c0c6da4a7e776d1b18f297da9d4e0500d877ee0b04",
       "rendered_digest": "969cb2176f0a1f54315d31479c4d7c14fbada32e603264652f1106a88fc5103e",
       "ast_digest": "72ac249f6b8d31d5714634abb4777ad71fbbbd222c476b5abbf7ced5b29acc09"
     },
     "srp": {
-      "values_digest": "d89c9b8620ee13e48c6605613af24623230f1388634befc9e7b0254042743a18",
+      "values_digest": "43531f3f82f8a8fb5637f2e9ee5841782a4a5e9ad38c77cc6f291c93fc18a8c6",
       "rendered_digest": "52fb257dda403d49ee324f3c1f6b52da1214006bfdb30f815888f951076af167",
       "ast_digest": "cd414cccf429eb48108a495cbb5c509255aa873e07b21321521a97f248d40ba4"
     },
     "sor": {
-      "values_digest": "04a845c6b80b670142a329ad73c0e4c5cd83ebe2198a36342ffda6c7342f44b0",
+      "values_digest": "c71a285a925b1da91c74fc98e877ddfd5dde5ec9b9f326c04f33dee5040018d4",
       "rendered_digest": "25298bd0591358dd514cfcfbfff4ed019e4e220f1b93bdb59eaf7fa182806669",
       "ast_digest": "6984b90631575fad7062963427eed6389ebb2a0fb0e4829a3d2ac18fbf61fa5e"
     }
@@ -123,6 +123,13 @@
       "actor": "codex:issue-5666-slot-1",
       "reason": "atomically record execution, validation, and implemented phase",
       "operation": "finalize_implementation"
+    },
+    {
+      "sequence": 5,
+      "generation": 3,
+      "actor": "operator:5666",
+      "reason": "reapprove changed issue design",
+      "operation": "approve_design"
     }
   ]
 }

--- a/.csdlc/issues/5666/index.json
+++ b/.csdlc/issues/5666/index.json
@@ -1,0 +1,128 @@
+{
+  "schema": "csdlc.issue.index.v1",
+  "issue": 5666,
+  "repository": "danielbaustin/agent-design-language",
+  "initialization_digest": "8a868f7f1c699671b7c60dd6bcfe05caaacf4325c016d16985f480282293ebac",
+  "phase": "implemented",
+  "generation": 2,
+  "digest": "ec2d02a49ad30bad69ab1329e76acad631abf84e6ad3cce4325f4b9983f1eafa",
+  "claim": {
+    "id": "claim-5666-throughput-fast-lane",
+    "owner": "codex:issue-5666-slot-1",
+    "generation": 2,
+    "acquired_unix_seconds": 1785024000,
+    "expires_unix_seconds": 1785628800,
+    "heartbeat_unix_seconds": 1785024000,
+    "branch": "codex/5666-throughput-fast-lane",
+    "worktree": ".",
+    "protected_paths": [
+      ".csdlc/evidence/5666",
+      ".csdlc/issues/5666",
+      ".csdlc/locks/5666.lock",
+      ".csdlc/prepared/issues/5666",
+      "docs/tooling/DEVELOPER_THROUGHPUT_FAST_LANE.md",
+      "docs/tooling/VALIDATION_PLATFORM_ROUTING.md",
+      "adl/tools/test_developer_throughput_fast_lane.sh"
+    ],
+    "purpose": "Add a proportional fast-lane policy and focused contract proof for small ADL fixes"
+  },
+  "review_assignment": null,
+  "review": null,
+  "publication": null,
+  "readiness": null,
+  "terminal": null,
+  "migration": null,
+  "design_path": ".csdlc/prepared/issues/5666/design.md",
+  "diagram_path": ".csdlc/prepared/issues/5666/diagram.mmd",
+  "design_review": {
+    "approved": {
+      "reviewer": "operator:5666",
+      "revision": "17e9330bc8371335f7a79046ba2b93a9832c9bef55da76e3e1844f62d7610e3a"
+    }
+  },
+  "cards": {
+    "sip": {
+      "values_digest": "6ec2bbec42662eb5543fa3b2d9e9d40e38007bab27b4a4eee09f0d7bc6ca7651",
+      "rendered_digest": "2d53e4b1a319307fcce4afc1632f5afadeec20050c235d3e6da8a71ad40d896e",
+      "ast_digest": "85f6117b94d62a7fd03bad16aa1c0c84fdcec16850e17fbdaa6f84481da00b76"
+    },
+    "stp": {
+      "values_digest": "0121cf97570a16f37328ea7fe76729544e16e33034fa583e522a90b043189ae4",
+      "rendered_digest": "a4c0abe508c7bb29e28f63b0c2fdc92486301073de7e33060318a772bbfd9f92",
+      "ast_digest": "02700ec02f2df43fc142b1e043e4e26227582ed0dc542d2b8637b5ac30078348"
+    },
+    "spp": {
+      "values_digest": "9ac247a51a13e60c02cab7ed0e798f91759d2dbd55314464a9cf677d9517a700",
+      "rendered_digest": "3f13551e92310f9723ce7b87ce64557d919d133d1f190e9026cd5d65b8722fc2",
+      "ast_digest": "75101cdd62277658799c0c251aed209b3b8d2cf2ae1022e7995cb0e035e665c0"
+    },
+    "vpp": {
+      "values_digest": "8174040c199142900d72ff6d55aaee5890f44dafc903782f7cc514c377aefda3",
+      "rendered_digest": "969cb2176f0a1f54315d31479c4d7c14fbada32e603264652f1106a88fc5103e",
+      "ast_digest": "72ac249f6b8d31d5714634abb4777ad71fbbbd222c476b5abbf7ced5b29acc09"
+    },
+    "srp": {
+      "values_digest": "d89c9b8620ee13e48c6605613af24623230f1388634befc9e7b0254042743a18",
+      "rendered_digest": "52fb257dda403d49ee324f3c1f6b52da1214006bfdb30f815888f951076af167",
+      "ast_digest": "cd414cccf429eb48108a495cbb5c509255aa873e07b21321521a97f248d40ba4"
+    },
+    "sor": {
+      "values_digest": "04a845c6b80b670142a329ad73c0e4c5cd83ebe2198a36342ffda6c7342f44b0",
+      "rendered_digest": "25298bd0591358dd514cfcfbfff4ed019e4e220f1b93bdb59eaf7fa182806669",
+      "ast_digest": "6984b90631575fad7062963427eed6389ebb2a0fb0e4829a3d2ac18fbf61fa5e"
+    }
+  },
+  "transitions": [
+    {
+      "sequence": 1,
+      "from": "initialized",
+      "to": "ready",
+      "actor": "codex:issue-5666-slot-1",
+      "reason": "automatic readiness verification"
+    },
+    {
+      "sequence": 2,
+      "from": "ready",
+      "to": "bound",
+      "actor": "codex:issue-5666-slot-1",
+      "reason": "verified Git worktree binding"
+    },
+    {
+      "sequence": 3,
+      "from": "bound",
+      "to": "implemented",
+      "actor": "codex:issue-5666-slot-1",
+      "reason": "execution and passing validation finalized atomically"
+    }
+  ],
+  "audit": [
+    {
+      "sequence": 1,
+      "generation": 0,
+      "actor": "codex:issue-5666-slot-1",
+      "reason": "initialize issue record and all six cards",
+      "operation": "bootstrap"
+    },
+    {
+      "sequence": 2,
+      "generation": 1,
+      "actor": "operator:5666",
+      "reason": "approve completed issue design",
+      "operation": "approve_design"
+    },
+    {
+      "sequence": 3,
+      "generation": 1,
+      "actor": "codex:issue-5666-slot-1",
+      "reason": "bind branch/worktree and activate claim",
+      "operation": "bind"
+    },
+    {
+      "sequence": 4,
+      "generation": 2,
+      "actor": "codex:issue-5666-slot-1",
+      "reason": "atomically record execution, validation, and implemented phase",
+      "operation": "finalize_implementation"
+    }
+  ]
+}

--- a/.csdlc/issues/5666/index.json
+++ b/.csdlc/issues/5666/index.json
@@ -3,13 +3,13 @@
   "issue": 5666,
   "repository": "danielbaustin/agent-design-language",
   "initialization_digest": "8a868f7f1c699671b7c60dd6bcfe05caaacf4325c016d16985f480282293ebac",
-  "phase": "implemented",
-  "generation": 3,
-  "digest": "186c33c496b2a27dda72ac1546ea01ad1316b857d35d77dddf2251bef7961d08",
+  "phase": "reviewed",
+  "generation": 4,
+  "digest": "5c052b363c3a9b82df1ab2fe227174a6711a2242ffc3167f8205ceb046be71e0",
   "claim": {
     "id": "claim-5666-throughput-fast-lane",
     "owner": "codex:issue-5666-slot-1",
-    "generation": 3,
+    "generation": 4,
     "acquired_unix_seconds": 1785024000,
     "expires_unix_seconds": 1785628800,
     "heartbeat_unix_seconds": 1785024000,
@@ -27,7 +27,24 @@
     "purpose": "Add a proportional fast-lane policy and focused contract proof for small ADL fixes"
   },
   "review_assignment": null,
-  "review": null,
+  "review": {
+    "reviewer": "subagent:sagan",
+    "scope": [
+      ".csdlc/evidence/5666",
+      ".csdlc/issues/5666",
+      ".csdlc/prepared/issues/5666",
+      "adl/tools/test_developer_throughput_fast_lane.sh",
+      "docs/tooling/DEVELOPER_THROUGHPUT_FAST_LANE.md",
+      "docs/tooling/VALIDATION_PLATFORM_ROUTING.md"
+    ],
+    "reviewed_revision": "git-blake3:30e495fda450d10a4e29b0c57195f759224a7214:bf3cbab163693daa1084c8119b458a550c59032eea66798f753f22166e22d3e6",
+    "findings": [],
+    "residual_risks": [
+      "Review confirmed the initial placeholder design finding was fixed before this exact scoped revision; remaining lock file is untracked and outside HEAD."
+    ],
+    "completed": true,
+    "non_substantive_proof": null
+  },
   "publication": null,
   "readiness": null,
   "terminal": null,
@@ -42,32 +59,32 @@
   },
   "cards": {
     "sip": {
-      "values_digest": "a99a2217dc3eaf44ffba3cc7565738e73a037d74e55e5c080b06f895287ed360",
+      "values_digest": "d3c26ed1839a271be7ea27106f198e451bea07322a5d5d8d1ce73996fecb02c2",
       "rendered_digest": "2d53e4b1a319307fcce4afc1632f5afadeec20050c235d3e6da8a71ad40d896e",
       "ast_digest": "85f6117b94d62a7fd03bad16aa1c0c84fdcec16850e17fbdaa6f84481da00b76"
     },
     "stp": {
-      "values_digest": "6959e26561b1304b1465ed53e98925a49125ecc0ebee4226377331ac27df5d73",
+      "values_digest": "6bce762f7fcd0d29f3ae122d4af45b52c5576fa35cbc29901a991508f7a80507",
       "rendered_digest": "a4c0abe508c7bb29e28f63b0c2fdc92486301073de7e33060318a772bbfd9f92",
       "ast_digest": "02700ec02f2df43fc142b1e043e4e26227582ed0dc542d2b8637b5ac30078348"
     },
     "spp": {
-      "values_digest": "c660a64603e9e60d55a5d7e7b6ee4b0f4b2f697393500b4ef9a18e29b0d3c415",
+      "values_digest": "b305a71baab90d677b713948110cc5f11f5f48a4e4c996cea784e1a325ba2c96",
       "rendered_digest": "cd4648f2df73491bc7b633be48d68db3c4ddbd010cea03fb5eb165f9eb56fbd6",
       "ast_digest": "622f57b394e1c0aaddf781eb1b01b4cd68f00d508f58d163a73b0ed440c60449"
     },
     "vpp": {
-      "values_digest": "fa366876cdaa97e4892f94c0c6da4a7e776d1b18f297da9d4e0500d877ee0b04",
+      "values_digest": "b0a7cc749678681c336c559ce37f84b699863415c0f6a06b136ce6d182b5f3cb",
       "rendered_digest": "969cb2176f0a1f54315d31479c4d7c14fbada32e603264652f1106a88fc5103e",
       "ast_digest": "72ac249f6b8d31d5714634abb4777ad71fbbbd222c476b5abbf7ced5b29acc09"
     },
     "srp": {
-      "values_digest": "43531f3f82f8a8fb5637f2e9ee5841782a4a5e9ad38c77cc6f291c93fc18a8c6",
-      "rendered_digest": "52fb257dda403d49ee324f3c1f6b52da1214006bfdb30f815888f951076af167",
-      "ast_digest": "cd414cccf429eb48108a495cbb5c509255aa873e07b21321521a97f248d40ba4"
+      "values_digest": "0fc775390db280e030aa3b7c779cf11ac2506dfa6858d9d078dd1c062d8519be",
+      "rendered_digest": "df7b07152a8de8fec15e52f4168cb93d6c641f0e3d2a6150ff1f4ed150659d90",
+      "ast_digest": "90cb3f6e0b5863227f3f41a5a5dac0afe778aa8a1acb94aae5771ace2951842a"
     },
     "sor": {
-      "values_digest": "c71a285a925b1da91c74fc98e877ddfd5dde5ec9b9f326c04f33dee5040018d4",
+      "values_digest": "33bab9e16a1d1c8668bab96fd05cf3d329732f3b9bb07d3d79988b20a26431b1",
       "rendered_digest": "25298bd0591358dd514cfcfbfff4ed019e4e220f1b93bdb59eaf7fa182806669",
       "ast_digest": "6984b90631575fad7062963427eed6389ebb2a0fb0e4829a3d2ac18fbf61fa5e"
     }
@@ -93,6 +110,13 @@
       "to": "implemented",
       "actor": "codex:issue-5666-slot-1",
       "reason": "execution and passing validation finalized atomically"
+    },
+    {
+      "sequence": 4,
+      "from": "implemented",
+      "to": "reviewed",
+      "actor": "codex:issue-5666-slot-1",
+      "reason": "exact scoped review passed"
     }
   ],
   "audit": [
@@ -130,6 +154,13 @@
       "actor": "operator:5666",
       "reason": "reapprove changed issue design",
       "operation": "approve_design"
+    },
+    {
+      "sequence": 6,
+      "generation": 4,
+      "actor": "codex:issue-5666-slot-1",
+      "reason": "atomically record exact review evidence and reviewed phase",
+      "operation": "record_review"
     }
   ]
 }

--- a/.csdlc/prepared/issues/5666/approve-design-request.json
+++ b/.csdlc/prepared/issues/5666/approve-design-request.json
@@ -1,7 +1,7 @@
 {
   "issue": 5666,
-  "expected_generation": 0,
-  "expected_digest": "b91114086aa6a16e9cc8ad5214ced373e7fd3f0898a5fe117a23c0bb7efe2a88",
+  "expected_generation": 2,
+  "expected_digest": "ec2d02a49ad30bad69ab1329e76acad631abf84e6ad3cce4325f4b9983f1eafa",
   "claim_id": "claim-5666-throughput-fast-lane",
   "reviewer": "operator:5666"
 }

--- a/.csdlc/prepared/issues/5666/approve-design-request.json
+++ b/.csdlc/prepared/issues/5666/approve-design-request.json
@@ -1,0 +1,7 @@
+{
+  "issue": 5666,
+  "expected_generation": 0,
+  "expected_digest": "b91114086aa6a16e9cc8ad5214ced373e7fd3f0898a5fe117a23c0bb7efe2a88",
+  "claim_id": "claim-5666-throughput-fast-lane",
+  "reviewer": "operator:5666"
+}

--- a/.csdlc/prepared/issues/5666/bind-request.json
+++ b/.csdlc/prepared/issues/5666/bind-request.json
@@ -1,0 +1,26 @@
+{
+  "issue": 5666,
+  "base_branch": "main",
+  "branch": "codex/5666-throughput-fast-lane",
+  "worktree": ".",
+  "claim": {
+    "id": "claim-5666-throughput-fast-lane",
+    "owner": "codex:issue-5666-slot-1",
+    "generation": 1,
+    "acquired_unix_seconds": 1785024000,
+    "expires_unix_seconds": 1785628800,
+    "heartbeat_unix_seconds": 1785024000,
+    "branch": "codex/5666-throughput-fast-lane",
+    "worktree": ".",
+    "protected_paths": [
+      ".csdlc/evidence/5666",
+      ".csdlc/issues/5666",
+      ".csdlc/locks/5666.lock",
+      ".csdlc/prepared/issues/5666",
+      "docs/tooling/DEVELOPER_THROUGHPUT_FAST_LANE.md",
+      "docs/tooling/VALIDATION_PLATFORM_ROUTING.md",
+      "adl/tools/test_developer_throughput_fast_lane.sh"
+    ],
+    "purpose": "Add a proportional fast-lane policy and focused contract proof for small ADL fixes"
+  }
+}

--- a/.csdlc/prepared/issues/5666/bootstrap-request.json
+++ b/.csdlc/prepared/issues/5666/bootstrap-request.json
@@ -1,0 +1,145 @@
+{
+  "issue": 5666,
+  "repository": "danielbaustin/agent-design-language",
+  "design_path": ".csdlc/prepared/issues/5666/design.md",
+  "diagram_path": ".csdlc/prepared/issues/5666/diagram.mmd",
+  "design_reviewer": "operator:5666",
+  "design_approved": false,
+  "claim": {
+    "id": "claim-5666-throughput-fast-lane",
+    "owner": "codex:issue-5666-slot-1",
+    "generation": 0,
+    "acquired_unix_seconds": 1785024000,
+    "expires_unix_seconds": 1785628800,
+    "heartbeat_unix_seconds": 1785024000,
+    "branch": "codex/5666-throughput-fast-lane",
+    "worktree": ".",
+    "protected_paths": [
+      ".csdlc/evidence/5666",
+      ".csdlc/issues/5666",
+      ".csdlc/locks/5666.lock",
+      ".csdlc/prepared/issues/5666",
+      "docs/tooling/DEVELOPER_THROUGHPUT_FAST_LANE.md",
+      "docs/tooling/VALIDATION_PLATFORM_ROUTING.md",
+      "adl/tools/test_developer_throughput_fast_lane.sh"
+    ],
+    "purpose": "Add a proportional fast-lane policy and focused contract proof for small ADL fixes"
+  },
+  "initial": {
+    "title": "[v0.91.8][tools][ci] Add proportional fast lane for small fixes",
+    "slug": "v0-91-8-tools-ci-throughput-fast-lane",
+    "version": "v0.91.8",
+    "goal": "Reduce development latency by making validation, review, PR watching, and lifecycle effort proportional to issue risk.",
+    "required_outcome": "A checked-in fast-lane policy and focused contract proof define how tiny tool/docs/test fixes move quickly without weakening typed C-SDLC v2 authority or exact-head truth.",
+    "declared_scope": [
+      "developer throughput fast-lane policy",
+      "validation routing documentation link and policy reference to the validation selector",
+      "small focused shell contract test for policy invariants",
+      "issue-local C-SDLC v2 lifecycle records"
+    ],
+    "authority_boundary": [
+      "typed C-SDLC v2 remains the lifecycle authority",
+      "fast lane changes validation selection and operator behavior, not product/runtime semantics",
+      "GitHub wait states must be changed-state/blocker reporting only"
+    ],
+    "operator_constraints": [
+      "Use FastWork for worktree, temp, and Rust build output",
+      "Do not write on root main",
+      "No AWS execution",
+      "No raw GitHub CLI or connector fallback for issue lifecycle",
+      "Keep the implementation small"
+    ],
+    "task_boundary": "Implement, validate, review, publish, merge, and close the bounded throughput fast-lane policy issue.",
+    "deliverables": [
+      "docs/tooling/DEVELOPER_THROUGHPUT_FAST_LANE.md",
+      "link from validation routing docs and selector reference in the policy",
+      "adl/tools/test_developer_throughput_fast_lane.sh"
+    ],
+    "acceptance_criteria": [
+      "AC-1: The policy names proportional issue classes, eligibility, escalation, stop conditions, and non-claims.",
+      "AC-2: Validation routing docs link the policy, and the policy references the validation selector without editing paths claimed by another issue.",
+      "AC-3: The policy requires FastWork or another declared external build root when the operator requires it, and forbids silent local-disk fallback.",
+      "AC-4: PR watching guidance is changed-state/blocker-only and says not to wait on GitHub when no action is possible.",
+      "AC-5: A focused contract test proves the required policy language and links exist."
+    ],
+    "dependencies": [
+      "GitHub issue #5666",
+      "existing validation lane selector",
+      "existing validation platform routing docs"
+    ],
+    "repo_inputs": [
+      "docs/architecture/VALIDATION_LANE_SELECTOR.md",
+      "docs/tooling/VALIDATION_PLATFORM_ROUTING.md",
+      "docs/milestones/v0.91.7/review/V0917_WP06_BUILD_THROUGHPUT_VALIDATION_COST_REDUCTION_4633.md"
+    ],
+    "non_goals": [
+      "Runtime or product feature changes",
+      "AWS execution",
+      "broad CI workflow rewrite",
+      "replacement of typed C-SDLC v2",
+      "large test-classification migration"
+    ],
+    "plan_summary": "Add a small policy plus contract test that turns the operator's ten speed improvements into enforceable ADL guidance for small fixes.",
+    "steps": [
+      {
+        "id": "S1",
+        "action": "Write the proportional fast-lane policy",
+        "status": "pending",
+        "acceptance_ids": ["AC-1", "AC-3", "AC-4"]
+      },
+      {
+        "id": "S2",
+        "action": "Link routing docs, reference the selector policy, and add focused contract test",
+        "status": "pending",
+        "acceptance_ids": ["AC-2", "AC-5"]
+      },
+      {
+        "id": "S3",
+        "action": "Validate, review, publish, and close out",
+        "status": "pending",
+        "acceptance_ids": ["AC-1", "AC-2", "AC-3", "AC-4", "AC-5"]
+      }
+    ],
+    "invariants": [
+      "small fixes do not bypass typed lifecycle",
+      "focused proof must be selected and truthful",
+      "runtime/product changes remain full proof",
+      "no waiting on unchanged GitHub states"
+    ],
+    "risks": [
+      "fast lane could be mistaken for weaker proof",
+      "policy-only work might not change behavior unless linked to contract tests",
+      "local disk fallback could reappear if not explicitly forbidden"
+    ],
+    "planning_profile": "small",
+    "stop_conditions": [
+      "FastWork is unavailable",
+      "scope expands into CI workflow rewrite or runtime/product code",
+      "typed lifecycle state cannot be initialized or validated",
+      "review finds unresolved actionables"
+    ],
+    "validation_lanes": [
+      {
+        "lane": "throughput-fast-lane-contract",
+        "proof_role": "Run focused shell contract test and diff hygiene for policy links and required invariants.",
+        "acceptance_ids": ["AC-1", "AC-2", "AC-3", "AC-4", "AC-5"],
+        "deterministic": true,
+        "resource_profile": "small",
+        "budget_seconds": 30,
+        "budget_tokens": 500,
+        "argv": ["bash", "adl/tools/test_developer_throughput_fast_lane.sh"],
+        "parallel_group": "docs-policy",
+        "defer_reason": null
+      }
+    ],
+    "failure_policy": "Fail closed on missing policy, broken links, absent FastWork/no-local-fallback language, broad CI/runtime scope, or unresolved review findings.",
+    "review_prompts": [
+      "Does the policy make lifecycle and validation proportional without weakening typed C-SDLC v2?",
+      "Does it clearly separate tiny fixes from runtime/product work?",
+      "Does it prevent local-disk fallback when FastWork is required?",
+      "Does it stop unchanged GitHub waiting and require blocker-only updates?",
+      "Is the implementation intentionally small?"
+    ],
+    "review_scope": "Review the fast-lane policy doc, routing link, selector reference, focused contract test, and issue-local lifecycle truth."
+  }
+}

--- a/.csdlc/prepared/issues/5666/design.md
+++ b/.csdlc/prepared/issues/5666/design.md
@@ -1,3 +1,55 @@
-# Issue 5666 design
+# Issue 5666 Design
 
-Status: design required before Ready.
+Status: ready for bounded implementation.
+
+## Intent
+
+Issue #5666 adds a small, publication-safe developer throughput fast-lane policy
+for low-risk ADL fixes. The work is documentation and focused contract proof
+only; it does not change runtime/product behavior, CI workflows, provider
+execution, GitHub lifecycle authority, or release gates.
+
+## Scope
+
+The protected implementation surface is:
+
+- `docs/tooling/DEVELOPER_THROUGHPUT_FAST_LANE.md`
+- `docs/tooling/VALIDATION_PLATFORM_ROUTING.md`
+- `adl/tools/test_developer_throughput_fast_lane.sh`
+- issue-local `.csdlc` records and evidence for #5666
+
+`docs/architecture/VALIDATION_LANE_SELECTOR.md` remains the selector authority
+and is referenced, not edited, because another lifecycle claim previously
+covered architecture paths.
+
+## Policy Requirements
+
+The fast-lane policy must:
+
+- define proportional issue classes and eligibility
+- preserve typed C-SDLC v2 as the lifecycle authority
+- require FastWork or another declared external build root when the operator
+  requires it
+- forbid silent local-disk fallback
+- require changed-state-only PR watching and no GitHub waiting when no action is
+  possible
+- define escalation and stop conditions for runtime, provider, security,
+  publication, closeout, release-gate, or ambiguous changes
+- state non-claims so focused proof cannot be used for broad runtime/product
+  completion
+
+## Validation
+
+Local proof is intentionally narrow:
+
+- `bash adl/tools/test_developer_throughput_fast_lane.sh`
+- `git diff --check`
+
+The shell contract checks for required policy strings, selector reference, and
+routing-doc linkage. It is not a runtime or CI proof.
+
+## Publication Boundary
+
+Publication requires exact-head review after implementation. Any review finding
+that changes the policy, design packet, validation evidence, or lifecycle truth
+requires revalidation and a fresh typed review before publication.

--- a/.csdlc/prepared/issues/5666/design.md
+++ b/.csdlc/prepared/issues/5666/design.md
@@ -1,0 +1,3 @@
+# Issue 5666 design
+
+Status: design required before Ready.

--- a/.csdlc/prepared/issues/5666/diagram.mmd
+++ b/.csdlc/prepared/issues/5666/diagram.mmd
@@ -1,2 +1,10 @@
-flowchart LR
-  I["Issue 5666"] --> D["Design required"]
+flowchart TD
+  I["Issue #5666"] --> P["Throughput fast-lane policy"]
+  I --> R["Validation routing link"]
+  I --> T["Focused contract test"]
+  P --> A["Proportional issue classes"]
+  P --> F["FastWork-required mode"]
+  P --> W["Changed-state-only PR watching"]
+  P --> E["Escalation and non-claims"]
+  T --> V["PVF local proof"]
+  V --> S["SOR validation truth"]

--- a/.csdlc/prepared/issues/5666/diagram.mmd
+++ b/.csdlc/prepared/issues/5666/diagram.mmd
@@ -1,0 +1,2 @@
+flowchart LR
+  I["Issue 5666"] --> D["Design required"]

--- a/.csdlc/prepared/issues/5666/finalize-implementation-request.json
+++ b/.csdlc/prepared/issues/5666/finalize-implementation-request.json
@@ -1,0 +1,98 @@
+{
+  "schema": "csdlc.finalize_request.v1",
+  "issue": 5666,
+  "expected_generation": 1,
+  "expected_digest": "ca07f225b082d3909994e16d7cf8fabfd942a0759b1287c36872216310eb9c73",
+  "claim_id": "claim-5666-throughput-fast-lane",
+  "actor": "codex:issue-5666-slot-1",
+  "summary": "Implemented a proportional developer throughput fast-lane policy, linked it from validation platform routing, and added focused contract proof for the required invariants.",
+  "changes": [
+    "Added docs/tooling/DEVELOPER_THROUGHPUT_FAST_LANE.md with proportional issue classes, FastWork-required behavior, changed-state-only PR watching, escalation rules, and non-claims.",
+    "Linked the fast-lane policy from docs/tooling/VALIDATION_PLATFORM_ROUTING.md.",
+    "Added adl/tools/test_developer_throughput_fast_lane.sh to prove required policy language and routing linkage."
+  ],
+  "artifacts": [
+    "docs/tooling/DEVELOPER_THROUGHPUT_FAST_LANE.md",
+    "docs/tooling/VALIDATION_PLATFORM_ROUTING.md",
+    "adl/tools/test_developer_throughput_fast_lane.sh"
+  ],
+  "execution": {
+    "manifest": {
+      "schema": "csdlc.pvf.manifest.v1",
+      "lanes": [
+        {
+          "id": "throughput-fast-lane-contract",
+          "proof_role": "focused policy contract",
+          "purpose": "Prove the throughput fast-lane policy, selector reference, no-local-fallback rule, changed-state watching rule, and routing link exist.",
+          "determinism": "deterministic",
+          "resources": {
+            "cpu_units": 1,
+            "memory_mib": 128,
+            "tokens": 50
+          },
+          "credentials": [],
+          "network": "denied",
+          "dependencies": [],
+          "parallel_group": "docs-policy",
+          "release_gate": "optional",
+          "execution": "local",
+          "timeout_seconds": 30,
+          "executable": "bash",
+          "argv": [
+            "adl/tools/test_developer_throughput_fast_lane.sh"
+          ],
+          "evidence": {
+            "max_log_bytes": 20000,
+            "redact_values": [],
+            "require_relative_paths": true
+          }
+        },
+        {
+          "id": "diff-hygiene",
+          "proof_role": "diff hygiene",
+          "purpose": "Verify changed files have no whitespace or patch hygiene errors.",
+          "determinism": "deterministic",
+          "resources": {
+            "cpu_units": 1,
+            "memory_mib": 128,
+            "tokens": 10
+          },
+          "credentials": [],
+          "network": "denied",
+          "dependencies": [],
+          "parallel_group": "docs-policy",
+          "release_gate": "optional",
+          "execution": "local",
+          "timeout_seconds": 30,
+          "executable": "git",
+          "argv": [
+            "diff",
+            "--check"
+          ],
+          "evidence": {
+            "max_log_bytes": 20000,
+            "redact_values": [],
+            "require_relative_paths": true
+          }
+        }
+      ]
+    },
+    "selection": {
+      "requested_lanes": [
+        "throughput-fast-lane-contract",
+        "diff-hygiene"
+      ],
+      "allow_network": false,
+      "available_credentials": []
+    },
+    "budget": {
+      "max_parallel": 2,
+      "cpu_units": 2,
+      "memory_mib": 256,
+      "tokens": 100
+    },
+    "root": "/Volumes/FastWork/adl-wp-5666",
+    "evidence_dir": "/Volumes/FastWork/adl-wp-5666/.csdlc/evidence/5666",
+    "cancellation_file": null
+  }
+}

--- a/.csdlc/prepared/issues/5666/publish-request.json
+++ b/.csdlc/prepared/issues/5666/publish-request.json
@@ -1,0 +1,16 @@
+{
+  "schema": "csdlc.publication_request.v1",
+  "issue": 5666,
+  "expected_generation": 4,
+  "expected_digest": "5c052b363c3a9b82df1ab2fe227174a6711a2242ffc3167f8205ceb046be71e0",
+  "claim_id": "claim-5666-throughput-fast-lane",
+  "actor": "codex:issue-5666-slot-1",
+  "repository": "danielbaustin/agent-design-language",
+  "base": "main",
+  "head": "codex/5666-throughput-fast-lane",
+  "title": "[v0.91.8][tools][ci] Add proportional fast lane for small fixes",
+  "body": "Closes #5666\n\nAdds a proportional developer throughput fast-lane policy for tiny docs/tooling/test fixes without weakening typed C-SDLC v2, exact-head review, runtime/product proof, or release-gate truth.\n\nChanges:\n- Add docs/tooling/DEVELOPER_THROUGHPUT_FAST_LANE.md with proportional issue classes, FastWork-required mode, changed-state-only PR watching, escalation rules, and non-claims.\n- Link the policy from docs/tooling/VALIDATION_PLATFORM_ROUTING.md.\n- Add adl/tools/test_developer_throughput_fast_lane.sh as a focused contract proof.\n\nValidation:\n- bash adl/tools/test_developer_throughput_fast_lane.sh\n- git diff --check\n- git diff --check origin/main...HEAD\n\nReview:\n- Subagent Sagan clean at scoped revision git-blake3:30e495fda450d10a4e29b0c57195f759224a7214:bf3cbab163693daa1084c8119b458a550c59032eea66798f753f22166e22d3e6 after fixing the initial placeholder design finding.\n- Typed C-SDLC review recorded in .csdlc/issues/5666 generation 4.",
+  "draft": true,
+  "remote": "origin",
+  "token_file": "/Users/daniel/keys/github.token"
+}

--- a/.csdlc/prepared/issues/5666/ready-request.json
+++ b/.csdlc/prepared/issues/5666/ready-request.json
@@ -1,0 +1,12 @@
+{
+  "schema": "csdlc.ready_publication_request.v1",
+  "issue": 5666,
+  "expected_generation": 5,
+  "expected_digest": "8f0c172b2370de74b29290e99a265f72cd6a66fae432bb4f43e2d404fb9cbe16",
+  "claim_id": "claim-5666-throughput-fast-lane",
+  "actor": "codex:issue-5666-slot-1",
+  "repository": "danielbaustin/agent-design-language",
+  "pull_request": 5668,
+  "expected_head_sha": "d5e1e48a5207481d4bd1b4a35b4c8e0d44281452",
+  "token_file": "/Users/daniel/keys/github.token"
+}

--- a/.csdlc/prepared/issues/5666/record-review-request.json
+++ b/.csdlc/prepared/issues/5666/record-review-request.json
@@ -1,0 +1,25 @@
+{
+  "issue": 5666,
+  "expected_generation": 3,
+  "expected_digest": "186c33c496b2a27dda72ac1546ea01ad1316b857d35d77dddf2251bef7961d08",
+  "claim_id": "claim-5666-throughput-fast-lane",
+  "actor": "codex:issue-5666-slot-1",
+  "evidence": {
+    "reviewer": "subagent:sagan",
+    "scope": [
+      ".csdlc/evidence/5666",
+      ".csdlc/issues/5666",
+      ".csdlc/prepared/issues/5666",
+      "adl/tools/test_developer_throughput_fast_lane.sh",
+      "docs/tooling/DEVELOPER_THROUGHPUT_FAST_LANE.md",
+      "docs/tooling/VALIDATION_PLATFORM_ROUTING.md"
+    ],
+    "reviewed_revision": "git-blake3:30e495fda450d10a4e29b0c57195f759224a7214:bf3cbab163693daa1084c8119b458a550c59032eea66798f753f22166e22d3e6",
+    "findings": [],
+    "residual_risks": [
+      "Review confirmed the initial placeholder design finding was fixed before this exact scoped revision; remaining lock file is untracked and outside HEAD."
+    ],
+    "completed": true,
+    "non_substantive_proof": null
+  }
+}

--- a/.csdlc/prepared/issues/5666/review-guard-request.json
+++ b/.csdlc/prepared/issues/5666/review-guard-request.json
@@ -1,0 +1,11 @@
+{
+  "scope": [
+    ".csdlc/evidence/5666",
+    ".csdlc/issues/5666",
+    ".csdlc/prepared/issues/5666",
+    "adl/tools/test_developer_throughput_fast_lane.sh",
+    "docs/tooling/DEVELOPER_THROUGHPUT_FAST_LANE.md",
+    "docs/tooling/VALIDATION_PLATFORM_ROUTING.md"
+  ],
+  "evidence": null
+}

--- a/.csdlc/prepared/issues/5666/review-guard-with-evidence-request.json
+++ b/.csdlc/prepared/issues/5666/review-guard-with-evidence-request.json
@@ -1,0 +1,28 @@
+{
+  "scope": [
+    ".csdlc/evidence/5666",
+    ".csdlc/issues/5666",
+    ".csdlc/prepared/issues/5666",
+    "adl/tools/test_developer_throughput_fast_lane.sh",
+    "docs/tooling/DEVELOPER_THROUGHPUT_FAST_LANE.md",
+    "docs/tooling/VALIDATION_PLATFORM_ROUTING.md"
+  ],
+  "evidence": {
+    "reviewer": "subagent:sagan",
+    "scope": [
+      ".csdlc/evidence/5666",
+      ".csdlc/issues/5666",
+      ".csdlc/prepared/issues/5666",
+      "adl/tools/test_developer_throughput_fast_lane.sh",
+      "docs/tooling/DEVELOPER_THROUGHPUT_FAST_LANE.md",
+      "docs/tooling/VALIDATION_PLATFORM_ROUTING.md"
+    ],
+    "reviewed_revision": "git-blake3:30e495fda450d10a4e29b0c57195f759224a7214:bf3cbab163693daa1084c8119b458a550c59032eea66798f753f22166e22d3e6",
+    "findings": [],
+    "residual_risks": [
+      "Review confirmed the initial placeholder design finding was fixed before this exact scoped revision; remaining lock file is untracked and outside HEAD."
+    ],
+    "completed": true,
+    "non_substantive_proof": null
+  }
+}

--- a/.csdlc/publication/5666.intent.json
+++ b/.csdlc/publication/5666.intent.json
@@ -1,0 +1,12 @@
+{
+  "schema": "csdlc.publication_intent.v1",
+  "issue": 5666,
+  "repository": "danielbaustin/agent-design-language",
+  "base": "main",
+  "head": "codex/5666-throughput-fast-lane",
+  "title": "[v0.91.8][tools][ci] Add proportional fast lane for small fixes",
+  "body": "Closes #5666\n\nAdds a proportional developer throughput fast-lane policy for tiny docs/tooling/test fixes without weakening typed C-SDLC v2, exact-head review, runtime/product proof, or release-gate truth.\n\nChanges:\n- Add docs/tooling/DEVELOPER_THROUGHPUT_FAST_LANE.md with proportional issue classes, FastWork-required mode, changed-state-only PR watching, escalation rules, and non-claims.\n- Link the policy from docs/tooling/VALIDATION_PLATFORM_ROUTING.md.\n- Add adl/tools/test_developer_throughput_fast_lane.sh as a focused contract proof.\n\nValidation:\n- bash adl/tools/test_developer_throughput_fast_lane.sh\n- git diff --check\n- git diff --check origin/main...HEAD\n\nReview:\n- Subagent Sagan clean at scoped revision git-blake3:30e495fda450d10a4e29b0c57195f759224a7214:bf3cbab163693daa1084c8119b458a550c59032eea66798f753f22166e22d3e6 after fixing the initial placeholder design finding.\n- Typed C-SDLC review recorded in .csdlc/issues/5666 generation 4.",
+  "draft": true,
+  "revision": "git-blake3:977cdfcc2236cd87b40e6feaac38359d5629d208:3695fa5b85299175494d75012a680a4842fef2658b9f789fc7879c1e0dbe4612",
+  "commit_sha": "977cdfcc2236cd87b40e6feaac38359d5629d208"
+}

--- a/adl/tools/test_developer_throughput_fast_lane.sh
+++ b/adl/tools/test_developer_throughput_fast_lane.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+POLICY="$ROOT/docs/tooling/DEVELOPER_THROUGHPUT_FAST_LANE.md"
+ROUTING="$ROOT/docs/tooling/VALIDATION_PLATFORM_ROUTING.md"
+
+test -s "$POLICY"
+test -s "$ROUTING"
+
+grep -F "Proportional issue classes" "$POLICY" >/dev/null
+grep -F "FastWork-required mode" "$POLICY" >/dev/null
+grep -F "changed-state-only PR watching" "$POLICY" >/dev/null
+grep -F "Do not wait on GitHub when no action is possible" "$POLICY" >/dev/null
+grep -F "typed C-SDLC v2 remains the lifecycle authority" "$POLICY" >/dev/null
+grep -F "docs/architecture/VALIDATION_LANE_SELECTOR.md" "$POLICY" >/dev/null
+grep -F "Do not silently fall back to the local disk" "$POLICY" >/dev/null
+grep -F "selector output is \`escalated\` or \`release_gate_required\`" "$POLICY" >/dev/null
+
+grep -F "DEVELOPER_THROUGHPUT_FAST_LANE.md" "$ROUTING" >/dev/null

--- a/docs/tooling/DEVELOPER_THROUGHPUT_FAST_LANE.md
+++ b/docs/tooling/DEVELOPER_THROUGHPUT_FAST_LANE.md
@@ -1,0 +1,116 @@
+# Developer Throughput Fast Lane
+
+ADL small fixes should move quickly without pretending that a narrow check proves
+a broad change. This policy defines a proportional fast lane for tiny,
+low-risk work while preserving typed C-SDLC v2, exact-head review, and truthful
+closeout.
+
+The validation selector remains the source for lane classification:
+`docs/architecture/VALIDATION_LANE_SELECTOR.md`.
+
+## Proportional issue classes
+
+Use the smallest class that truthfully covers the changed surface.
+
+| Class | Typical scope | Local proof floor | Escalate when |
+| --- | --- | --- | --- |
+| `tiny-docs` | one policy, README, handoff, or routing doc | diff hygiene plus a focused text/link contract | the doc changes release truth, review gates, security claims, or milestone status |
+| `tiny-tooling` | one shell/Rust tool contract or help-path fix | focused tool contract or owner lane for that tool | shared workflow control, publication, closeout, or provider behavior changes |
+| `narrow-test` | one deterministic test or fixture classification | the changed test plus selector proof | fixture routing affects release gates, coverage, or slow/fast partitioning |
+| `runtime-product` | runtime, provider, security, or user-visible behavior | issue-specific integrated proof | never use the fast lane as completion proof |
+| `release-control` | CI, merge, shepherd, closeout, or milestone gates | focused contract plus exact-head lifecycle review | any ambiguity; default to escalation |
+
+Fast lane eligibility requires all of the following:
+
+- the changed paths are explicitly protected by the issue claim
+- the selector or issue VPP names a focused proof lane
+- the proof is deterministic, cheap, and directly tied to the acceptance
+  criteria
+- exact-head review can inspect the full behavioral surface
+- no runtime, provider, security, release, or cross-issue dependency claim is
+  widened
+
+## FastWork-required mode
+
+When the operator says to use FastWork, all worktree, temp, cache, and Rust build
+output must stay on the declared external build root. Do not silently fall back to the local disk.
+
+Required behavior:
+
+- verify the FastWork mount before starting implementation
+- set `TMPDIR` and `CARGO_TARGET_DIR` to FastWork for Rust validation or typed
+  binary builds
+- stop and report the mount blocker when FastWork is unavailable
+- record any tooling problem as issue-local evidence instead of working around
+  it invisibly
+
+## Validation Selection
+
+The fast lane changes how much proof is selected, not who owns lifecycle truth.
+The typed C-SDLC v2 remains the lifecycle authority.
+
+For fast-lane issues:
+
+1. Run the selector or issue-local VPP lane that matches the changed paths.
+2. Run one focused contract test that directly proves the policy or tool
+   invariant being changed.
+3. Run `git diff --check`.
+4. Record what was run and what was deliberately deferred in SOR truth.
+
+Do not use a fast-lane result to claim completion for:
+
+- runtime/product behavior
+- live provider behavior
+- release readiness
+- broad coverage health
+- external review remediation
+- milestone closeout
+
+## changed-state-only PR watching
+
+PR watchers and shepherds should report only changed state, blockers, or
+operator-actionable transitions. Repeating unchanged pending status burns
+operator attention and model budget without moving the work.
+
+Changed-state-only PR watching means:
+
+- report new check failures, conflicts, draft/ready transitions, review
+  requests, mergeability changes, and exact-head SHA changes
+- stay quiet for unchanged pending checks
+- stop failed runs promptly when the operator has authorized cancellation
+- hand off blockers to the right owner instead of narrating a wait loop
+
+Do not wait on GitHub when no action is possible. If checks are pending and no
+new information exists, preserve the watcher state and work on the next
+independent issue or return control to the operator.
+
+## Escalation And Stop Conditions
+
+Leave the fast lane and escalate when any of these appears:
+
+- touched paths include shared Rust, provider, runtime, security, publication,
+  closeout, or release-gate code
+- selector output is `escalated` or `release_gate_required`
+- the issue claim does not cover a touched path
+- review finds an unresolved behavioral risk
+- local proof is fixture-only for an integrated feature
+- FastWork or the declared build root is unavailable when required
+- GitHub truth contradicts local lifecycle state
+
+Escalation should be explicit: update the issue plan or route a follow-on issue
+rather than letting a tiny fix become an unbounded repair session.
+
+## Non-Claims
+
+This policy does not:
+
+- bypass typed C-SDLC v2
+- remove exact-head review before publication
+- make docs-only proof sufficient for runtime/product work
+- authorize raw GitHub lifecycle operations
+- authorize AWS or other paid infrastructure
+- make local green checks a substitute for required PR checks
+- permit local disk fallback when FastWork-required mode is active
+
+The goal is less waiting and less unnecessary ceremony for small fixes, while
+keeping every completion claim evidence-bound.

--- a/docs/tooling/VALIDATION_PLATFORM_ROUTING.md
+++ b/docs/tooling/VALIDATION_PLATFORM_ROUTING.md
@@ -4,6 +4,11 @@
 the validation platform scheduler. The routing contract explains which platform
 should run a selected validation profile and why other platforms are rejected.
 
+For small, low-risk fixes, pair this routing contract with
+[`DEVELOPER_THROUGHPUT_FAST_LANE.md`](DEVELOPER_THROUGHPUT_FAST_LANE.md) so the
+selected platform, focused proof, FastWork posture, and PR-watching behavior
+stay proportional to the changed surface.
+
 The manager does not launch paid cloud resources. It only emits dry-run routing
 truth and wrapper commands. Live AWS Spot or CodeBuild runs still require the
 platform wrapper's explicit live-run flag or workflow trigger.


### PR DESCRIPTION
Closes #5666

Adds a proportional developer throughput fast-lane policy for tiny docs/tooling/test fixes without weakening typed C-SDLC v2, exact-head review, runtime/product proof, or release-gate truth.

Changes:
- Add docs/tooling/DEVELOPER_THROUGHPUT_FAST_LANE.md with proportional issue classes, FastWork-required mode, changed-state-only PR watching, escalation rules, and non-claims.
- Link the policy from docs/tooling/VALIDATION_PLATFORM_ROUTING.md.
- Add adl/tools/test_developer_throughput_fast_lane.sh as a focused contract proof.

Validation:
- bash adl/tools/test_developer_throughput_fast_lane.sh
- git diff --check
- git diff --check origin/main...HEAD

Review:
- Subagent Sagan clean at scoped revision git-blake3:30e495fda450d10a4e29b0c57195f759224a7214:bf3cbab163693daa1084c8119b458a550c59032eea66798f753f22166e22d3e6 after fixing the initial placeholder design finding.
- Typed C-SDLC review recorded in .csdlc/issues/5666 generation 4.