### PR TITLE
[v0.91.8][provider] Add Anthropic Claude Opus 5 provider profile

### DIFF
--- a/.csdlc/evidence/5671/provider-build-focused.log
+++ b/.csdlc/evidence/5671/provider-build-focused.log
@@ -1,0 +1,1 @@
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.17s

--- a/.csdlc/evidence/5671/provider-profile-focused.log
+++ b/.csdlc/evidence/5671/provider-profile-focused.log
@@ -1,0 +1,583 @@
+
+running 179 tests
+test adl::tests::validate_provider_http_requires_endpoint ... ok
+test adl::tests::validate_provider_profile_rejects_empty_value ... ok
+test adl::tests::validate_provider_http_allows_loopback_plaintext_for_local_harnesses ... ok
+test adl::tests::validate_provider_http_rejects_plaintext_remote_endpoint ... ok
+test godel::ghb_loop::tests::ghb_loop_rejects_remote_provider_mismatch ... ok
+test instrumentation::action_log::tests::runtime_action_log_projects_policy_and_provider_events_without_raw_messages ... ok
+test long_lived_agent::tests::provider_result_summary_does_not_retain_sensitive_fields ... ok
+test model_identity::tests::hosted_provider_asserted_identity_does_not_require_digest ... ok
+test model_identity::tests::model_ref_and_provider_model_id_can_differ ... ok
+test execute::tests::execute_step_with_retry_does_not_retry_unknown_provider_setup_failure ... ok
+test agent_comms::tests::acip_coding_provider_boundary_adapter_rejects_worktree_lane_and_ref_drift ... ok
+test agent_comms::tests::acip_coding_provider_boundary_adapter_adapts_ok_provider_result_without_leaking_runtime_artifact ... ok
+test agent_comms::tests::acip_coding_provider_boundary_adapter_rejects_unsafe_provider_result_refs ... ok
+test agent_comms::tests::acip_coding_sample_contracts_cover_all_provider_lanes_and_output_modes ... ok
+test provider::http_family::tests::bedrock_provider_requires_agent_logic_profile_before_live_call ... ok
+test agent_comms::tests::acip_coding_provider_boundary_adapter_preserves_governed_refs_and_lower_route ... ok
+test model_proposal_benchmark::tests::model_proposal_benchmark_records_provider_model_conditions_truthfully ... ok
+test csm_resident_agents::tests::csm_shepherd_is_privileged_by_role_not_by_provider_bypass ... ok
+test provider::http_family::tests::anthropic_provider_complete_normalizes_empty_refusal_response ... ok
+test long_lived_agent::tests::pre_execution_admission_blocks_unsupported_workflow_before_provider_work ... ok
+test provider::http_family::tests::deepseek_provider_complete_records_chat_completion_request ... ok
+test csm_resident_agents::tests::csm_resident_agent_set_admits_shepherd_codex_and_ollama_through_provider_substrate ... ok
+test provider::http_family::tests::anthropic_provider_complete_records_output_and_version_header ... ok
+test provider::http_family::tests::deepseek_provider_rejects_missing_credentials_and_bad_response_shape ... ok
+test provider::tests::provider_mod_build_provider_dispatches_supported_native_and_compatibility_kinds ... ok
+test provider::tests::provider_mod_build_provider_rejects_unknown_kind_and_invalid_native_endpoint ... ok
+test provider::tests::provider_mod_cfg_numeric_helpers_cover_all_supported_and_rejected_types ... ok
+test provider::tests::provider_mod_complete_stream_default_buffers_mock_output ... ok
+test provider::tests::provider_mod_error_helpers_and_classification_are_stable ... ok
+test provider::tests::provider_mod_profile_endpoint_validation_allows_loopback_http_for_local_harnesses ... ok
+test provider::tests::provider_mod_profile_endpoint_validation_rejects_hostless_https ... ok
+test provider::tests::provider_mod_profile_endpoint_validation_rejects_loopback_prefix_confusion ... ok
+test provider::tests::provider_mod_profile_endpoint_validation_rejects_placeholder_and_invalid_hosts ... ok
+test provider::tests::provider_mod_profile_endpoint_validation_rejects_plain_http ... ok
+test provider::tests::provider_mod_provider_profile_registry_includes_first_class_claude_profiles ... ok
+test provider::tests::provider_mod_registry_keeps_expanded_vendor_identities_distinct ... ok
+test provider::tests::provider_mod_remote_retry_classification_distinguishes_deterministic_failures ... ok
+test provider::tests::provider_mod_timeout_secs_rejects_zero_and_uses_default_without_env ... ok
+test provider_adapter::tests::bedrock_error_sanitizer_removes_signed_aws_values ... ok
+test provider_adapter::tests::bedrock_profile_guard_rejects_default_profile ... ok
+test provider_adapter::tests::bedrock_request_body_uses_nova_messages_shape ... ok
+test provider_adapter::tests::claude_hosted_adapter_normalizes_empty_refusal_response ... ok
+test provider_adapter::tests::claude_hosted_adapter_returns_output_and_redacts_log ... ok
+test provider_adapter::tests::deepseek_hosted_adapter_returns_output_and_redacts_log ... ok
+test provider_adapter::tests::gemini_generate_url_does_not_embed_api_key ... ok
+test provider_adapter::tests::gemini_generate_url_rejects_invalid_endpoint_ref ... ok
+test provider::http_family::tests::http_provider_complete_and_helper_errors_cover_status_and_validation ... ok
+test provider_adapter::tests::gemini_hosted_adapter_returns_output_and_redacts_log ... ok
+test provider::http_family::tests::ollama_http_provider_complete_posts_to_generate_endpoint ... ok
+test provider::http_family::tests::ollama_http_provider_prefers_explicit_config_timeout_over_env ... ok
+test provider::http_family::tests::ollama_http_provider_rejects_invalid_explicit_timeout ... ok
+test provider_adapter::tests::hosted_gemini_adapter_sends_api_key_header_without_url_key ... ok
+test provider_adapter::tests::hosted_openai_adapter_returns_output_and_redacts_log ... ok
+test provider::http_family::tests::ollama_http_provider_rejects_missing_response_text ... ok
+test provider::http_family::tests::ollama_http_provider_rejects_zero_explicit_timeout ... ok
+test provider::http_family::tests::ollama_http_provider_uses_adl_timeout_secs_when_config_missing ... ok
+test provider::http_family::tests::ollama_http_provider_uses_default_timeout_when_env_missing ... ok
+test provider_adapter::tests::missing_hosted_key_is_normalized_without_network_call ... ok
+test provider_adapter::tests::ollama_bulkhead_is_scoped_per_endpoint_and_model ... ok
+test provider_adapter::tests::ollama_bulkhead_saturation_is_reported_as_local_runtime_busy ... ok
+test provider_adapter::tests::ollama_generate_url_rejects_invalid_endpoint_ref ... ok
+test provider_adapter::tests::ollama_invalid_endpoint_is_not_masked_by_busy_default_bulkhead ... ok
+test provider::http_family::tests::openai_provider_complete_records_output_and_invocation_artifact ... ok
+test provider_adapter::tests::ollama_url_helpers_normalize_base_and_api_endpoint_refs ... ok
+test provider_adapter::tests::omitted_output_token_budget_preserves_adapter_defaults ... ok
+test provider_adapter::tests::hosted_openai_timeout_is_reported_through_shared_timeout_layer ... ok
+test provider_adapter::tests::hosted_openai_stops_after_non_retryable_failure ... ok
+test provider_adapter::tests::hosted_openai_repeated_failures_open_provider_circuit ... ok
+test provider_adapter::tests::hosted_openai_reports_retry_budget_exhaustion_after_last_retryable_failure ... ok
+test provider_adapter::tests::hosted_openai_retries_retryable_failure_then_succeeds ... ok
+test provider_adapter::tests::hosted_openai_retry_flow_emits_reviewable_log_sequence ... ok
+test provider_adapter::tests::optional_output_token_budget_maps_to_provider_native_fields ... ok
+test provider_adapter::tests::preflight_failures_do_not_claim_circuit_trace ... ok
+test provider_adapter::tests::preflight_request_validation_failure_emits_valid_failed_result_shape ... ok
+test provider_adapter::tests::provider_credential_debug_redacts_secret_value ... ok
+test provider_adapter::tests::provider_endpoint_url_rejects_non_http_endpoint_refs ... ok
+test provider_adapter::tests::unsupported_hosted_provider_is_rejected_not_misrouted ... ok
+test provider_adapter::tests::zai_hosted_adapter_rejects_missing_key_without_network_call ... ok
+test provider::http_family::tests::openrouter_provider_complete_records_chat_completion_request ... ok
+test provider_adapter::tests::openai_output_array_shape_is_supported ... ok
+test provider_adapter::tests::openrouter_hosted_adapter_classifies_reasoning_only_output ... ok
+test provider_adapter_cli::tests::cli_run_writes_result_and_tail_log_for_normalized_failure ... ok
+test provider_adapter_cli::tests::normalize_observability_ref_prefers_repo_relative_and_redacts_absolute_paths ... ok
+test provider_adapter_cli::tests::normalize_observability_ref_preserves_bounded_uniqueness_for_same_basename ... ok
+test provider_communication::tests::failure_classifier_covers_hosted_and_local_operational_failures ... ok
+test provider_communication::tests::hosted_and_ollama_results_share_normalized_shape ... ok
+test provider_communication::tests::hosted_identity_is_provider_asserted_without_digest ... ok
+test provider_communication::tests::invalid_api_key_is_auth_error_not_missing_auth ... ok
+test provider_communication::tests::ollama_identity_is_pinned_only_with_digest ... ok
+test provider_communication::tests::provider_attempt_policy_maps_to_resilience_policy ... ok
+test provider_communication::tests::provider_failure_round_trips_through_shared_resilience_vocab ... ok
+test provider_communication::tests::provider_fault_classification_is_total_for_generic_provider_failures ... ok
+test provider_communication::tests::provider_fault_classification_redacts_sensitive_summary ... ok
+test provider_communication::tests::provider_fault_classification_uses_shared_resilience_vocab ... ok
+test provider_communication::tests::provider_run_logger_injects_request_and_artifact_refs_from_context ... ok
+test provider_communication::tests::provider_run_logger_writes_flushed_jsonl_without_prompt_or_secret_fields ... ok
+test provider_communication::tests::request_validation_rejects_empty_and_zero_policy_fields ... ok
+test provider_communication::tests::review_provider_request_fails_closed_without_scope_or_authority ... ok
+test provider_communication::tests::review_provider_request_validates_scope_authority_and_provider_request ... ok
+test provider_communication::tests::review_provider_result_preserves_findings_and_provider_failure_boundaries ... ok
+test provider_communication::tests::review_provider_result_rejects_findings_on_failed_or_passed_status ... ok
+test provider_communication::tests::review_provider_result_rejects_passed_status_when_provider_failed ... ok
+test provider_communication::tests::review_provider_result_transitively_rejects_malformed_provider_result ... ok
+test provider_communication::tests::url_query_api_keys_are_redacted_from_provider_failures ... ok
+test provider_communication::tests::utf8_diagnostics_truncate_without_panic ... ok
+test provider_extension_packaging::tests::provider_extension_packaging_binds_existing_provider_substrate ... ok
+test provider_extension_packaging::tests::provider_extension_packaging_exposes_reviewer_proof_hook ... ok
+test provider_extension_packaging::tests::provider_extension_packaging_keeps_security_extension_deferred ... ok
+test provider_native_tool_call_comparison::tests::provider_native_tool_call_comparison_artifact_path_is_repo_relative_and_bounded ... ok
+test provider_native_tool_call_comparison::tests::provider_native_tool_call_comparison_compatibility_profiles_do_not_report_native_tool_support ... ok
+test provider_native_tool_call_comparison::tests::provider_native_tool_call_comparison_covers_expected_provider_panel ... ok
+test provider_native_tool_call_comparison::tests::provider_native_tool_call_comparison_preserves_native_vs_unsupported_truth ... ok
+test provider_native_tool_call_comparison::tests::provider_native_tool_call_comparison_records_json_baseline_reference ... ok
+test provider_native_tool_call_comparison::tests::provider_native_tool_call_comparison_report_writer_emits_portable_json ... ok
+test provider_native_tool_call_comparison::tests::provider_native_tool_call_comparison_serializes_deterministically_without_host_paths ... ok
+test provider_native_tool_call_comparison::tests::provider_native_tool_call_comparison_splits_direct_native_from_compatibility_counts ... ok
+test provider_native_tool_call_comparison::tests::provider_native_tool_call_comparison_tracked_report_matches_generated_report ... ok
+test provider_substrate::tests::invocation_target_keeps_model_ref_distinct_from_provider_model_id ... ok
+test provider_substrate::tests::invocation_target_uses_model_override_as_stable_model_ref ... ok
+test provider_substrate::tests::provider_substrate_accepts_native_openai_anthropic_deepseek_openrouter_and_zai_kinds ... ok
+test provider_substrate::tests::provider_substrate_accepts_zai_profile_and_distinct_provider_model_id ... ok
+test provider_substrate::tests::provider_substrate_allows_explicit_native_override_for_generic_http_profiles ... ok
+test provider_substrate::tests::provider_substrate_honors_explicit_capability_overrides ... ok
+test provider_substrate::tests::provider_substrate_infers_first_class_claude_profile_vendor ... ok
+test provider_substrate::tests::provider_substrate_infers_openrouter_endpoint_vendor_and_preserves_model_id ... ok
+test provider_substrate::tests::provider_substrate_keeps_http_deepseek_profile_as_compatibility_lane ... ok
+test provider_substrate::tests::provider_substrate_keeps_local_ollama_cli_transport ... ok
+test provider_substrate::tests::provider_substrate_manifest_is_sorted_and_stable ... ok
+test provider_substrate::tests::provider_substrate_marks_deepseek_ollama_for_semantic_fallback ... ok
+test provider_substrate::tests::provider_substrate_marks_generic_http_profiles_as_compatibility_by_default ... ok
+test provider_substrate::tests::provider_substrate_marks_gpt_oss_ollama_as_tool_capable ... ok
+test provider_substrate::tests::provider_substrate_preserves_expanded_vendor_and_model_identity ... ok
+test provider_substrate::tests::provider_substrate_separates_http_vendor_and_transport ... ok
+test provider_substrate::tests::provider_substrate_uses_http_transport_for_ollama_with_endpoint ... ok
+test provider_adapter::tests::openrouter_hosted_adapter_prefers_observed_provider_model_identity ... ok
+test remote_exec::tests::execute_request_rejects_invalid_provider_spec ... ok
+test resilience::tests::provider_fault_classifier_covers_remaining_provider_fault_branches ... ok
+test resilience::tests::provider_fault_classifier_emits_operator_gated_auth_missing ... ok
+test resilience::tests::provider_fault_classifier_emits_retryable_timeout ... ok
+test resilience::tests::provider_fault_summary_normalizes_whitespace_and_truncates_long_messages ... ok
+test resilience::tests::provider_fault_summary_redacts_secret_like_content ... ok
+test resilience::tests::representative_provider_flow_composes_retry_rate_limit_timeout_breaker_and_fallback ... ok
+test resolve::tests::resolve_provider_falls_back_to_single_provider ... ok
+test resolve::tests::resolve_provider_prefers_agent_provider ... ok
+test resolve::wp02_followup_tests::resolve_provider_does_not_choose_when_multiple_providers_exist ... ok
+test provider_adapter::tests::hosted_openai_half_open_success_closes_provider_circuit ... ok
+test provider_adapter::tests::openrouter_hosted_adapter_returns_output_and_redacts_log ... ok
+test provider_adapter::tests::openrouter_hosted_adapter_supports_array_content_shape ... ok
+test provider_adapter::tests::openrouter_hosted_adapter_surfaces_error_envelope_on_success_status ... ok
+test runtime_aws_signal::tests::live_provider_helpers_fail_closed_before_unconfigured_provider_calls ... ok
+test runtime_v2::tests::godel_agent_runtime::runtime_v2_godel_agent_runtime_rejects_launch_plan_provider_rebinding ... ok
+test runtime_v2::tests::godel_agent_runtime::runtime_v2_godel_agent_runtime_rejects_provider_and_replay_mismatch ... ok
+test scheduler::tests::combined_provider_route_accepts_known_provider_family_aliases_for_same_model ... ok
+test scheduler::tests::combined_provider_route_rejects_model_suitability_identity_mismatch ... ok
+test scheduler::tests::role_provider_context_rejects_assignment_without_policy ... ok
+test scheduler::tests::role_provider_context_rejects_duplicate_task_assignment ... ok
+test scheduler::tests::role_provider_context_rejects_policy_without_eligible_route ... ok
+test scheduler::tests::role_provider_context_rejects_untracked_provider_profile_ref ... ok
+test scheduler::tests::role_provider_context_requires_provider_route_bundle_schema ... ok
+test scheduler::tests::role_provider_context_selects_first_eligible_tracked_profile_for_scheduler_decision ... ok
+test trace_schema_v1::tests::validate_trace_event_envelope_v1_rejects_missing_provider_on_model_invocation ... ok
+test uts_acc_multi_model_benchmark::tests::is_retryable_provider_error_matches_expected_patterns ... ok
+test uts_acc_multi_model_benchmark::tests::provider_complete_with_retries_fails_fast_for_non_retryable_error ... ok
+test uts_acc_multi_model_benchmark::tests::provider_complete_with_retries_stops_on_retryable_error_and_succeeds ... ok
+test uts_acc_multi_model_benchmark::tests::provider_completion_error_is_recorded_as_unusable_case ... ok
+test provider_adapter::tests::zai_hosted_adapter_returns_output_observed_model_and_redacts_log ... ok
+test provider::http_family::tests::openrouter_provider_rejects_missing_credentials_and_bad_response_shape ... ok
+test remote_exec::tests::execute_request_maps_provider_runtime_error ... ok
+test provider_adapter_cli::tests::cli_run_emits_heartbeat_and_timeout_diagnostics_for_slow_provider_calls ... ok
+test provider_adapter_cli::tests::cli_run_records_failed_terminal_event_when_result_write_fails ... ok
+test provider_adapter::tests::ollama_adapter_returns_output_and_redacts_log ... ok
+test provider_adapter::tests::ollama_missing_model_is_not_reported_as_busy ... ok
+test provider::http_family::tests::zai_provider_rejects_missing_credentials_and_bad_response_shape ... ok
+test runtime_aws_signal::tests::csm_governed_notice_signal_blocks_live_channels_before_provider_calls ... ok
+test runtime_aws_signal::tests::csm_notice_control_plane_live_block_matrix_avoids_provider_calls ... ok
+test runtime_aws_signal::tests::csm_notice_cloudwatch_live_block_matrix_avoids_provider_calls ... ok
+test runtime_aws_signal::tests::csm_notice_sns_live_block_matrix_avoids_provider_calls ... ok
+test provider::http_family::tests::zai_provider_sends_chat_completion_request_and_records_sanitized_artifact ... ok
+test uts_acc_multi_model_benchmark::tests::run_benchmark_with_stubbed_provider_executes_evaluated_model ... ok
+
+test result: ok. 179 passed; 0 failed; 0 ignored; 0 measured; 1744 filtered out; finished in 4.63s
+
+
+running 14 tests
+test cli::provider_cmd::tests::provider_setup_supports_all_declared_families ... ok
+test cli::provider_cmd::tests::real_provider_uses_repo_root_for_default_output ... ok
+Initialized empty Git repository in /private/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T/adl-provider-subcommands-1785035491101812000/.git/
+test cli::provider_cmd::tests::provider_requires_subcommand_and_rejects_unknown_subcommand ... ok
+Initialized empty Git repository in /private/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T/adl-identity-provider-extension-packaging-1785035491101818000/.git/
+Initialized empty Git repository in /private/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T/adl-provider-help-1785035491101806000/.git/
+test cli::provider_cmd::tests::provider_help_paths_succeed ... ok
+Initialized empty Git repository in /private/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T/adl-provider-claude-1785035491101942000/.git/
+Initialized empty Git repository in /private/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T/adl-provider-claude-opus-5-1785035491101947000/.git/
+Initialized empty Git repository in /private/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T/adl-provider-bad-args-1785035491101923000/.git/
+Initialized empty Git repository in /private/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T/adl-provider-bedrock-1785035491101938000/.git/
+Initialized empty Git repository in /private/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T/adl-provider-unknown-family-1785035491101865000/.git/
+test cli::provider_cmd::tests::provider_setup_validates_setup_args ... ok
+test cli::provider_cmd::tests::provider_setup_rejects_unknown_family ... ok
+Initialized empty Git repository in /private/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T/adl-provider-openrouter-model-override-1785035491101924000/.git/
+test cli::identity_cmd::tests::skill_contracts::identity_provider_extension_packaging_writes_contract_json ... ok
+Initialized empty Git repository in /private/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T/adl-identity-provider-extension-packaging-errors-1785035491101792000/.git/
+Initialized empty Git repository in /private/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T/adl-provider-out-force-1785035491101886000/.git/
+test cli::identity_cmd::tests::skill_contracts::identity_provider_extension_packaging_validates_unknown_args_and_missing_out_value ... ok
+Initialized empty Git repository in /private/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T/adl-provider-chatgpt-1785035491101929000/.git/
+test cli::provider_cmd::tests::provider_setup_writes_expected_bundle_for_claude ... ok
+test cli::provider_cmd::tests::provider_setup_writes_expected_bundle_for_claude_opus_5 ... ok
+test cli::provider_cmd::tests::provider_setup_writes_bedrock_account_pin_material ... ok
+test cli::provider_cmd::tests::provider_setup_supports_model_override_for_openrouter ... ok
+test cli::provider_cmd::tests::provider_setup_writes_expected_bundle_for_chatgpt ... ok
+test cli::provider_cmd::tests::provider_setup_supports_explicit_out_and_force ... ok
+
+test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 208 filtered out; finished in 0.08s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 51 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s
+
+
+running 4 tests
+test tests::demo_v0912_provider_native_tool_call_comparison_resolve_out_path_defaults_to_tracked_artifact_path ... ok
+test tests::demo_v0912_provider_native_tool_call_comparison_resolve_out_path_uses_explicit_argument ... ok
+test tests::demo_v0912_provider_native_tool_call_comparison_write_report_adds_context_on_failure ... ok
+test tests::demo_v0912_provider_native_tool_call_comparison_write_report_creates_expected_json_artifact ... ok
+
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 9 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+
+running 4 tests
+test validate_rejects_unsupported_provider_kind ... ok
+test validate_rejects_profile_with_explicit_provider_fields ... ok
+test validate_accepts_provider_profile_without_explicit_provider_fields ... ok
+test validate_accepts_native_openai_and_anthropic_provider_kinds ... ok
+
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 26 filtered out; finished in 0.00s
+
+
+running 3 tests
+test godel::godel_ghb_proof_validates_required_and_provider_args ... ok
+test basics::print_plan_v0_3_remote_provider_demo_works ... ok
+test instrument_and_cli::run_flag_executes_fixture_with_mock_provider_and_writes_outputs ... ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 105 filtered out; finished in 0.14s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 25 filtered out; finished in 0.00s
+
+
+running 3 tests
+test run_flows::run_honors_agent_model_over_provider_model ... ok
+test runtime_artifacts::artifact_failures::run_surfaces_provider_failure_stderr ... ok
+test runtime_artifacts::run_state::run_status_failure_kind_maps_timeout_without_raw_provider_error_text ... ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 74 filtered out; finished in 1.16s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 8 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+
+running 3 tests
+test instrument_provider_substrate_schema_rejects_extra_args ... ok
+test instrument_provider_substrate_requires_path ... ok
+test instrument_provider_substrate_rejects_extra_args ... ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.01s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s
+
+
+running 1 test
+test build_provider_accepts_local_ollama_kind ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+
+
+running 1 test
+test build_provider_builds_mock_provider_and_echoes_prompt ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s
+
+
+running 40 tests
+test construction::build_provider_rejects_unknown_kind ... ok
+test construction::build_provider_builds_mock_provider_and_echoes_prompt ... ok
+test construction::build_provider_builds_ollama_provider ... ok
+test http_family::bedrock_provider_builds_without_network_and_preserves_model_id ... ok
+test http_family::http_provider_rejects_missing_endpoint ... ok
+test http_family::http_provider_accepts_https_endpoint ... ok
+test http_family::http_provider_rejects_non_bearer_auth_type ... ok
+test http_family::http_provider_supports_timeout_secs_string_and_rejects_negative_number ... ok
+test http_family::http_provider_rejects_non_object_headers_and_non_string_values ... ok
+test http_family::http_provider_rejects_plaintext_remote_endpoint ... ok
+test http_family::http_provider_4xx_is_non_retryable ... ok
+test http_family::http_provider_missing_auth_env_var ... ok
+test profiles::expand_provider_profiles_accepts_bedrock_nova_lite_profile ... ok
+test profiles::expand_provider_profiles_accepts_bedrock_nova_pro_inference_profile ... ok
+test profiles::expand_provider_profiles_accepts_chatgpt_profile_with_endpoint_override ... ok
+test profiles::expand_provider_profiles_accepts_claude_profile_with_endpoint_override ... ok
+test profiles::expand_provider_profiles_accepts_http_profile_with_endpoint_override ... ok
+test profiles::expand_provider_profiles_accepts_zai_glm5_profile ... ok
+test profiles::expand_provider_profiles_builds_claude_opus_5_anthropic_provider ... ok
+test profiles::expand_provider_profiles_is_byte_stable_across_runs ... ok
+test profiles::expand_provider_profiles_rejects_http_profile_without_endpoint_override ... ok
+test profiles::expand_provider_profiles_rejects_profile_with_explicit_fields ... ok
+test profiles::expand_provider_profiles_rejects_unknown_profile ... ok
+test profiles::expand_provider_profiles_rejects_vendor_identity_override ... ok
+test profiles::provider_profile_names_include_chatgpt_family ... ok
+test profiles::provider_profile_names_include_claude_family ... ok
+test profiles::provider_profiles_registry_is_deterministic_and_has_at_least_twelve_profiles ... ok
+test http_family::http_provider_happy_path ... ok
+test http_family::anthropic_provider_translates_native_response ... ok
+test http_family::http_provider_long_error_body_is_truncated_deterministically ... ok
+test http_family::http_provider_non_200_response ... ok
+test http_family::http_provider_rejects_json_without_output_field ... ok
+test http_family::http_provider_timeout ... ok
+test http_family::openai_provider_translates_native_response ... ok
+test http_family::native_provider_missing_auth_env_is_sanitized ... ok
+test http_family::zai_provider_translates_native_response_through_build_provider ... ok
+test process::provider_complete_times_out_with_env_override ... ok
+test process::provider_complete_surfaces_stderr_on_failure ... ok
+test process::provider_complete_rejects_invalid_timeout_env ... ok
+test process::provider_complete_uses_mock_binary_success ... ok
+
+test result: ok. 40 passed; 0 failed; 0 ignored; 0 measured; 9 filtered out; finished in 3.14s
+
+
+running 1 test
+test build_provider_accepts_remote_ollama_http_transport ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.13s
+
+
+running 4 tests
+test resolve_run_rejects_unknown_provider_profile ... ok
+test resolve_sets_provider_none_when_agent_provider_is_empty_string ... ok
+test resolve_provider_selection_uses_agent_provider ... ok
+test resolve_run_expands_provider_profile_deterministically ... ok
+
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out; finished in 0.00s
+
+
+running 1 test
+test strict_rejects_unknown_provider_field ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 18 filtered out; finished in 0.01s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 13 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s
+
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.22s
+     Running unittests src/lib.rs (adl/target/debug/deps/adl-a34f9e047593d439)
+     Running unittests src/main.rs (adl/target/debug/deps/adl-47d9eadb07f18786)
+     Running unittests src/bin/adl_aws_remote_validation.rs (adl/target/debug/deps/adl_aws_remote_validation-5430f4eb5460f7b9)
+     Running unittests src/bin/demo_adl_gws_context_mirror.rs (adl/target/debug/deps/adl_gws_context_mirror-aec95401e282dd2e)
+     Running unittests src/bin/adl_process.rs (adl/target/debug/deps/adl_process-e6d156f1c370e078)
+     Running unittests tools/adl_provider_adapter.rs (adl/target/debug/deps/adl_provider_adapter-7f63c77414ef5bc8)
+     Running unittests src/bin/adl_remote.rs (adl/target/debug/deps/adl_remote-c6e443c0dc6818e4)
+     Running unittests src/bin/adl_review.rs (adl/target/debug/deps/adl_review-83fb1cb4567ed411)
+     Running unittests src/bin/adl_runtime.rs (adl/target/debug/deps/adl_runtime-de34a7fdab3bd9cc)
+     Running unittests src/bin/csm.rs (adl/target/debug/deps/csm-17cf2752c95c5305)
+     Running unittests src/bin/csmctl.rs (adl/target/debug/deps/csmctl-1f9b86effc13df6c)
+     Running unittests src/bin/demo_adl_gws_native_drive_sync.rs (adl/target/debug/deps/demo_adl_gws_native_drive_sync-42e58578da226015)
+     Running unittests src/bin/demo_v086_candidate_selection.rs (adl/target/debug/deps/demo_v086_candidate_selection-0e942c728e5fab89)
+     Running unittests src/bin/demo_v086_fast_slow.rs (adl/target/debug/deps/demo_v086_fast_slow-4fcd055e298145f6)
+     Running unittests src/bin/demo_v086_freedom_gate.rs (adl/target/debug/deps/demo_v086_freedom_gate-ff1d20a0b0740853)
+     Running unittests src/bin/demo_v086_review_surface.rs (adl/target/debug/deps/demo_v086_review_surface-1cb2f170f0728ecf)
+     Running unittests src/bin/demo_v0905_local_gemma_model_evaluation.rs (adl/target/debug/deps/demo_v0905_local_gemma_model_evaluation-6bb60af7283732de)
+     Running unittests src/bin/demo_v0905_model_proposal_benchmark.rs (adl/target/debug/deps/demo_v0905_model_proposal_benchmark-d358a2c180267732)
+     Running unittests src/bin/demo_v0911_capability_aptitude_testing.rs (adl/target/debug/deps/demo_v0911_capability_aptitude_testing-2b705b4232815572)
+     Running unittests src/bin/demo_v0912_gws_live_capability_execution_surface.rs (adl/target/debug/deps/demo_v0912_gws_live_capability_execution_surface-f621c3762583c116)
+     Running unittests src/bin/demo_v0912_gws_live_content_card_roundtrip.rs (adl/target/debug/deps/demo_v0912_gws_live_content_card_roundtrip-c5b3f6eceb319f1c)
+     Running unittests src/bin/demo_v0912_gws_live_safety_package.rs (adl/target/debug/deps/demo_v0912_gws_live_safety_package-44eba7608ba2cea4)
+     Running unittests src/bin/demo_v0912_provider_native_tool_call_comparison.rs (adl/target/debug/deps/demo_v0912_provider_native_tool_call_comparison-dc30fd474931db92)
+     Running unittests src/bin/demo_v0912_rust_native_gws_adapter_boundary.rs (adl/target/debug/deps/demo_v0912_rust_native_gws_adapter_boundary-6922e092478c0298)
+     Running unittests src/bin/demo_v0912_speculative_decoding_prototype.rs (adl/target/debug/deps/demo_v0912_speculative_decoding_prototype-423a3f01a41dc8c5)
+     Running unittests src/bin/demo_v0912_uts_acc_multi_model_benchmark.rs (adl/target/debug/deps/demo_v0912_uts_acc_multi_model_benchmark-e83ec69069fee067)
+     Running unittests src/bin/demo_v0917_dspark_speculative_decoding_evaluation.rs (adl/target/debug/deps/demo_v0917_dspark_speculative_decoding_evaluation-5036ff7d4b2417f0)
+     Running unittests src/bin/run_v0916_acip_aee_memory_integration.rs (adl/target/debug/deps/run_v0916_acip_aee_memory_integration-fd5dc359e9da5b62)
+     Running unittests src/bin/run_v0916_integrated_runtime_soak.rs (adl/target/debug/deps/run_v0916_integrated_runtime_soak-6dcf27c5b9fb88fb)
+     Running unittests src/bin/run_v0916_runtime_failure_injection.rs (adl/target/debug/deps/run_v0916_runtime_failure_injection-5ae7edd8cc3736e3)
+     Running unittests src/bin/run_v0917_integrated_resilience_failure_injection.rs (adl/target/debug/deps/run_v0917_integrated_resilience_failure_injection-762eea8c6a31a70e)
+     Running unittests src/bin/run_wp08_acip_sns_live_proof.rs (adl/target/debug/deps/run_wp08_acip_sns_live_proof-27cca7777aa9ef0e)
+     Running unittests src/bin/run_wp12_acip_websocket_transport_proof.rs (adl/target/debug/deps/run_wp12_acip_websocket_transport_proof-6a2d2d2de6a2e724)
+     Running tests/adl_tests.rs (adl/target/debug/deps/adl_tests-cb1ae62a8ab96003)
+     Running tests/cli_smoke.rs (adl/target/debug/deps/cli_smoke-b42b247a603b6789)
+     Running tests/demo_tests.rs (adl/target/debug/deps/demo_tests-07345dcd8684a2d6)
+     Running tests/execute_tests.rs (adl/target/debug/deps/execute_tests-78be7770e5763d00)
+     Running tests/file_inputs.rs (adl/target/debug/deps/file_inputs-07837176deefe233)
+     Running tests/helpers.rs (adl/target/debug/deps/helpers-ea041bfc601f782b)
+     Running tests/instrument_tests.rs (adl/target/debug/deps/instrument_tests-02a621649255cb8b)
+     Running tests/local_gemma_model_evaluation_demo_tests.rs (adl/target/debug/deps/local_gemma_model_evaluation_demo_tests-78fca27000aa6444)
+     Running tests/local_ollama_provider_tests.rs (adl/target/debug/deps/local_ollama_provider_tests-8598746831efe704)
+     Running tests/mock_provider_tests.rs (adl/target/debug/deps/mock_provider_tests-a1918438396abf04)
+     Running tests/model_proposal_benchmark_demo_tests.rs (adl/target/debug/deps/model_proposal_benchmark_demo_tests-4e9ef2ae56e3b27a)
+     Running tests/obsmem_validation_tests.rs (adl/target/debug/deps/obsmem_validation_tests-8e4f5488980f6c90)
+     Running tests/provider_tests.rs (adl/target/debug/deps/provider_tests-5d89ff56561acd3e)
+     Running tests/remote_ollama_provider_tests.rs (adl/target/debug/deps/remote_ollama_provider_tests-dce76ef2f55aac42)
+     Running tests/resolve_tests.rs (adl/target/debug/deps/resolve_tests-7a8cf5dceb221ff8)
+     Running tests/schema_tests.rs (adl/target/debug/deps/schema_tests-09385c40bb2c491d)
+     Running tests/signing_tests.rs (adl/target/debug/deps/signing_tests-368ba90e783e5d7c)
+     Running tests/trace_tests.rs (adl/target/debug/deps/trace_tests-e4120683079051c1)
+     Running tests/uts_acc_multi_model_benchmark_demo_tests.rs (adl/target/debug/deps/uts_acc_multi_model_benchmark_demo_tests-48829b42fb78e4c9)

--- a/.csdlc/issues/5671/audit.jsonl
+++ b/.csdlc/issues/5671/audit.jsonl
@@ -1,0 +1,5 @@
+{"sequence":1,"generation":0,"actor":"codex:5671-execution","reason":"initialize issue record and all six cards","operation":"bootstrap"}
+{"sequence":2,"generation":1,"actor":"codex:5671-preparation-review","reason":"approve completed issue design","operation":"approve_design"}
+{"sequence":3,"generation":1,"actor":"codex:5671-execution","reason":"bind branch/worktree and activate claim","operation":"bind"}
+{"sequence":4,"generation":1,"actor":"codex:5671-execution","reason":"Add the focused integration test and setup usage surface to the declared issue scope","operation":"{\"add_protected_paths\":[\"adl/tests/provider_tests/profiles.rs\",\"adl/src/cli/usage.rs\",\"adl/src/provider/http_family/tests.rs\"],\"operation\":\"amend_claim_scope\"}"}
+{"sequence":5,"generation":2,"actor":"codex:5671-execution","reason":"atomically record execution, validation, and implemented phase","operation":"finalize_implementation"}

--- a/.csdlc/issues/5671/audit.jsonl
+++ b/.csdlc/issues/5671/audit.jsonl
@@ -7,3 +7,4 @@
 {"sequence":7,"generation":3,"actor":"codex:5671-subagent-review","reason":"atomically record assigned review evidence and SRP projection","operation":"record_review"}
 {"sequence":8,"generation":4,"actor":"codex:5671-execution","reason":"Advance the exact reviewed implementation into the publication phase","operation":"{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"}
 {"sequence":9,"generation":5,"actor":"codex:5671-execution","reason":"atomically record observed GitHub publication and SOR projection","operation":"record_publication"}
+{"sequence":10,"generation":6,"actor":"codex:5671-execution","reason":"atomically record observed GitHub publication and SOR projection","operation":"record_publication"}

--- a/.csdlc/issues/5671/audit.jsonl
+++ b/.csdlc/issues/5671/audit.jsonl
@@ -3,3 +3,7 @@
 {"sequence":3,"generation":1,"actor":"codex:5671-execution","reason":"bind branch/worktree and activate claim","operation":"bind"}
 {"sequence":4,"generation":1,"actor":"codex:5671-execution","reason":"Add the focused integration test and setup usage surface to the declared issue scope","operation":"{\"add_protected_paths\":[\"adl/tests/provider_tests/profiles.rs\",\"adl/src/cli/usage.rs\",\"adl/src/provider/http_family/tests.rs\"],\"operation\":\"amend_claim_scope\"}"}
 {"sequence":5,"generation":2,"actor":"codex:5671-execution","reason":"atomically record execution, validation, and implemented phase","operation":"finalize_implementation"}
+{"sequence":6,"generation":2,"actor":"codex:5671-execution","reason":"assign bounded exact-revision review","operation":"assign_review"}
+{"sequence":7,"generation":3,"actor":"codex:5671-subagent-review","reason":"atomically record assigned review evidence and SRP projection","operation":"record_review"}
+{"sequence":8,"generation":4,"actor":"codex:5671-execution","reason":"Advance the exact reviewed implementation into the publication phase","operation":"{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"}
+{"sequence":9,"generation":5,"actor":"codex:5671-execution","reason":"atomically record observed GitHub publication and SOR projection","operation":"record_publication"}

--- a/.csdlc/issues/5671/cards/sip.md
+++ b/.csdlc/issues/5671/cards/sip.md
@@ -1,0 +1,41 @@
+# Structured Intent Prompt
+
+Template: 1.0.0
+
+Issue: 5671
+
+Repository: danielbaustin/agent-design-language
+
+Card: sip
+
+Status: ready
+
+## Goal
+
+Add a first-class Claude Opus 5 provider profile and setup route using the existing Rust-native Anthropic Messages adapter.
+
+## Required Outcome
+
+Profile expansion, setup generation, and focused mocked adapter proof for claude-opus-5.
+
+## Scope
+
+- adl/src/provider/profiles.rs
+- adl/src/provider/mod.rs
+- adl/src/cli/provider_cmd.rs
+
+## Authority
+
+- The change defines local provider routing only; it does not provision credentials, call Anthropic live, or approve release policy.
+
+## Assumptions
+
+- none
+
+## Operator Constraints
+
+- never write main
+- use typed v2 binaries
+- no raw gh
+- no AWS
+- no direct card/state edits

--- a/.csdlc/issues/5671/cards/sip.values.json
+++ b/.csdlc/issues/5671/cards/sip.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][provider] Add Anthropic Claude Opus 5 provider profile",
     "slug": "anthropic-claude-opus-5-provider",
     "version": "v0.91.8",
-    "generation": 2
+    "generation": 5
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5671/cards/sip.values.json
+++ b/.csdlc/issues/5671/cards/sip.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][provider] Add Anthropic Claude Opus 5 provider profile",
     "slug": "anthropic-claude-opus-5-provider",
     "version": "v0.91.8",
-    "generation": 5
+    "generation": 6
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5671/cards/sip.values.json
+++ b/.csdlc/issues/5671/cards/sip.values.json
@@ -1,0 +1,36 @@
+{
+  "identity": {
+    "schema_version": "1.0.0",
+    "template_version": "1.0.0",
+    "issue": 5671,
+    "repository": "danielbaustin/agent-design-language",
+    "title": "[v0.91.8][provider] Add Anthropic Claude Opus 5 provider profile",
+    "slug": "anthropic-claude-opus-5-provider",
+    "version": "v0.91.8",
+    "generation": 2
+  },
+  "status": "ready",
+  "content": {
+    "card_kind": "sip",
+    "values": {
+      "goal": "Add a first-class Claude Opus 5 provider profile and setup route using the existing Rust-native Anthropic Messages adapter.",
+      "required_outcome": "Profile expansion, setup generation, and focused mocked adapter proof for claude-opus-5.",
+      "declared_scope": [
+        "adl/src/provider/profiles.rs",
+        "adl/src/provider/mod.rs",
+        "adl/src/cli/provider_cmd.rs"
+      ],
+      "authority_boundary": [
+        "The change defines local provider routing only; it does not provision credentials, call Anthropic live, or approve release policy."
+      ],
+      "initial_assumptions": [],
+      "operator_constraints": [
+        "never write main",
+        "use typed v2 binaries",
+        "no raw gh",
+        "no AWS",
+        "no direct card/state edits"
+      ]
+    }
+  }
+}

--- a/.csdlc/issues/5671/cards/sor.md
+++ b/.csdlc/issues/5671/cards/sor.md
@@ -1,0 +1,75 @@
+# Structured Output Record
+
+Template: 1.0.0
+
+Issue: 5671
+
+Repository: danielbaustin/agent-design-language
+
+Card: sor
+
+Status: pre_phase
+
+## Summary
+
+Implemented Claude Opus 5 profile, setup template, and focused provider proof.
+
+## Artifacts
+
+- .csdlc/prepared/issues/5671/validation-evidence/provider-profile-focused.log
+- .csdlc/prepared/issues/5671/validation-evidence/provider-build-focused.log
+
+## Execution
+
+- adl/src/provider/profiles.rs
+- adl/src/provider/mod.rs
+- adl/src/provider/http_family/tests.rs
+- adl/src/cli/provider_cmd.rs
+- adl/src/cli/usage.rs
+- adl/tests/provider_tests/profiles.rs
+
+## Validation
+
+[
+  {
+    "command": [
+      "cargo",
+      "check",
+      "--manifest-path",
+      "adl/Cargo.toml"
+    ],
+    "purpose": "Compile the ADL crate after the provider change",
+    "outcome": "passed",
+    "evidence_ref": "provider-build-focused.log"
+  },
+  {
+    "command": [
+      "cargo",
+      "test",
+      "--manifest-path",
+      "adl/Cargo.toml",
+      "provider_"
+    ],
+    "purpose": "Run the focused provider test suite for Opus 5",
+    "outcome": "passed",
+    "evidence_ref": "provider-profile-focused.log"
+  }
+]
+
+## Integration
+
+not_started
+
+## Publication
+
+Publication: not_published
+
+Merge: not_merged
+
+## Closeout
+
+not_started
+
+## Follow Ups
+
+- none

--- a/.csdlc/issues/5671/cards/sor.md
+++ b/.csdlc/issues/5671/cards/sor.md
@@ -58,11 +58,11 @@ Implemented Claude Opus 5 profile, setup template, and focused provider proof.
 
 ## Integration
 
-not_started
+pr_open
 
 ## Publication
 
-Publication: not_published
+Publication: draft
 
 Merge: not_merged
 

--- a/.csdlc/issues/5671/cards/sor.values.json
+++ b/.csdlc/issues/5671/cards/sor.values.json
@@ -1,0 +1,61 @@
+{
+  "identity": {
+    "schema_version": "1.0.0",
+    "template_version": "1.0.0",
+    "issue": 5671,
+    "repository": "danielbaustin/agent-design-language",
+    "title": "[v0.91.8][provider] Add Anthropic Claude Opus 5 provider profile",
+    "slug": "anthropic-claude-opus-5-provider",
+    "version": "v0.91.8",
+    "generation": 2
+  },
+  "status": "pre_phase",
+  "content": {
+    "card_kind": "sor",
+    "values": {
+      "summary": "Implemented Claude Opus 5 profile, setup template, and focused provider proof.",
+      "actual_changes": [
+        "adl/src/provider/profiles.rs",
+        "adl/src/provider/mod.rs",
+        "adl/src/provider/http_family/tests.rs",
+        "adl/src/cli/provider_cmd.rs",
+        "adl/src/cli/usage.rs",
+        "adl/tests/provider_tests/profiles.rs"
+      ],
+      "artifacts": [
+        ".csdlc/prepared/issues/5671/validation-evidence/provider-profile-focused.log",
+        ".csdlc/prepared/issues/5671/validation-evidence/provider-build-focused.log"
+      ],
+      "actual_validation": [
+        {
+          "command": [
+            "cargo",
+            "check",
+            "--manifest-path",
+            "adl/Cargo.toml"
+          ],
+          "purpose": "Compile the ADL crate after the provider change",
+          "outcome": "passed",
+          "evidence_ref": "provider-build-focused.log"
+        },
+        {
+          "command": [
+            "cargo",
+            "test",
+            "--manifest-path",
+            "adl/Cargo.toml",
+            "provider_"
+          ],
+          "purpose": "Run the focused provider test suite for Opus 5",
+          "outcome": "passed",
+          "evidence_ref": "provider-profile-focused.log"
+        }
+      ],
+      "integration_state": "not_started",
+      "publication_state": "not_published",
+      "merge_state": "not_merged",
+      "closeout_state": "not_started",
+      "follow_ups": []
+    }
+  }
+}

--- a/.csdlc/issues/5671/cards/sor.values.json
+++ b/.csdlc/issues/5671/cards/sor.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][provider] Add Anthropic Claude Opus 5 provider profile",
     "slug": "anthropic-claude-opus-5-provider",
     "version": "v0.91.8",
-    "generation": 2
+    "generation": 5
   },
   "status": "pre_phase",
   "content": {
@@ -51,8 +51,8 @@
           "evidence_ref": "provider-profile-focused.log"
         }
       ],
-      "integration_state": "not_started",
-      "publication_state": "not_published",
+      "integration_state": "pr_open",
+      "publication_state": "draft",
       "merge_state": "not_merged",
       "closeout_state": "not_started",
       "follow_ups": []

--- a/.csdlc/issues/5671/cards/sor.values.json
+++ b/.csdlc/issues/5671/cards/sor.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][provider] Add Anthropic Claude Opus 5 provider profile",
     "slug": "anthropic-claude-opus-5-provider",
     "version": "v0.91.8",
-    "generation": 5
+    "generation": 6
   },
   "status": "pre_phase",
   "content": {

--- a/.csdlc/issues/5671/cards/spp.md
+++ b/.csdlc/issues/5671/cards/spp.md
@@ -1,0 +1,96 @@
+# Structured Planning Prompt
+
+Template: 1.0.0
+
+Issue: 5671
+
+Repository: danielbaustin/agent-design-language
+
+Card: spp
+
+Status: ready
+
+## Summary
+
+Add the canonical Claude Opus 5 profile and setup route on the existing Rust Anthropic adapter, prove it with focused mocks, review the exact head, and publish a draft PR.
+
+## Plan
+
+Revision 1
+
+## Steps
+
+[
+  {
+    "id": "S1",
+    "action": "Bind the issue worktree and normalize the six lifecycle cards",
+    "acceptance_ids": [
+      "AC-1",
+      "AC-2",
+      "AC-3"
+    ],
+    "status": "pending"
+  },
+  {
+    "id": "S2",
+    "action": "Implement profile expansion, setup generation, and focused mock proof",
+    "acceptance_ids": [
+      "AC-1",
+      "AC-2",
+      "AC-3",
+      "AC-4"
+    ],
+    "status": "pending"
+  },
+  {
+    "id": "S3",
+    "action": "Run focused validation, exact-head review, and publish a draft PR",
+    "acceptance_ids": [
+      "AC-5"
+    ],
+    "status": "pending"
+  }
+]
+
+## Invariants
+
+- Existing Claude profiles remain compatible
+- Anthropic credentials stay on ANTHROPIC_API_KEY
+- No live provider call is required
+- main remains untouched
+
+## Risks
+
+- Routing Opus 5 through generic HTTP would lose Anthropic request semantics
+- setup family drift
+- unsupported model id claims
+
+## Estimates
+
+{
+  "elapsed_seconds": 7200,
+  "total_tokens": 40000,
+  "validation_seconds": 1200
+}
+
+## Design
+
+.csdlc/prepared/issues/5671/design.md
+
+Digest: ed8ebae320de231a3b843b0cd646af2480f4c53752eb062a4400713e30cc0afc
+
+## Diagram
+
+.csdlc/prepared/issues/5671/diagram.mmd
+
+Digest: 4b776521482a4c212c66cfc858a084fe41b55c607f07450c346b299dc53c75aa
+
+## Stop Conditions
+
+- canonical model id cannot be verified
+- existing adapter lacks mock proof surface
+- focused validation fails without a bounded repair
+
+## Handoff
+
+Proceed only after doctor readiness.

--- a/.csdlc/issues/5671/cards/spp.values.json
+++ b/.csdlc/issues/5671/cards/spp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][provider] Add Anthropic Claude Opus 5 provider profile",
     "slug": "anthropic-claude-opus-5-provider",
     "version": "v0.91.8",
-    "generation": 2
+    "generation": 5
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5671/cards/spp.values.json
+++ b/.csdlc/issues/5671/cards/spp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][provider] Add Anthropic Claude Opus 5 provider profile",
     "slug": "anthropic-claude-opus-5-provider",
     "version": "v0.91.8",
-    "generation": 5
+    "generation": 6
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5671/cards/spp.values.json
+++ b/.csdlc/issues/5671/cards/spp.values.json
@@ -1,0 +1,78 @@
+{
+  "identity": {
+    "schema_version": "1.0.0",
+    "template_version": "1.0.0",
+    "issue": 5671,
+    "repository": "danielbaustin/agent-design-language",
+    "title": "[v0.91.8][provider] Add Anthropic Claude Opus 5 provider profile",
+    "slug": "anthropic-claude-opus-5-provider",
+    "version": "v0.91.8",
+    "generation": 2
+  },
+  "status": "ready",
+  "content": {
+    "card_kind": "spp",
+    "values": {
+      "plan_revision": 1,
+      "summary": "Add the canonical Claude Opus 5 profile and setup route on the existing Rust Anthropic adapter, prove it with focused mocks, review the exact head, and publish a draft PR.",
+      "steps": [
+        {
+          "id": "S1",
+          "action": "Bind the issue worktree and normalize the six lifecycle cards",
+          "acceptance_ids": [
+            "AC-1",
+            "AC-2",
+            "AC-3"
+          ],
+          "status": "pending"
+        },
+        {
+          "id": "S2",
+          "action": "Implement profile expansion, setup generation, and focused mock proof",
+          "acceptance_ids": [
+            "AC-1",
+            "AC-2",
+            "AC-3",
+            "AC-4"
+          ],
+          "status": "pending"
+        },
+        {
+          "id": "S3",
+          "action": "Run focused validation, exact-head review, and publish a draft PR",
+          "acceptance_ids": [
+            "AC-5"
+          ],
+          "status": "pending"
+        }
+      ],
+      "affected_areas": [],
+      "invariants": [
+        "Existing Claude profiles remain compatible",
+        "Anthropic credentials stay on ANTHROPIC_API_KEY",
+        "No live provider call is required",
+        "main remains untouched"
+      ],
+      "risks": [
+        "Routing Opus 5 through generic HTTP would lose Anthropic request semantics",
+        "setup family drift",
+        "unsupported model id claims"
+      ],
+      "execution_estimates": {
+        "elapsed_seconds": 7200,
+        "total_tokens": 40000,
+        "validation_seconds": 1200
+      },
+      "stop_conditions": [
+        "canonical model id cannot be verified",
+        "existing adapter lacks mock proof surface",
+        "focused validation fails without a bounded repair"
+      ],
+      "replan_triggers": [],
+      "design_ref": ".csdlc/prepared/issues/5671/design.md",
+      "design_digest": "ed8ebae320de231a3b843b0cd646af2480f4c53752eb062a4400713e30cc0afc",
+      "diagram_ref": ".csdlc/prepared/issues/5671/diagram.mmd",
+      "diagram_digest": "4b776521482a4c212c66cfc858a084fe41b55c607f07450c346b299dc53c75aa"
+    }
+  }
+}

--- a/.csdlc/issues/5671/cards/srp.md
+++ b/.csdlc/issues/5671/cards/srp.md
@@ -12,7 +12,12 @@ Status: pre_phase
 
 ## Scope
 
-provider profile registry, setup template, and focused tests
+adl/src/provider/profiles.rs
+adl/src/provider/mod.rs
+adl/src/provider/http_family/tests.rs
+adl/src/cli/provider_cmd.rs
+adl/src/cli/usage.rs
+adl/tests/provider_tests/profiles.rs
 
 ## Prompts
 
@@ -22,7 +27,18 @@ provider profile registry, setup template, and focused tests
 
 ## Findings
 
-[]
+[
+  {
+    "id": "R-5671-001",
+    "severity": "p2",
+    "summary": "The initial implementation needed an end-to-end expansion/build assertion and typed scope coverage for the added integration and usage paths.",
+    "actionable": true,
+    "in_scope": true,
+    "disposition": "fixed",
+    "fix_revision": "git-blake3:86a1bfbc250954bfede4eec8ea8e1a2d314c07ff:4d4fe30bfe94daa9b40e484fc4897f8837ff1f3114858b35e6b85b688bb73be9",
+    "route": null
+  }
+]
 
 ## Dispositions
 
@@ -30,12 +46,12 @@ Every actionable finding requires a terminal disposition.
 
 ## Residual Risk
 
-- none
+- No live Anthropic credential was available in the approved key-file route, so live Opus review remains unproven; mocked HTTP proof and real local adapter execution pass.
 
 ## Review Result
 
-Revision: None
+Revision: Some("git-blake3:86a1bfbc250954bfede4eec8ea8e1a2d314c07ff:4d4fe30bfe94daa9b40e484fc4897f8837ff1f3114858b35e6b85b688bb73be9")
 
-Reviewer: None
+Reviewer: Some("codex:5671-subagent-review")
 
-Result: pre_review
+Result: pass

--- a/.csdlc/issues/5671/cards/srp.md
+++ b/.csdlc/issues/5671/cards/srp.md
@@ -1,0 +1,41 @@
+# Structured Review Prompt
+
+Template: 1.0.0
+
+Issue: 5671
+
+Repository: danielbaustin/agent-design-language
+
+Card: srp
+
+Status: pre_phase
+
+## Scope
+
+provider profile registry, setup template, and focused tests
+
+## Prompts
+
+- Check that Opus 5 uses the Rust Anthropic adapter rather than generic HTTP
+- Check compatibility of existing Claude profiles
+- Check setup output, credential boundary, and mocked request proof
+
+## Findings
+
+[]
+
+## Dispositions
+
+Every actionable finding requires a terminal disposition.
+
+## Residual Risk
+
+- none
+
+## Review Result
+
+Revision: None
+
+Reviewer: None
+
+Result: pre_review

--- a/.csdlc/issues/5671/cards/srp.values.json
+++ b/.csdlc/issues/5671/cards/srp.values.json
@@ -7,23 +7,36 @@
     "title": "[v0.91.8][provider] Add Anthropic Claude Opus 5 provider profile",
     "slug": "anthropic-claude-opus-5-provider",
     "version": "v0.91.8",
-    "generation": 2
+    "generation": 5
   },
   "status": "pre_phase",
   "content": {
     "card_kind": "srp",
     "values": {
-      "review_scope": "provider profile registry, setup template, and focused tests",
-      "review_revision": null,
-      "reviewer": null,
+      "review_scope": "adl/src/provider/profiles.rs\nadl/src/provider/mod.rs\nadl/src/provider/http_family/tests.rs\nadl/src/cli/provider_cmd.rs\nadl/src/cli/usage.rs\nadl/tests/provider_tests/profiles.rs",
+      "review_revision": "git-blake3:86a1bfbc250954bfede4eec8ea8e1a2d314c07ff:4d4fe30bfe94daa9b40e484fc4897f8837ff1f3114858b35e6b85b688bb73be9",
+      "reviewer": "codex:5671-subagent-review",
       "review_prompts": [
         "Check that Opus 5 uses the Rust Anthropic adapter rather than generic HTTP",
         "Check compatibility of existing Claude profiles",
         "Check setup output, credential boundary, and mocked request proof"
       ],
-      "findings": [],
-      "residual_risk": [],
-      "review_result": "pre_review"
+      "findings": [
+        {
+          "id": "R-5671-001",
+          "severity": "p2",
+          "summary": "The initial implementation needed an end-to-end expansion/build assertion and typed scope coverage for the added integration and usage paths.",
+          "actionable": true,
+          "in_scope": true,
+          "disposition": "fixed",
+          "fix_revision": "git-blake3:86a1bfbc250954bfede4eec8ea8e1a2d314c07ff:4d4fe30bfe94daa9b40e484fc4897f8837ff1f3114858b35e6b85b688bb73be9",
+          "route": null
+        }
+      ],
+      "residual_risk": [
+        "No live Anthropic credential was available in the approved key-file route, so live Opus review remains unproven; mocked HTTP proof and real local adapter execution pass."
+      ],
+      "review_result": "pass"
     }
   }
 }

--- a/.csdlc/issues/5671/cards/srp.values.json
+++ b/.csdlc/issues/5671/cards/srp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][provider] Add Anthropic Claude Opus 5 provider profile",
     "slug": "anthropic-claude-opus-5-provider",
     "version": "v0.91.8",
-    "generation": 5
+    "generation": 6
   },
   "status": "pre_phase",
   "content": {

--- a/.csdlc/issues/5671/cards/srp.values.json
+++ b/.csdlc/issues/5671/cards/srp.values.json
@@ -1,0 +1,29 @@
+{
+  "identity": {
+    "schema_version": "1.0.0",
+    "template_version": "1.0.0",
+    "issue": 5671,
+    "repository": "danielbaustin/agent-design-language",
+    "title": "[v0.91.8][provider] Add Anthropic Claude Opus 5 provider profile",
+    "slug": "anthropic-claude-opus-5-provider",
+    "version": "v0.91.8",
+    "generation": 2
+  },
+  "status": "pre_phase",
+  "content": {
+    "card_kind": "srp",
+    "values": {
+      "review_scope": "provider profile registry, setup template, and focused tests",
+      "review_revision": null,
+      "reviewer": null,
+      "review_prompts": [
+        "Check that Opus 5 uses the Rust Anthropic adapter rather than generic HTTP",
+        "Check compatibility of existing Claude profiles",
+        "Check setup output, credential boundary, and mocked request proof"
+      ],
+      "findings": [],
+      "residual_risk": [],
+      "review_result": "pre_review"
+    }
+  }
+}

--- a/.csdlc/issues/5671/cards/stp.md
+++ b/.csdlc/issues/5671/cards/stp.md
@@ -1,0 +1,49 @@
+# Structured Task Prompt
+
+Template: 1.0.0
+
+Issue: 5671
+
+Repository: danielbaustin/agent-design-language
+
+Card: stp
+
+Status: ready
+
+## Task
+
+Implement the Opus 5 profile/setup route and bounded tests in the existing provider modules.
+
+## Deliverables
+
+- provider profile
+- setup template
+- focused Rust tests
+- design and diagram
+
+## Acceptance
+
+1. AC-1: claude:claude-opus-5 resolves to the Anthropic provider kind, endpoint, and canonical model id.
+2. AC-2: Existing Claude profiles remain unchanged and profile expansion preserves vendor identity.
+3. AC-3: provider setup claude-opus-5 emits the profile and ANTHROPIC_API_KEY route.
+4. AC-4: Mocked Anthropic adapter proof verifies claude-opus-5 and the canonical version header.
+5. AC-5: Focused Rust validation and exact-head review pass without a live provider call.
+
+## Dependencies
+
+- existing Rust-native Anthropic Messages adapter
+- canonical model id claude-opus-5
+
+## Inputs
+
+- adl/src/provider/profiles.rs
+- adl/src/provider/mod.rs
+- adl/src/cli/provider_cmd.rs
+- adl/src/provider/http_family.rs
+
+## Non Goals
+
+- new transport
+- live API call
+- credential provisioning
+- pricing or benchmarking

--- a/.csdlc/issues/5671/cards/stp.values.json
+++ b/.csdlc/issues/5671/cards/stp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][provider] Add Anthropic Claude Opus 5 provider profile",
     "slug": "anthropic-claude-opus-5-provider",
     "version": "v0.91.8",
-    "generation": 2
+    "generation": 5
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5671/cards/stp.values.json
+++ b/.csdlc/issues/5671/cards/stp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][provider] Add Anthropic Claude Opus 5 provider profile",
     "slug": "anthropic-claude-opus-5-provider",
     "version": "v0.91.8",
-    "generation": 5
+    "generation": 6
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5671/cards/stp.values.json
+++ b/.csdlc/issues/5671/cards/stp.values.json
@@ -1,0 +1,48 @@
+{
+  "identity": {
+    "schema_version": "1.0.0",
+    "template_version": "1.0.0",
+    "issue": 5671,
+    "repository": "danielbaustin/agent-design-language",
+    "title": "[v0.91.8][provider] Add Anthropic Claude Opus 5 provider profile",
+    "slug": "anthropic-claude-opus-5-provider",
+    "version": "v0.91.8",
+    "generation": 2
+  },
+  "status": "ready",
+  "content": {
+    "card_kind": "stp",
+    "values": {
+      "task_boundary": "Implement the Opus 5 profile/setup route and bounded tests in the existing provider modules.",
+      "deliverables": [
+        "provider profile",
+        "setup template",
+        "focused Rust tests",
+        "design and diagram"
+      ],
+      "acceptance_criteria": [
+        "AC-1: claude:claude-opus-5 resolves to the Anthropic provider kind, endpoint, and canonical model id.",
+        "AC-2: Existing Claude profiles remain unchanged and profile expansion preserves vendor identity.",
+        "AC-3: provider setup claude-opus-5 emits the profile and ANTHROPIC_API_KEY route.",
+        "AC-4: Mocked Anthropic adapter proof verifies claude-opus-5 and the canonical version header.",
+        "AC-5: Focused Rust validation and exact-head review pass without a live provider call."
+      ],
+      "dependencies": [
+        "existing Rust-native Anthropic Messages adapter",
+        "canonical model id claude-opus-5"
+      ],
+      "repo_inputs": [
+        "adl/src/provider/profiles.rs",
+        "adl/src/provider/mod.rs",
+        "adl/src/cli/provider_cmd.rs",
+        "adl/src/provider/http_family.rs"
+      ],
+      "non_goals": [
+        "new transport",
+        "live API call",
+        "credential provisioning",
+        "pricing or benchmarking"
+      ]
+    }
+  }
+}

--- a/.csdlc/issues/5671/cards/vpp.md
+++ b/.csdlc/issues/5671/cards/vpp.md
@@ -1,0 +1,92 @@
+# Validation Planning Prompt
+
+Template: 1.0.0
+
+Issue: 5671
+
+Repository: danielbaustin/agent-design-language
+
+Card: vpp
+
+Status: ready
+
+## Summary
+
+Execute the smallest proving validation DAG.
+
+## Lane Inputs
+
+Design: .csdlc/prepared/issues/5671/design.md
+
+Diagram: .csdlc/prepared/issues/5671/diagram.mmd
+
+## Selected Lanes
+
+[
+  {
+    "lane": "provider-profile-focused",
+    "proof_role": "registry, expansion, setup, and mocked Anthropic request proof",
+    "acceptance_ids": [
+      "AC-1",
+      "AC-2",
+      "AC-3",
+      "AC-4",
+      "AC-5"
+    ],
+    "deterministic": true,
+    "resource_profile": "small",
+    "budget_seconds": 600,
+    "budget_tokens": 4000,
+    "argv": [
+      "cargo",
+      "test",
+      "--manifest-path",
+      "adl/Cargo.toml",
+      "provider_"
+    ],
+    "parallel_group": "local",
+    "defer_reason": null
+  },
+  {
+    "lane": "provider-build-focused",
+    "proof_role": "compile the touched Rust provider surface",
+    "acceptance_ids": [
+      "AC-5"
+    ],
+    "deterministic": true,
+    "resource_profile": "small",
+    "budget_seconds": 300,
+    "budget_tokens": 2000,
+    "argv": [
+      "cargo",
+      "check",
+      "--manifest-path",
+      "adl/Cargo.toml"
+    ],
+    "parallel_group": "local",
+    "defer_reason": null
+  }
+]
+
+## Parallelization
+
+Only declared parallel groups may overlap.
+
+## Budgets
+
+Seconds: 1200
+
+Tokens: 10000
+
+## Commands
+
+- `cargo test --manifest-path adl/Cargo.toml provider_`
+- `cargo check --manifest-path adl/Cargo.toml`
+
+## Failure Semantics
+
+Fail closed on model, endpoint, credential, or proof drift; repair only the bounded provider surface.
+
+## Handoff
+
+Retain typed evidence before convergence.

--- a/.csdlc/issues/5671/cards/vpp.values.json
+++ b/.csdlc/issues/5671/cards/vpp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][provider] Add Anthropic Claude Opus 5 provider profile",
     "slug": "anthropic-claude-opus-5-provider",
     "version": "v0.91.8",
-    "generation": 2
+    "generation": 5
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5671/cards/vpp.values.json
+++ b/.csdlc/issues/5671/cards/vpp.values.json
@@ -1,0 +1,71 @@
+{
+  "identity": {
+    "schema_version": "1.0.0",
+    "template_version": "1.0.0",
+    "issue": 5671,
+    "repository": "danielbaustin/agent-design-language",
+    "title": "[v0.91.8][provider] Add Anthropic Claude Opus 5 provider profile",
+    "slug": "anthropic-claude-opus-5-provider",
+    "version": "v0.91.8",
+    "generation": 2
+  },
+  "status": "ready",
+  "content": {
+    "card_kind": "vpp",
+    "values": {
+      "summary": "Execute the smallest proving validation DAG.",
+      "lanes": [
+        {
+          "lane": "provider-profile-focused",
+          "proof_role": "registry, expansion, setup, and mocked Anthropic request proof",
+          "acceptance_ids": [
+            "AC-1",
+            "AC-2",
+            "AC-3",
+            "AC-4",
+            "AC-5"
+          ],
+          "deterministic": true,
+          "resource_profile": "small",
+          "budget_seconds": 600,
+          "budget_tokens": 4000,
+          "argv": [
+            "cargo",
+            "test",
+            "--manifest-path",
+            "adl/Cargo.toml",
+            "provider_"
+          ],
+          "parallel_group": "local",
+          "defer_reason": null
+        },
+        {
+          "lane": "provider-build-focused",
+          "proof_role": "compile the touched Rust provider surface",
+          "acceptance_ids": [
+            "AC-5"
+          ],
+          "deterministic": true,
+          "resource_profile": "small",
+          "budget_seconds": 300,
+          "budget_tokens": 2000,
+          "argv": [
+            "cargo",
+            "check",
+            "--manifest-path",
+            "adl/Cargo.toml"
+          ],
+          "parallel_group": "local",
+          "defer_reason": null
+        }
+      ],
+      "planned_validation_seconds": 1200,
+      "planned_validation_tokens": 10000,
+      "failure_policy": "Fail closed on model, endpoint, credential, or proof drift; repair only the bounded provider surface.",
+      "design_ref": ".csdlc/prepared/issues/5671/design.md",
+      "design_digest": "ed8ebae320de231a3b843b0cd646af2480f4c53752eb062a4400713e30cc0afc",
+      "diagram_ref": ".csdlc/prepared/issues/5671/diagram.mmd",
+      "diagram_digest": "4b776521482a4c212c66cfc858a084fe41b55c607f07450c346b299dc53c75aa"
+    }
+  }
+}

--- a/.csdlc/issues/5671/cards/vpp.values.json
+++ b/.csdlc/issues/5671/cards/vpp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][provider] Add Anthropic Claude Opus 5 provider profile",
     "slug": "anthropic-claude-opus-5-provider",
     "version": "v0.91.8",
-    "generation": 5
+    "generation": 6
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5671/index.json
+++ b/.csdlc/issues/5671/index.json
@@ -4,12 +4,12 @@
   "repository": "danielbaustin/agent-design-language",
   "initialization_digest": "dab42acf5c368379d4a37d2f3ddd8412f5146e44a6f0099cd7ae0a27a24d197b",
   "phase": "published",
-  "generation": 5,
-  "digest": "e04bb0143ad366aca3c13c5f0b907c0a93d1cf2c8c2040c09357fcea5710db7e",
+  "generation": 6,
+  "digest": "896f18df6edea8a18de256752ed5512b1465e2c2155a8b8124462f34c664daec",
   "claim": {
     "id": "claim-5671-anthropic-opus-5",
     "owner": "codex:5671-execution",
-    "generation": 5,
+    "generation": 6,
     "acquired_unix_seconds": 1784851200,
     "expires_unix_seconds": 1785456000,
     "heartbeat_unix_seconds": 1784851200,
@@ -77,7 +77,7 @@
     "url": "https://github.com/danielbaustin/agent-design-language/pull/5673",
     "base": "main",
     "head": "codex/5671-anthropic-opus-5",
-    "revision": "git-blake3:86a1bfbc250954bfede4eec8ea8e1a2d314c07ff:4d4fe30bfe94daa9b40e484fc4897f8837ff1f3114858b35e6b85b688bb73be9",
+    "revision": "git-blake3:f10d7a87020272b9cc340da35262c3d53d98e572:7dfd9ba093ef5f283b9bbfc66588b999a6384206b9ea9ed92592bba71cb0e1f3",
     "draft": true,
     "observed_state": "open"
   },
@@ -94,32 +94,32 @@
   },
   "cards": {
     "sip": {
-      "values_digest": "f555fcdab93e66c20dc78e95de15e3b30f1cc0ffa52362ff7ce9e380ac4d4ff6",
+      "values_digest": "87fdd8049fa047b31c36900cc6d5b6c9ac8d69f2b0beece4702f765027c2c3f8",
       "rendered_digest": "ebea4d650aaca26229abe222dc682f70ba880618ff6ad962389c052570d031ec",
       "ast_digest": "609d791c5ec9db9ccb5bff44abce0222ecb3ae1f059b635f2133f8586dd9cfd9"
     },
     "stp": {
-      "values_digest": "12c0c66906b39699ee7750f77c9257ab760511239ef546800b4e2a4e85550e77",
+      "values_digest": "d09c13dc5f84cbd95323a070cd5e180b745a817dc8fcfea2d175abc1c6627454",
       "rendered_digest": "8b08658ad1bb340a9b8d3b83d28fca91afdddda26d12c952e0e48a8b206de719",
       "ast_digest": "f43d4248233a1f4cccc855c5da3c078ce9195c8c2b191f5e7bf650793648a391"
     },
     "spp": {
-      "values_digest": "0b24362eef6167afec859d9bb1588e334964b69ddae5e94a1e51c468f4bc6aee",
+      "values_digest": "cb83ed226a5dcb8b83696aa939b493bd59d6d70052106148da025b0d533abbb4",
       "rendered_digest": "a3505196dba4b81203e0def1f807fb36e0852ad5c77c056f05f8e12648f9d7f9",
       "ast_digest": "558fdfb30d2b37e5e60b5646303c8b91b53180b47a4ac3c6ca9c66902b91521a"
     },
     "vpp": {
-      "values_digest": "7adf15a70138bd1723ff289bf05827da7a51cc43bc82886a2a330070fd67aa01",
+      "values_digest": "a9f6e5cfb8bb50fd404353ca2df3be85a68535a84b5930c26d7363edd003ec54",
       "rendered_digest": "e09ae6cf86e8317065688f84112c9256180103601d31031b349a9bd6c1aea709",
       "ast_digest": "7a5d2278c8892c511c8d833f6ccb2e9d6c35dc5c1d9c899f9be6780e1340f33a"
     },
     "srp": {
-      "values_digest": "ca9f208dbca7a14c2e90f8ccb9fcbee9365a0e0548169a598b6e9e9ef81f5df2",
+      "values_digest": "cfdd9d2a93b5cc6a8f269af57c7e43502105df40ba6e22dae4d0347bd0028c26",
       "rendered_digest": "9850d251705a6321bb47a839a6a89c2ef204ceda22062d639da5e0fc6a921228",
       "ast_digest": "fd593eb97f04d9074455edcdd624cabe0311ffc54f06294f90b3ab998cf096b0"
     },
     "sor": {
-      "values_digest": "72c9c8ceac31e9c6cf1c17cbb4446a879f2cff77372e9dc303e7dc3736ec4687",
+      "values_digest": "74694c9b29249eca0c399458f93da5908e4289620cd124843f21bca2c6c69a62",
       "rendered_digest": "9509ccfee816dd072919907b7efced0d126df34133c40d3083fc179744bcc66a",
       "ast_digest": "24d5e001c3e8e62728d7dc70899b599b424441562e997ffda32f129061095235"
     }
@@ -221,6 +221,13 @@
     {
       "sequence": 9,
       "generation": 5,
+      "actor": "codex:5671-execution",
+      "reason": "atomically record observed GitHub publication and SOR projection",
+      "operation": "record_publication"
+    },
+    {
+      "sequence": 10,
+      "generation": 6,
       "actor": "codex:5671-execution",
       "reason": "atomically record observed GitHub publication and SOR projection",
       "operation": "record_publication"

--- a/.csdlc/issues/5671/index.json
+++ b/.csdlc/issues/5671/index.json
@@ -1,0 +1,137 @@
+{
+  "schema": "csdlc.issue.index.v1",
+  "issue": 5671,
+  "repository": "danielbaustin/agent-design-language",
+  "initialization_digest": "dab42acf5c368379d4a37d2f3ddd8412f5146e44a6f0099cd7ae0a27a24d197b",
+  "phase": "implemented",
+  "generation": 2,
+  "digest": "16e0e05b9bd713ec0245c3b2bebde2125c37e076bd9b47bf793a0d5b6a2655f8",
+  "claim": {
+    "id": "claim-5671-anthropic-opus-5",
+    "owner": "codex:5671-execution",
+    "generation": 2,
+    "acquired_unix_seconds": 1784851200,
+    "expires_unix_seconds": 1785456000,
+    "heartbeat_unix_seconds": 1784851200,
+    "branch": "codex/5671-anthropic-opus-5",
+    "worktree": ".",
+    "protected_paths": [
+      ".csdlc/issues/5671",
+      ".csdlc/locks/5671.lock",
+      ".csdlc/prepared/issues/5671",
+      "adl/src/cli/provider_cmd.rs",
+      "adl/src/cli/usage.rs",
+      "adl/src/provider/http_family/tests.rs",
+      "adl/src/provider/mod.rs",
+      "adl/src/provider/profiles.rs",
+      "adl/tests/provider_tests/profiles.rs"
+    ],
+    "purpose": "Implement and validate the Claude Opus 5 provider profile and setup route"
+  },
+  "review_assignment": null,
+  "review": null,
+  "publication": null,
+  "readiness": null,
+  "terminal": null,
+  "migration": null,
+  "design_path": ".csdlc/prepared/issues/5671/design.md",
+  "diagram_path": ".csdlc/prepared/issues/5671/diagram.mmd",
+  "design_review": {
+    "approved": {
+      "reviewer": "codex:5671-preparation-review",
+      "revision": "ed8ebae320de231a3b843b0cd646af2480f4c53752eb062a4400713e30cc0afc"
+    }
+  },
+  "cards": {
+    "sip": {
+      "values_digest": "9f33e94cd9607fc82e346775edf77cefa537ff28885177b63571bd923f5cf45b",
+      "rendered_digest": "ebea4d650aaca26229abe222dc682f70ba880618ff6ad962389c052570d031ec",
+      "ast_digest": "609d791c5ec9db9ccb5bff44abce0222ecb3ae1f059b635f2133f8586dd9cfd9"
+    },
+    "stp": {
+      "values_digest": "35527676c67506aac09b2f320e764972edefac25f72dfa7e1895f901ab6b7063",
+      "rendered_digest": "8b08658ad1bb340a9b8d3b83d28fca91afdddda26d12c952e0e48a8b206de719",
+      "ast_digest": "f43d4248233a1f4cccc855c5da3c078ce9195c8c2b191f5e7bf650793648a391"
+    },
+    "spp": {
+      "values_digest": "ec2e24d9cbf785c03d22e69af1b685ae1781a036d574d46535a8be9e4b716f53",
+      "rendered_digest": "a3505196dba4b81203e0def1f807fb36e0852ad5c77c056f05f8e12648f9d7f9",
+      "ast_digest": "558fdfb30d2b37e5e60b5646303c8b91b53180b47a4ac3c6ca9c66902b91521a"
+    },
+    "vpp": {
+      "values_digest": "ccfec3c221c4cf7125660af38e0035f9129c3673d7f95b4fc7369d72bf65dcb4",
+      "rendered_digest": "e09ae6cf86e8317065688f84112c9256180103601d31031b349a9bd6c1aea709",
+      "ast_digest": "7a5d2278c8892c511c8d833f6ccb2e9d6c35dc5c1d9c899f9be6780e1340f33a"
+    },
+    "srp": {
+      "values_digest": "241d9fe7539839cc94d81a84f6ba8cd4cf75852b3e412092ac319403c78214d8",
+      "rendered_digest": "f219550200c0e5f5c7063ec719cdaaf0c4edf5ff07f0d554684f23cd1a420ad1",
+      "ast_digest": "e71e05e7ac59e61e1e78fe6e1dc9fb8a1ef451401ff038aea8bbe6a8d4abc850"
+    },
+    "sor": {
+      "values_digest": "6ea00abe8b96a3752ba53e766ec64f919610d605b0151a7db68ba14ef9f3d057",
+      "rendered_digest": "f0875b6cb31c1d1a4b06b177cc60d9e5eeff767b89a04441b45bd96b52009992",
+      "ast_digest": "07b75e7ae9f89afb44514e9ab6b4c5543e4e4b7a945becd3d268cd0c7a148ac5"
+    }
+  },
+  "transitions": [
+    {
+      "sequence": 1,
+      "from": "initialized",
+      "to": "ready",
+      "actor": "codex:5671-execution",
+      "reason": "automatic readiness verification"
+    },
+    {
+      "sequence": 2,
+      "from": "ready",
+      "to": "bound",
+      "actor": "codex:5671-execution",
+      "reason": "verified Git worktree binding"
+    },
+    {
+      "sequence": 3,
+      "from": "bound",
+      "to": "implemented",
+      "actor": "codex:5671-execution",
+      "reason": "execution and passing validation finalized atomically"
+    }
+  ],
+  "audit": [
+    {
+      "sequence": 1,
+      "generation": 0,
+      "actor": "codex:5671-execution",
+      "reason": "initialize issue record and all six cards",
+      "operation": "bootstrap"
+    },
+    {
+      "sequence": 2,
+      "generation": 1,
+      "actor": "codex:5671-preparation-review",
+      "reason": "approve completed issue design",
+      "operation": "approve_design"
+    },
+    {
+      "sequence": 3,
+      "generation": 1,
+      "actor": "codex:5671-execution",
+      "reason": "bind branch/worktree and activate claim",
+      "operation": "bind"
+    },
+    {
+      "sequence": 4,
+      "generation": 1,
+      "actor": "codex:5671-execution",
+      "reason": "Add the focused integration test and setup usage surface to the declared issue scope",
+      "operation": "{\"add_protected_paths\":[\"adl/tests/provider_tests/profiles.rs\",\"adl/src/cli/usage.rs\",\"adl/src/provider/http_family/tests.rs\"],\"operation\":\"amend_claim_scope\"}"
+    },
+    {
+      "sequence": 5,
+      "generation": 2,
+      "actor": "codex:5671-execution",
+      "reason": "atomically record execution, validation, and implemented phase",
+      "operation": "finalize_implementation"
+    }
+  ]
+}

--- a/.csdlc/issues/5671/index.json
+++ b/.csdlc/issues/5671/index.json
@@ -3,13 +3,13 @@
   "issue": 5671,
   "repository": "danielbaustin/agent-design-language",
   "initialization_digest": "dab42acf5c368379d4a37d2f3ddd8412f5146e44a6f0099cd7ae0a27a24d197b",
-  "phase": "implemented",
-  "generation": 2,
-  "digest": "16e0e05b9bd713ec0245c3b2bebde2125c37e076bd9b47bf793a0d5b6a2655f8",
+  "phase": "published",
+  "generation": 5,
+  "digest": "e04bb0143ad366aca3c13c5f0b907c0a93d1cf2c8c2040c09357fcea5710db7e",
   "claim": {
     "id": "claim-5671-anthropic-opus-5",
     "owner": "codex:5671-execution",
-    "generation": 2,
+    "generation": 5,
     "acquired_unix_seconds": 1784851200,
     "expires_unix_seconds": 1785456000,
     "heartbeat_unix_seconds": 1784851200,
@@ -28,9 +28,59 @@
     ],
     "purpose": "Implement and validate the Claude Opus 5 provider profile and setup route"
   },
-  "review_assignment": null,
-  "review": null,
-  "publication": null,
+  "review_assignment": {
+    "reviewer": "codex:5671-subagent-review",
+    "assigned_by": "codex:5671-execution",
+    "revision": "git-blake3:86a1bfbc250954bfede4eec8ea8e1a2d314c07ff:4d4fe30bfe94daa9b40e484fc4897f8837ff1f3114858b35e6b85b688bb73be9",
+    "scope": [
+      "adl/src/provider/profiles.rs",
+      "adl/src/provider/mod.rs",
+      "adl/src/provider/http_family/tests.rs",
+      "adl/src/cli/provider_cmd.rs",
+      "adl/src/cli/usage.rs",
+      "adl/tests/provider_tests/profiles.rs"
+    ]
+  },
+  "review": {
+    "reviewer": "codex:5671-subagent-review",
+    "scope": [
+      "adl/src/provider/profiles.rs",
+      "adl/src/provider/mod.rs",
+      "adl/src/provider/http_family/tests.rs",
+      "adl/src/cli/provider_cmd.rs",
+      "adl/src/cli/usage.rs",
+      "adl/tests/provider_tests/profiles.rs"
+    ],
+    "reviewed_revision": "git-blake3:86a1bfbc250954bfede4eec8ea8e1a2d314c07ff:4d4fe30bfe94daa9b40e484fc4897f8837ff1f3114858b35e6b85b688bb73be9",
+    "findings": [
+      {
+        "id": "R-5671-001",
+        "severity": "p2",
+        "summary": "The initial implementation needed an end-to-end expansion/build assertion and typed scope coverage for the added integration and usage paths.",
+        "actionable": true,
+        "in_scope": true,
+        "disposition": "fixed",
+        "fix_revision": "git-blake3:86a1bfbc250954bfede4eec8ea8e1a2d314c07ff:4d4fe30bfe94daa9b40e484fc4897f8837ff1f3114858b35e6b85b688bb73be9",
+        "route": null
+      }
+    ],
+    "residual_risks": [
+      "No live Anthropic credential was available in the approved key-file route, so live Opus review remains unproven; mocked HTTP proof and real local adapter execution pass."
+    ],
+    "completed": true,
+    "non_substantive_proof": null
+  },
+  "publication": {
+    "repository": "danielbaustin/agent-design-language",
+    "issue": 5671,
+    "pull_request": 5673,
+    "url": "https://github.com/danielbaustin/agent-design-language/pull/5673",
+    "base": "main",
+    "head": "codex/5671-anthropic-opus-5",
+    "revision": "git-blake3:86a1bfbc250954bfede4eec8ea8e1a2d314c07ff:4d4fe30bfe94daa9b40e484fc4897f8837ff1f3114858b35e6b85b688bb73be9",
+    "draft": true,
+    "observed_state": "open"
+  },
   "readiness": null,
   "terminal": null,
   "migration": null,
@@ -44,34 +94,34 @@
   },
   "cards": {
     "sip": {
-      "values_digest": "9f33e94cd9607fc82e346775edf77cefa537ff28885177b63571bd923f5cf45b",
+      "values_digest": "f555fcdab93e66c20dc78e95de15e3b30f1cc0ffa52362ff7ce9e380ac4d4ff6",
       "rendered_digest": "ebea4d650aaca26229abe222dc682f70ba880618ff6ad962389c052570d031ec",
       "ast_digest": "609d791c5ec9db9ccb5bff44abce0222ecb3ae1f059b635f2133f8586dd9cfd9"
     },
     "stp": {
-      "values_digest": "35527676c67506aac09b2f320e764972edefac25f72dfa7e1895f901ab6b7063",
+      "values_digest": "12c0c66906b39699ee7750f77c9257ab760511239ef546800b4e2a4e85550e77",
       "rendered_digest": "8b08658ad1bb340a9b8d3b83d28fca91afdddda26d12c952e0e48a8b206de719",
       "ast_digest": "f43d4248233a1f4cccc855c5da3c078ce9195c8c2b191f5e7bf650793648a391"
     },
     "spp": {
-      "values_digest": "ec2e24d9cbf785c03d22e69af1b685ae1781a036d574d46535a8be9e4b716f53",
+      "values_digest": "0b24362eef6167afec859d9bb1588e334964b69ddae5e94a1e51c468f4bc6aee",
       "rendered_digest": "a3505196dba4b81203e0def1f807fb36e0852ad5c77c056f05f8e12648f9d7f9",
       "ast_digest": "558fdfb30d2b37e5e60b5646303c8b91b53180b47a4ac3c6ca9c66902b91521a"
     },
     "vpp": {
-      "values_digest": "ccfec3c221c4cf7125660af38e0035f9129c3673d7f95b4fc7369d72bf65dcb4",
+      "values_digest": "7adf15a70138bd1723ff289bf05827da7a51cc43bc82886a2a330070fd67aa01",
       "rendered_digest": "e09ae6cf86e8317065688f84112c9256180103601d31031b349a9bd6c1aea709",
       "ast_digest": "7a5d2278c8892c511c8d833f6ccb2e9d6c35dc5c1d9c899f9be6780e1340f33a"
     },
     "srp": {
-      "values_digest": "241d9fe7539839cc94d81a84f6ba8cd4cf75852b3e412092ac319403c78214d8",
-      "rendered_digest": "f219550200c0e5f5c7063ec719cdaaf0c4edf5ff07f0d554684f23cd1a420ad1",
-      "ast_digest": "e71e05e7ac59e61e1e78fe6e1dc9fb8a1ef451401ff038aea8bbe6a8d4abc850"
+      "values_digest": "ca9f208dbca7a14c2e90f8ccb9fcbee9365a0e0548169a598b6e9e9ef81f5df2",
+      "rendered_digest": "9850d251705a6321bb47a839a6a89c2ef204ceda22062d639da5e0fc6a921228",
+      "ast_digest": "fd593eb97f04d9074455edcdd624cabe0311ffc54f06294f90b3ab998cf096b0"
     },
     "sor": {
-      "values_digest": "6ea00abe8b96a3752ba53e766ec64f919610d605b0151a7db68ba14ef9f3d057",
-      "rendered_digest": "f0875b6cb31c1d1a4b06b177cc60d9e5eeff767b89a04441b45bd96b52009992",
-      "ast_digest": "07b75e7ae9f89afb44514e9ab6b4c5543e4e4b7a945becd3d268cd0c7a148ac5"
+      "values_digest": "72c9c8ceac31e9c6cf1c17cbb4446a879f2cff77372e9dc303e7dc3736ec4687",
+      "rendered_digest": "9509ccfee816dd072919907b7efced0d126df34133c40d3083fc179744bcc66a",
+      "ast_digest": "24d5e001c3e8e62728d7dc70899b599b424441562e997ffda32f129061095235"
     }
   },
   "transitions": [
@@ -95,6 +145,20 @@
       "to": "implemented",
       "actor": "codex:5671-execution",
       "reason": "execution and passing validation finalized atomically"
+    },
+    {
+      "sequence": 4,
+      "from": "implemented",
+      "to": "reviewed",
+      "actor": "codex:5671-execution",
+      "reason": "Advance the exact reviewed implementation into the publication phase"
+    },
+    {
+      "sequence": 5,
+      "from": "reviewed",
+      "to": "published",
+      "actor": "codex:5671-execution",
+      "reason": "observed exact PR after current review"
     }
   ],
   "audit": [
@@ -132,6 +196,34 @@
       "actor": "codex:5671-execution",
       "reason": "atomically record execution, validation, and implemented phase",
       "operation": "finalize_implementation"
+    },
+    {
+      "sequence": 6,
+      "generation": 2,
+      "actor": "codex:5671-execution",
+      "reason": "assign bounded exact-revision review",
+      "operation": "assign_review"
+    },
+    {
+      "sequence": 7,
+      "generation": 3,
+      "actor": "codex:5671-subagent-review",
+      "reason": "atomically record assigned review evidence and SRP projection",
+      "operation": "record_review"
+    },
+    {
+      "sequence": 8,
+      "generation": 4,
+      "actor": "codex:5671-execution",
+      "reason": "Advance the exact reviewed implementation into the publication phase",
+      "operation": "{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"
+    },
+    {
+      "sequence": 9,
+      "generation": 5,
+      "actor": "codex:5671-execution",
+      "reason": "atomically record observed GitHub publication and SOR projection",
+      "operation": "record_publication"
     }
   ]
 }

--- a/.csdlc/prepared/issues/5671/advance-reviewed.json
+++ b/.csdlc/prepared/issues/5671/advance-reviewed.json
@@ -1,0 +1,10 @@
+{
+  "issue": 5671,
+  "card": "sip",
+  "expected_generation": 3,
+  "expected_digest": "d08eee22ebc055d51f7c3da3e3530213cde5a78fa54548d70233d82ce9aa0bb8",
+  "claim_id": "claim-5671-anthropic-opus-5",
+  "actor": "codex:5671-execution",
+  "reason": "Advance the exact reviewed implementation into the publication phase",
+  "operation": {"operation":"advance_phase","phase":"reviewed"}
+}

--- a/.csdlc/prepared/issues/5671/amend-claim.json
+++ b/.csdlc/prepared/issues/5671/amend-claim.json
@@ -1,0 +1,14 @@
+{
+  "issue": 5671,
+  "claim_id": "claim-5671-anthropic-opus-5",
+  "expected_generation": 1,
+  "expected_digest": "49105d2181b18523bc868cb708d1696e7db3be901d12d4fceff401f73e23a9fc",
+  "now_unix_seconds": 1785035311,
+  "actor": "codex:5671-execution",
+  "reason": "Add the focused integration test and setup usage surface to the declared issue scope",
+  "add_protected_paths": [
+    "adl/tests/provider_tests/profiles.rs",
+    "adl/src/cli/usage.rs",
+    "adl/src/provider/http_family/tests.rs"
+  ]
+}

--- a/.csdlc/prepared/issues/5671/approve-design.json
+++ b/.csdlc/prepared/issues/5671/approve-design.json
@@ -1,0 +1,7 @@
+{
+  "issue": 5671,
+  "expected_generation": 0,
+  "expected_digest": "792d36350405c488b260765779e335c96eda797cd5470ff7a9d986d29c30a6c1",
+  "claim_id": "claim-5671-anthropic-opus-5",
+  "reviewer": "codex:5671-preparation-review"
+}

--- a/.csdlc/prepared/issues/5671/bind-request.json
+++ b/.csdlc/prepared/issues/5671/bind-request.json
@@ -1,0 +1,25 @@
+{
+  "issue": 5671,
+  "base_branch": "main",
+  "branch": "codex/5671-anthropic-opus-5",
+  "worktree": ".",
+  "claim": {
+    "id": "claim-5671-anthropic-opus-5",
+    "owner": "codex:5671-execution",
+    "generation": 1,
+    "acquired_unix_seconds": 1784851200,
+    "expires_unix_seconds": 1785456000,
+    "heartbeat_unix_seconds": 1784851200,
+    "branch": "codex/5671-anthropic-opus-5",
+    "worktree": ".",
+    "protected_paths": [
+      ".csdlc/issues/5671",
+      ".csdlc/locks/5671.lock",
+      ".csdlc/prepared/issues/5671",
+      "adl/src/provider/profiles.rs",
+      "adl/src/provider/mod.rs",
+      "adl/src/cli/provider_cmd.rs"
+    ],
+    "purpose": "Implement and validate the Claude Opus 5 provider profile and setup route"
+  }
+}

--- a/.csdlc/prepared/issues/5671/bootstrap-request.json
+++ b/.csdlc/prepared/issues/5671/bootstrap-request.json
@@ -1,0 +1,66 @@
+{
+  "issue": 5671,
+  "repository": "danielbaustin/agent-design-language",
+  "design_path": ".csdlc/prepared/issues/5671/design.md",
+  "diagram_path": ".csdlc/prepared/issues/5671/diagram.mmd",
+  "design_reviewer": "codex:5671-preparation-review",
+  "design_approved": false,
+  "claim": {
+    "id": "claim-5671-anthropic-opus-5",
+    "owner": "codex:5671-execution",
+    "generation": 0,
+    "acquired_unix_seconds": 1784851200,
+    "expires_unix_seconds": 1785456000,
+    "heartbeat_unix_seconds": 1784851200,
+    "branch": "codex/5671-anthropic-opus-5",
+    "worktree": ".",
+    "protected_paths": [
+      ".csdlc/issues/5671",
+      ".csdlc/locks/5671.lock",
+      ".csdlc/prepared/issues/5671",
+      "adl/src/provider/profiles.rs",
+      "adl/src/provider/mod.rs",
+      "adl/src/cli/provider_cmd.rs"
+    ],
+    "purpose": "Implement and validate the Claude Opus 5 provider profile and setup route"
+  },
+  "initial": {
+    "title": "[v0.91.8][provider] Add Anthropic Claude Opus 5 provider profile",
+    "slug": "anthropic-claude-opus-5-provider",
+    "version": "v0.91.8",
+    "goal": "Add a first-class Claude Opus 5 provider profile and setup route using the existing Rust-native Anthropic Messages adapter.",
+    "required_outcome": "Profile expansion, setup generation, and focused mocked adapter proof for claude-opus-5.",
+    "declared_scope": ["adl/src/provider/profiles.rs", "adl/src/provider/mod.rs", "adl/src/cli/provider_cmd.rs"],
+    "acceptance_criteria": [
+      "AC-1: claude:claude-opus-5 resolves to the Anthropic provider kind, endpoint, and canonical model id.",
+      "AC-2: Existing Claude profiles remain unchanged and profile expansion preserves vendor identity.",
+      "AC-3: provider setup claude-opus-5 emits the profile and ANTHROPIC_API_KEY route.",
+      "AC-4: Mocked Anthropic adapter proof verifies claude-opus-5 and the canonical version header.",
+      "AC-5: Focused Rust validation and exact-head review pass without a live provider call."
+    ],
+    "authority_boundary": ["The change defines local provider routing only; it does not provision credentials, call Anthropic live, or approve release policy."],
+    "task_boundary": "Implement the Opus 5 profile/setup route and bounded tests in the existing provider modules.",
+    "deliverables": ["provider profile", "setup template", "focused Rust tests", "design and diagram"],
+    "dependencies": ["existing Rust-native Anthropic Messages adapter", "canonical model id claude-opus-5"],
+    "repo_inputs": ["adl/src/provider/profiles.rs", "adl/src/provider/mod.rs", "adl/src/cli/provider_cmd.rs", "adl/src/provider/http_family.rs"],
+    "non_goals": ["new transport", "live API call", "credential provisioning", "pricing or benchmarking"],
+    "operator_constraints": ["never write main", "use typed v2 binaries", "no raw gh", "no AWS", "no direct card/state edits"],
+    "steps": [
+      {"id":"S1","action":"Bind the issue worktree and normalize the six lifecycle cards","acceptance_ids":["AC-1","AC-2","AC-3"],"status":"pending"},
+      {"id":"S2","action":"Implement profile expansion, setup generation, and focused mock proof","acceptance_ids":["AC-1","AC-2","AC-3","AC-4"],"status":"pending"},
+      {"id":"S3","action":"Run focused validation, exact-head review, and publish a draft PR","acceptance_ids":["AC-5"],"status":"pending"}
+    ],
+    "invariants": ["Existing Claude profiles remain compatible", "Anthropic credentials stay on ANTHROPIC_API_KEY", "No live provider call is required", "main remains untouched"],
+    "risks": ["Routing Opus 5 through generic HTTP would lose Anthropic request semantics", "setup family drift", "unsupported model id claims"],
+    "planning_profile": "small",
+    "stop_conditions": ["canonical model id cannot be verified", "existing adapter lacks mock proof surface", "focused validation fails without a bounded repair"],
+    "validation_lanes": [
+      {"lane":"provider-profile-focused","proof_role":"registry, expansion, setup, and mocked Anthropic request proof","acceptance_ids":["AC-1","AC-2","AC-3","AC-4","AC-5"],"deterministic":true,"resource_profile":"small","budget_seconds":600,"budget_tokens":4000,"argv":["cargo","test","--manifest-path","adl/Cargo.toml","provider_"],"parallel_group":"local","defer_reason":null},
+      {"lane":"provider-build-focused","proof_role":"compile the touched Rust provider surface","acceptance_ids":["AC-5"],"deterministic":true,"resource_profile":"small","budget_seconds":300,"budget_tokens":2000,"argv":["cargo","check","--manifest-path","adl/Cargo.toml"],"parallel_group":"local","defer_reason":null}
+    ],
+    "failure_policy": "Fail closed on model, endpoint, credential, or proof drift; repair only the bounded provider surface.",
+    "review_prompts": ["Check that Opus 5 uses the Rust Anthropic adapter rather than generic HTTP", "Check compatibility of existing Claude profiles", "Check setup output, credential boundary, and mocked request proof"],
+    "review_scope": "provider profile registry, setup template, and focused tests",
+    "plan_summary": "Add the canonical Claude Opus 5 profile and setup route on the existing Rust Anthropic adapter, prove it with focused mocks, review the exact head, and publish a draft PR."
+  }
+}

--- a/.csdlc/prepared/issues/5671/design.md
+++ b/.csdlc/prepared/issues/5671/design.md
@@ -1,0 +1,34 @@
+# Issue #5671 — Anthropic Claude Opus 5 provider
+
+## Goal
+
+Add a first-class Claude Opus 5 provider profile and setup route while reusing
+the existing Rust-native Anthropic Messages adapter.
+
+## Design
+
+The profile `claude:claude-opus-5` expands to the Anthropic provider kind,
+the canonical model id `claude-opus-5`, the Messages API endpoint, and the
+`ANTHROPIC_API_KEY` credential boundary. A `provider setup claude-opus-5`
+template emits that profile and a reproducible local setup bundle.
+
+No second transport, shell wrapper, live credential, or live provider call is
+introduced. Focused tests use the existing mock HTTP harness to prove request
+headers, model selection, response extraction, and setup rendering.
+
+## Acceptance
+
+1. The profile registry contains `claude:claude-opus-5` with Anthropic kind,
+   endpoint, default model, and provider model id.
+2. Profile expansion produces an Anthropic provider without changing existing
+   Claude profiles.
+3. The setup command accepts `claude-opus-5` and emits the canonical model and
+   credential variable.
+4. Mocked adapter proof verifies the Opus 5 model and Anthropic version header.
+5. Focused Rust validation and exact-head review pass without a live API call.
+
+## Scope boundary
+
+Only provider profile expansion, setup generation, and focused tests are in
+scope. Pricing, account provisioning, credentials, fallback policy, and model
+benchmarking are follow-on work.

--- a/.csdlc/prepared/issues/5671/diagram.mmd
+++ b/.csdlc/prepared/issues/5671/diagram.mmd
@@ -1,0 +1,7 @@
+flowchart LR
+  A["provider setup claude-opus-5"] --> B["claude:claude-opus-5 profile"]
+  B --> C["profile expansion"]
+  C --> D["Rust Anthropic Messages adapter"]
+  E["ANTHROPIC_API_KEY"] -. credential boundary .-> D
+  D --> F["mock HTTP proof"]
+  F --> G["model claude-opus-5 + version header"]

--- a/.csdlc/prepared/issues/5671/finalize-request.json
+++ b/.csdlc/prepared/issues/5671/finalize-request.json
@@ -1,0 +1,25 @@
+{
+  "schema": "csdlc.finalize_request.v1",
+  "issue": 5671,
+  "expected_generation": 1,
+  "expected_digest": "8e75fa77b6813b3cd85694f6a2de9695fb0993e36c1e6271166994b47eac6804",
+  "claim_id": "claim-5671-anthropic-opus-5",
+  "actor": "codex:5671-execution",
+  "summary": "Implemented Claude Opus 5 profile, setup template, and focused provider proof.",
+  "changes": ["adl/src/provider/profiles.rs", "adl/src/provider/mod.rs", "adl/src/provider/http_family/tests.rs", "adl/src/cli/provider_cmd.rs", "adl/src/cli/usage.rs", "adl/tests/provider_tests/profiles.rs"],
+  "artifacts": [".csdlc/prepared/issues/5671/validation-evidence/provider-profile-focused.log", ".csdlc/prepared/issues/5671/validation-evidence/provider-build-focused.log"],
+  "execution": {
+    "manifest": {
+      "schema": "csdlc.pvf.manifest.v1",
+      "lanes": [
+        {"id":"provider-profile-focused","proof_role":"registry expansion setup and mocked Anthropic request proof","purpose":"Run the focused provider test suite for Opus 5","determinism":"deterministic","resources":{"cpu_units":2,"memory_mib":2048,"tokens":4000},"credentials":[],"network":"denied","dependencies":[],"parallel_group":"local","release_gate":"required","execution":"local","timeout_seconds":600,"executable":"cargo","argv":["test","--manifest-path","adl/Cargo.toml","provider_"],"evidence":{"max_log_bytes":200000,"redact_values":[],"require_relative_paths":true}},
+        {"id":"provider-build-focused","proof_role":"compile the touched Rust provider surface","purpose":"Compile the ADL crate after the provider change","determinism":"deterministic","resources":{"cpu_units":2,"memory_mib":2048,"tokens":2000},"credentials":[],"network":"denied","dependencies":["provider-profile-focused"],"parallel_group":"local","release_gate":"required","execution":"local","timeout_seconds":300,"executable":"cargo","argv":["check","--manifest-path","adl/Cargo.toml"],"evidence":{"max_log_bytes":200000,"redact_values":[],"require_relative_paths":true}}
+      ]
+    },
+    "selection":{"requested_lanes":["provider-profile-focused","provider-build-focused"],"allow_network":false,"available_credentials":[]},
+    "budget":{"max_parallel":1,"cpu_units":2,"memory_mib":2048,"tokens":6000},
+    "root":"/Volumes/FastWork/adl-5671-opus-5",
+    "evidence_dir":"/Volumes/FastWork/adl-5671-opus-5/.csdlc/evidence/5671",
+    "cancellation_file":null
+  }
+}

--- a/.csdlc/prepared/issues/5671/opus-review-request.json
+++ b/.csdlc/prepared/issues/5671/opus-review-request.json
@@ -1,0 +1,10 @@
+{
+  "model": "claude-opus-5",
+  "max_tokens": 1200,
+  "messages": [
+    {
+      "role": "user",
+      "content": "Review issue #5671 implementation for correctness and scope. The change adds claude:claude-opus-5 as an Anthropic Messages profile with model claude-opus-5, adds provider setup claude-opus-5, and updates focused registry/setup/adapter tests. Existing Claude profiles remain generic HTTP. Identify only actionable defects or missing proof; if none, respond exactly NO_FINDINGS. Do not request a live provider call as a prerequisite."
+    }
+  ]
+}

--- a/.csdlc/prepared/issues/5671/publish-request.json
+++ b/.csdlc/prepared/issues/5671/publish-request.json
@@ -1,0 +1,16 @@
+{
+  "schema": "csdlc.publication_request.v1",
+  "issue": 5671,
+  "repository": "danielbaustin/agent-design-language",
+  "remote": "origin",
+  "base": "main",
+  "head": "codex/5671-anthropic-opus-5",
+  "title": "[v0.91.8][provider] Add Anthropic Claude Opus 5 provider profile",
+  "body": "Implements #5671. Adds the canonical claude:claude-opus-5 profile, provider setup route, end-to-end profile expansion/build proof, and mocked Anthropic Messages request validation. No live provider credential is required for the local proof; a live Opus review remains pending because no approved Anthropic key file is configured.",
+  "draft": true,
+  "expected_generation": 4,
+  "expected_digest": "fca2fcc03b8589d5023abf186aa3117e73a3c2747d244d5c88c36960b69ce964",
+  "claim_id": "claim-5671-anthropic-opus-5",
+  "actor": "codex:5671-execution",
+  "token_file": null
+}

--- a/.csdlc/prepared/issues/5671/publish-request.json
+++ b/.csdlc/prepared/issues/5671/publish-request.json
@@ -8,8 +8,8 @@
   "title": "[v0.91.8][provider] Add Anthropic Claude Opus 5 provider profile",
   "body": "Implements #5671. Adds the canonical claude:claude-opus-5 profile, provider setup route, end-to-end profile expansion/build proof, and mocked Anthropic Messages request validation. No live provider credential is required for the local proof; a live Opus review remains pending because no approved Anthropic key file is configured.",
   "draft": true,
-  "expected_generation": 4,
-  "expected_digest": "fca2fcc03b8589d5023abf186aa3117e73a3c2747d244d5c88c36960b69ce964",
+  "expected_generation": 5,
+  "expected_digest": "e04bb0143ad366aca3c13c5f0b907c0a93d1cf2c8c2040c09357fcea5710db7e",
   "claim_id": "claim-5671-anthropic-opus-5",
   "actor": "codex:5671-execution",
   "token_file": null

--- a/.csdlc/prepared/issues/5671/review-assign.json
+++ b/.csdlc/prepared/issues/5671/review-assign.json
@@ -1,0 +1,9 @@
+{
+  "issue": 5671,
+  "expected_generation": 2,
+  "expected_digest": "16e0e05b9bd713ec0245c3b2bebde2125c37e076bd9b47bf793a0d5b6a2655f8",
+  "claim_id": "claim-5671-anthropic-opus-5",
+  "reviewer": "codex:5671-subagent-review",
+  "assigned_by": "codex:5671-execution",
+  "scope": ["adl/src/provider/profiles.rs", "adl/src/provider/mod.rs", "adl/src/provider/http_family/tests.rs", "adl/src/cli/provider_cmd.rs", "adl/src/cli/usage.rs", "adl/tests/provider_tests/profiles.rs"]
+}

--- a/.csdlc/prepared/issues/5671/review-record.json
+++ b/.csdlc/prepared/issues/5671/review-record.json
@@ -1,0 +1,18 @@
+{
+  "issue": 5671,
+  "expected_generation": 2,
+  "expected_digest": "59e2b0522123ae9b2e009db87fb80b6263b74fdf7cbbdf8c483bcf90fc507dad",
+  "claim_id": "claim-5671-anthropic-opus-5",
+  "actor": "codex:5671-subagent-review",
+  "evidence": {
+    "reviewer": "codex:5671-subagent-review",
+    "scope": ["adl/src/provider/profiles.rs", "adl/src/provider/mod.rs", "adl/src/provider/http_family/tests.rs", "adl/src/cli/provider_cmd.rs", "adl/src/cli/usage.rs", "adl/tests/provider_tests/profiles.rs"],
+    "reviewed_revision": "git-blake3:86a1bfbc250954bfede4eec8ea8e1a2d314c07ff:4d4fe30bfe94daa9b40e484fc4897f8837ff1f3114858b35e6b85b688bb73be9",
+    "findings": [
+      {"id":"R-5671-001","severity":"p2","summary":"The initial implementation needed an end-to-end expansion/build assertion and typed scope coverage for the added integration and usage paths.","actionable":true,"in_scope":true,"disposition":"fixed","fix_revision":"git-blake3:86a1bfbc250954bfede4eec8ea8e1a2d314c07ff:4d4fe30bfe94daa9b40e484fc4897f8837ff1f3114858b35e6b85b688bb73be9","route":null}
+    ],
+    "residual_risks": ["No live Anthropic credential was available in the approved key-file route, so live Opus review remains unproven; mocked HTTP proof and real local adapter execution pass."],
+    "completed": true,
+    "non_substantive_proof": null
+  }
+}

--- a/.csdlc/prepared/issues/5671/validation-request.json
+++ b/.csdlc/prepared/issues/5671/validation-request.json
@@ -1,0 +1,46 @@
+{
+  "manifest": {
+    "schema": "csdlc.pvf.manifest.v1",
+    "lanes": [
+      {
+        "id": "provider-profile-focused",
+        "proof_role": "registry expansion setup and mocked Anthropic request proof",
+        "purpose": "Run the focused provider test suite for Opus 5",
+        "determinism": "deterministic",
+        "resources": {"cpu_units": 2, "memory_mib": 2048, "tokens": 4000},
+        "credentials": [],
+        "network": "denied",
+        "dependencies": [],
+        "parallel_group": "local",
+        "release_gate": "required",
+        "execution": "local",
+        "timeout_seconds": 600,
+        "executable": "cargo",
+        "argv": ["test", "--manifest-path", "adl/Cargo.toml", "provider_"],
+        "evidence": {"max_log_bytes": 200000, "redact_values": [], "require_relative_paths": true}
+      },
+      {
+        "id": "provider-build-focused",
+        "proof_role": "compile the touched Rust provider surface",
+        "purpose": "Compile the ADL crate after the provider change",
+        "determinism": "deterministic",
+        "resources": {"cpu_units": 2, "memory_mib": 2048, "tokens": 2000},
+        "credentials": [],
+        "network": "denied",
+        "dependencies": ["provider-profile-focused"],
+        "parallel_group": "local",
+        "release_gate": "required",
+        "execution": "local",
+        "timeout_seconds": 300,
+        "executable": "cargo",
+        "argv": ["check", "--manifest-path", "adl/Cargo.toml"],
+        "evidence": {"max_log_bytes": 200000, "redact_values": [], "require_relative_paths": true}
+      }
+    ]
+  },
+  "selection": {"requested_lanes": ["provider-profile-focused", "provider-build-focused"], "allow_network": false, "available_credentials": []},
+  "budget": {"max_parallel": 1, "cpu_units": 2, "memory_mib": 2048, "tokens": 6000},
+  "root": "/Volumes/FastWork/adl-5671-opus-5",
+  "evidence_dir": ".csdlc/prepared/issues/5671/validation-evidence",
+  "cancellation_file": null
+}

--- a/.csdlc/publication/5671.intent.json
+++ b/.csdlc/publication/5671.intent.json
@@ -7,6 +7,6 @@
   "title": "[v0.91.8][provider] Add Anthropic Claude Opus 5 provider profile",
   "body": "Implements #5671. Adds the canonical claude:claude-opus-5 profile, provider setup route, end-to-end profile expansion/build proof, and mocked Anthropic Messages request validation. No live provider credential is required for the local proof; a live Opus review remains pending because no approved Anthropic key file is configured.",
   "draft": true,
-  "revision": "git-blake3:86a1bfbc250954bfede4eec8ea8e1a2d314c07ff:4d4fe30bfe94daa9b40e484fc4897f8837ff1f3114858b35e6b85b688bb73be9",
-  "commit_sha": "86a1bfbc250954bfede4eec8ea8e1a2d314c07ff"
+  "revision": "git-blake3:f10d7a87020272b9cc340da35262c3d53d98e572:7dfd9ba093ef5f283b9bbfc66588b999a6384206b9ea9ed92592bba71cb0e1f3",
+  "commit_sha": "f10d7a87020272b9cc340da35262c3d53d98e572"
 }

--- a/.csdlc/publication/5671.intent.json
+++ b/.csdlc/publication/5671.intent.json
@@ -1,0 +1,12 @@
+{
+  "schema": "csdlc.publication_intent.v1",
+  "issue": 5671,
+  "repository": "danielbaustin/agent-design-language",
+  "base": "main",
+  "head": "codex/5671-anthropic-opus-5",
+  "title": "[v0.91.8][provider] Add Anthropic Claude Opus 5 provider profile",
+  "body": "Implements #5671. Adds the canonical claude:claude-opus-5 profile, provider setup route, end-to-end profile expansion/build proof, and mocked Anthropic Messages request validation. No live provider credential is required for the local proof; a live Opus review remains pending because no approved Anthropic key file is configured.",
+  "draft": true,
+  "revision": "git-blake3:86a1bfbc250954bfede4eec8ea8e1a2d314c07ff:4d4fe30bfe94daa9b40e484fc4897f8837ff1f3114858b35e6b85b688bb73be9",
+  "commit_sha": "86a1bfbc250954bfede4eec8ea8e1a2d314c07ff"
+}

--- a/adl/src/cli/provider_cmd.rs
+++ b/adl/src/cli/provider_cmd.rs
@@ -148,6 +148,18 @@ fn template_for_family(family: &str) -> Result<&'static ProviderSetupTemplate> {
             endpoint_hint: Some("https://api.example.invalid/v1/complete"),
             notes: "Use this when you want the first-class Claude family surface. Keep the endpoint pointed at an ADL-compatible completion endpoint and supply your Anthropic credential through the generated env file.",
         },
+        "claude-opus-5" => &ProviderSetupTemplate {
+            family: "claude-opus-5",
+            profile: Some("claude:claude-opus-5"),
+            kind: None,
+            env_var: "ANTHROPIC_API_KEY",
+            provider_id: "claude_opus_5_primary",
+            agent_id: "claude_opus_5_agent",
+            model_ref: "claude-opus-5",
+            provider_model_id: "claude-opus-5",
+            endpoint_hint: Some("https://api.anthropic.com/v1/messages"),
+            notes: "Use this for the first-class Claude Opus 5 profile. The profile selects the Rust-native Anthropic Messages adapter and the canonical claude-opus-5 model; supply your Anthropic credential through the generated env file.",
+        },
         "openai" => &ProviderSetupTemplate {
             family: "openai",
             profile: None,
@@ -246,7 +258,7 @@ fn template_for_family(family: &str) -> Result<&'static ProviderSetupTemplate> {
         },
         other => {
             return Err(anyhow!(
-                "unsupported provider setup family '{other}' (supported: chatgpt, claude, openai, anthropic, gemini, deepseek, openrouter, bedrock, z_ai, http)"
+                "unsupported provider setup family '{other}' (supported: chatgpt, claude, claude-opus-5, openai, anthropic, gemini, deepseek, openrouter, bedrock, z_ai, http)"
             ))
         }
     };
@@ -476,6 +488,26 @@ mod tests {
     }
 
     #[test]
+    fn provider_setup_writes_expected_bundle_for_claude_opus_5() {
+        let repo = temp_repo("claude-opus-5");
+        real_provider_in_repo(&["setup".to_string(), "claude-opus-5".to_string()], &repo)
+            .expect("claude opus 5 setup should succeed");
+
+        let out = repo.join(".adl/provider-setup/claude-opus-5");
+        let provider_text =
+            fs::read_to_string(out.join("provider.adl.yaml")).expect("provider yaml");
+        let env_text = fs::read_to_string(out.join("env.example")).expect("env example");
+        let readme = fs::read_to_string(out.join("README.md")).expect("readme");
+
+        assert!(provider_text.contains("profile: \"claude:claude-opus-5\""));
+        assert!(provider_text.contains("model: \"claude-opus-5\""));
+        assert!(provider_text.contains("provider: \"claude_opus_5_primary\""));
+        assert!(provider_text.contains("env: ANTHROPIC_API_KEY"));
+        assert!(env_text.contains("ANTHROPIC_API_KEY=replace-me"));
+        assert!(readme.contains("Rust-native Anthropic Messages adapter"));
+    }
+
+    #[test]
     fn provider_setup_writes_bedrock_account_pin_material() {
         let repo = temp_repo("bedrock");
         real_provider_in_repo(&["setup".to_string(), "bedrock".to_string()], &repo)
@@ -628,6 +660,11 @@ mod tests {
             (
                 "claude",
                 "profile: \"claude:claude-3-7-sonnet\"",
+                "ANTHROPIC_API_KEY",
+            ),
+            (
+                "claude-opus-5",
+                "profile: \"claude:claude-opus-5\"",
                 "ANTHROPIC_API_KEY",
             ),
             ("openai", "type: \"openai\"", "OPENAI_API_KEY"),

--- a/adl/src/cli/usage.rs
+++ b/adl/src/cli/usage.rs
@@ -153,6 +153,7 @@ Examples:
   adl scheduler plan --input adl/tests/fixtures/scheduler/economics_inputs_v1.json --out artifacts/examples/scheduler-plan.json
   adl provider setup chatgpt
   adl provider setup claude
+  adl provider setup claude-opus-5
   adl provider setup openrouter
   adl provider setup bedrock
   adl provider setup z_ai

--- a/adl/src/provider/http_family/tests.rs
+++ b/adl/src/provider/http_family/tests.rs
@@ -932,7 +932,7 @@ fn anthropic_provider_complete_records_output_and_version_header() {
     let target = provider_target(
         "anthropic",
         format!("{endpoint}/v1/messages"),
-        "claude-test",
+        "claude-opus-5",
     );
     let provider = AnthropicProvider::from_target(&spec, &target).expect("provider");
 
@@ -941,7 +941,7 @@ fn anthropic_provider_complete_records_output_and_version_header() {
 
     let captured = captured.lock().expect("capture").clone().expect("request");
     assert_eq!(captured.url, "/v1/messages");
-    assert!(captured.body.contains(r#""model":"claude-test""#));
+    assert!(captured.body.contains(r#""model":"claude-opus-5""#));
     assert!(captured.body.contains(r#""max_tokens":220"#));
     assert!(captured
         .headers

--- a/adl/src/provider/mod.rs
+++ b/adl/src/provider/mod.rs
@@ -479,6 +479,7 @@ mod tests {
         let names = provider_profile_names();
         assert!(names.contains(&"claude:claude-3-7-sonnet".to_string()));
         assert!(names.contains(&"claude:claude-3-5-haiku".to_string()));
+        assert!(names.contains(&"claude:claude-opus-5".to_string()));
 
         let preset = provider_profile_registry()
             .get("claude:claude-3-7-sonnet")
@@ -486,6 +487,15 @@ mod tests {
             .expect("claude sonnet preset");
         assert_eq!(preset.kind, "http");
         assert_eq!(preset.default_model, Some("claude-3-7-sonnet-latest"));
+
+        let opus = provider_profile_registry()
+            .get("claude:claude-opus-5")
+            .copied()
+            .expect("claude opus 5 preset");
+        assert_eq!(opus.kind, "anthropic");
+        assert_eq!(opus.default_model, Some("claude-opus-5"));
+        assert_eq!(opus.provider_model_id, Some("claude-opus-5"));
+        assert_eq!(opus.endpoint, Some(ANTHROPIC_MESSAGES_ENDPOINT));
     }
 
     #[test]

--- a/adl/src/provider/profiles.rs
+++ b/adl/src/provider/profiles.rs
@@ -290,6 +290,15 @@ pub(crate) fn provider_profile_registry() -> BTreeMap<&'static str, ProviderProf
         );
     }
     // Claude-facing presets (same bounded HTTP substrate, distinct profile family)
+    m.insert(
+        "claude:claude-opus-5",
+        ProviderProfilePreset {
+            kind: "anthropic",
+            default_model: Some("claude-opus-5"),
+            provider_model_id: Some("claude-opus-5"),
+            endpoint: Some(ANTHROPIC_MESSAGES_ENDPOINT),
+        },
+    );
     for (name, model) in [
         ("claude:claude-3-7-sonnet", "claude-3-7-sonnet-latest"),
         ("claude:claude-3-5-haiku", "claude-3-5-haiku-latest"),

--- a/adl/tests/provider_tests/profiles.rs
+++ b/adl/tests/provider_tests/profiles.rs
@@ -1,4 +1,4 @@
-use ::adl::provider::{expand_provider_profiles, provider_profile_names};
+use ::adl::provider::{build_provider, expand_provider_profiles, provider_profile_names};
 
 use super::support::adl_doc_from_yaml;
 
@@ -465,6 +465,48 @@ run:
             .and_then(|v| v.as_str()),
         Some("ANTHROPIC_API_KEY")
     );
+}
+
+#[test]
+fn expand_provider_profiles_builds_claude_opus_5_anthropic_provider() {
+    let doc = adl_doc_from_yaml(
+        r#"
+version: "0.5"
+providers:
+  opus:
+    profile: "claude:claude-opus-5"
+agents:
+  reviewer:
+    provider: "opus"
+    model: "claude-opus-5"
+tasks:
+  review:
+    prompt:
+      user: "review"
+run:
+  workflow:
+    kind: sequential
+    steps:
+      - agent: "reviewer"
+        task: "review"
+"#,
+    );
+    let expanded = expand_provider_profiles(&doc).expect("profile expansion should succeed");
+    let provider = &expanded.providers["opus"];
+    assert_eq!(provider.kind, "anthropic");
+    assert_eq!(provider.default_model.as_deref(), Some("claude-opus-5"));
+    assert_eq!(
+        provider
+            .config
+            .get("provider_model_id")
+            .and_then(|v| v.as_str()),
+        Some("claude-opus-5")
+    );
+    assert_eq!(
+        provider.config.get("endpoint").and_then(|v| v.as_str()),
+        Some("https://api.anthropic.com/v1/messages")
+    );
+    build_provider(provider, None).expect("expanded profile should build Anthropic provider");
 }
 
 #[test]


### PR DESCRIPTION
Implements #5671. Adds the canonical claude:claude-opus-5 profile, provider setup route, end-to-end profile expansion/build proof, and mocked Anthropic Messages request validation. No live provider credential is required for the local proof; a live Opus review remains pending because no approved Anthropic key file is configured.

Closes #5671
