### PR TITLE
[v0.91.8][ci][coverage] Avoid duplicate hosted coverage on podcast/demo page PRs

### DIFF
--- a/.csdlc/evidence/5719/ci-path-policy-podcast-launch-contract.log
+++ b/.csdlc/evidence/5719/ci-path-policy-podcast-launch-contract.log
@@ -1,0 +1,169 @@
+PASS test_warm_rust_dependency_cache
+Authoritative coverage mode: bounded_policy_surface_pr
+Features: default
+Full authoritative default-feature proof remains reserved for push-to-main and mixed runtime policy changes.
+Authoritative coverage test threads: 4
+Authoritative coverage skip patterns: real_pr_,runtime_v2_runtime_inhabitant_integration_proof_route_paths_exist,runtime_v2_runtime_inhabitant_integration_contract_is_stable,runtime_v2_runtime_inhabitant_integration_matches_golden_fixture_and_report,runtime_v2_runtime_inhabitant_integration_validation_rejects_metadata_drift,runtime_v2_runtime_inhabitant_integration_validation_rejects_stage_and_trace_gaps,runtime_v2_runtime_inhabitant_integration_validate_against_rejects_dependency_drift,runtime_v2_runtime_inhabitant_integration_contract_registry_smoke_covers_accessors,csmctl_authenticated_api_client_waits_for_slow_listener_startup
+{"status":"skipped","reason":"source target cache missing","source_target":"/Volumes/FastWork/adl-wp-5719/adl/target","dest_target":"/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T//authoritative-coverage.Oaqy3Q/scratch/target/llvm-cov-target/run-a/adl-runtime","validation_proof":false}
+Authoritative coverage companion: adl-runtime
+{"status":"skipped","reason":"source target cache missing","source_target":"/Volumes/FastWork/adl-wp-5719/adl/target","dest_target":"/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T//authoritative-coverage.Oaqy3Q/scratch/target/llvm-cov-target/run-a/workspace","validation_proof":false}
+Authoritative coverage mode: bounded_policy_surface_pr
+Features: default
+Full authoritative default-feature proof remains reserved for push-to-main and mixed runtime policy changes.
+Authoritative coverage test threads: 4
+Authoritative coverage skip patterns: real_pr_,runtime_v2_runtime_inhabitant_integration_proof_route_paths_exist,runtime_v2_runtime_inhabitant_integration_contract_is_stable,runtime_v2_runtime_inhabitant_integration_matches_golden_fixture_and_report,runtime_v2_runtime_inhabitant_integration_validation_rejects_metadata_drift,runtime_v2_runtime_inhabitant_integration_validation_rejects_stage_and_trace_gaps,runtime_v2_runtime_inhabitant_integration_validate_against_rejects_dependency_drift,runtime_v2_runtime_inhabitant_integration_contract_registry_smoke_covers_accessors,csmctl_authenticated_api_client_waits_for_slow_listener_startup
+{"status":"skipped","reason":"source target cache missing","source_target":"/Volumes/FastWork/adl-wp-5719/adl/target","dest_target":"/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T//authoritative-coverage.Oaqy3Q/scratch/target/llvm-cov-target/run-collect-shard/workspace","validation_proof":false}
+Authoritative coverage mode: bounded_policy_surface_pr
+Features: default
+Full authoritative default-feature proof remains reserved for push-to-main and mixed runtime policy changes.
+Authoritative coverage test threads: 4
+Authoritative coverage skip patterns: real_pr_,runtime_v2_runtime_inhabitant_integration_proof_route_paths_exist,runtime_v2_runtime_inhabitant_integration_contract_is_stable,runtime_v2_runtime_inhabitant_integration_matches_golden_fixture_and_report,runtime_v2_runtime_inhabitant_integration_validation_rejects_metadata_drift,runtime_v2_runtime_inhabitant_integration_validation_rejects_stage_and_trace_gaps,runtime_v2_runtime_inhabitant_integration_validate_against_rejects_dependency_drift,runtime_v2_runtime_inhabitant_integration_contract_registry_smoke_covers_accessors,csmctl_authenticated_api_client_waits_for_slow_listener_startup
+{"status":"skipped","reason":"source target cache missing","source_target":"/Volumes/FastWork/adl-wp-5719/adl/target","dest_target":"/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T//authoritative-coverage.Oaqy3Q/scratch/target/llvm-cov-target/run-report-only/workspace","validation_proof":false}
+Imported coverage profraw profiles: 1
+Authoritative coverage mode: full_authoritative_default_features
+Features: default
+Authoritative coverage linker mode: default
+Authoritative coverage test threads: 4
+Authoritative coverage skip patterns: real_pr_,runtime_v2_runtime_inhabitant_integration_proof_route_paths_exist,runtime_v2_runtime_inhabitant_integration_contract_is_stable,runtime_v2_runtime_inhabitant_integration_matches_golden_fixture_and_report,runtime_v2_runtime_inhabitant_integration_validation_rejects_metadata_drift,runtime_v2_runtime_inhabitant_integration_validation_rejects_stage_and_trace_gaps,runtime_v2_runtime_inhabitant_integration_validate_against_rejects_dependency_drift,runtime_v2_runtime_inhabitant_integration_contract_registry_smoke_covers_accessors,csmctl_authenticated_api_client_waits_for_slow_listener_startup
+{"status":"skipped","reason":"source target cache missing","source_target":"/Volumes/FastWork/adl-wp-5719/adl/target","dest_target":"/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T//authoritative-coverage.Oaqy3Q/scratch/target/llvm-cov-target/run-isolated-workspace/workspace","validation_proof":false}
+Authoritative coverage mode: full_authoritative_default_features
+Features: default
+Authoritative coverage linker mode: default
+Authoritative coverage test threads: 4
+Authoritative coverage skip patterns: real_pr_,runtime_v2_runtime_inhabitant_integration_proof_route_paths_exist,runtime_v2_runtime_inhabitant_integration_contract_is_stable,runtime_v2_runtime_inhabitant_integration_matches_golden_fixture_and_report,runtime_v2_runtime_inhabitant_integration_validation_rejects_metadata_drift,runtime_v2_runtime_inhabitant_integration_validation_rejects_stage_and_trace_gaps,runtime_v2_runtime_inhabitant_integration_validate_against_rejects_dependency_drift,runtime_v2_runtime_inhabitant_integration_contract_registry_smoke_covers_accessors,csmctl_authenticated_api_client_waits_for_slow_listener_startup
+{"status":"skipped","reason":"source target cache missing","source_target":"/Volumes/FastWork/adl-wp-5719/adl/target","dest_target":"/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T//authoritative-coverage.Oaqy3Q/scratch/target/llvm-cov-target/run-isolated-adl-runtime/adl-runtime","validation_proof":false}
+Authoritative coverage companion: adl-runtime
+Authoritative coverage mode: full_authoritative_default_features
+Features: default
+Authoritative coverage linker mode: default
+Authoritative coverage test threads: 4
+Authoritative coverage skip patterns: real_pr_,runtime_v2_runtime_inhabitant_integration_proof_route_paths_exist,runtime_v2_runtime_inhabitant_integration_contract_is_stable,runtime_v2_runtime_inhabitant_integration_matches_golden_fixture_and_report,runtime_v2_runtime_inhabitant_integration_validation_rejects_metadata_drift,runtime_v2_runtime_inhabitant_integration_validation_rejects_stage_and_trace_gaps,runtime_v2_runtime_inhabitant_integration_validate_against_rejects_dependency_drift,runtime_v2_runtime_inhabitant_integration_contract_registry_smoke_covers_accessors,csmctl_authenticated_api_client_waits_for_slow_listener_startup
+{"status":"skipped","reason":"source target cache missing","source_target":"/Volumes/FastWork/adl-wp-5719/adl/target","dest_target":"/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T//authoritative-coverage.Oaqy3Q/scratch/target/llvm-cov-target/run-release-artifacts/workspace","validation_proof":false}
+workspace summary from current isolated profile
+Authoritative coverage mode: full_authoritative_default_features
+Features: default
+Authoritative coverage linker mode: default
+Authoritative coverage test threads: 4
+Authoritative coverage skip patterns: real_pr_,runtime_v2_runtime_inhabitant_integration_proof_route_paths_exist,runtime_v2_runtime_inhabitant_integration_contract_is_stable,runtime_v2_runtime_inhabitant_integration_matches_golden_fixture_and_report,runtime_v2_runtime_inhabitant_integration_validation_rejects_metadata_drift,runtime_v2_runtime_inhabitant_integration_validation_rejects_stage_and_trace_gaps,runtime_v2_runtime_inhabitant_integration_validate_against_rejects_dependency_drift,runtime_v2_runtime_inhabitant_integration_contract_registry_smoke_covers_accessors,csmctl_authenticated_api_client_waits_for_slow_listener_startup
+Authoritative coverage mode: bounded_policy_surface_pr
+Features: default
+Full authoritative default-feature proof remains reserved for push-to-main and mixed runtime policy changes.
+Authoritative coverage test threads: 4
+Authoritative coverage skip patterns: real_pr_,runtime_v2_runtime_inhabitant_integration_proof_route_paths_exist,runtime_v2_runtime_inhabitant_integration_contract_is_stable,runtime_v2_runtime_inhabitant_integration_matches_golden_fixture_and_report,runtime_v2_runtime_inhabitant_integration_validation_rejects_metadata_drift,runtime_v2_runtime_inhabitant_integration_validation_rejects_stage_and_trace_gaps,runtime_v2_runtime_inhabitant_integration_validate_against_rejects_dependency_drift,runtime_v2_runtime_inhabitant_integration_contract_registry_smoke_covers_accessors,csmctl_authenticated_api_client_waits_for_slow_listener_startup
+{"status":"skipped","reason":"source target cache missing","source_target":"/Volumes/FastWork/adl-wp-5719/adl/target","dest_target":"/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T//authoritative-coverage.Oaqy3Q/scratch/target/llvm-cov-target/run-prebuild-failure/adl-runtime","validation_proof":false}
+Authoritative coverage companion: adl-runtime
+{"status":"skipped","reason":"source target cache missing","source_target":"/Volumes/FastWork/adl-wp-5719/adl/target","dest_target":"/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T//authoritative-coverage.Oaqy3Q/scratch/target/llvm-cov-target/run-prebuild-failure/workspace","validation_proof":false}
+Authoritative coverage mode: bounded_policy_surface_pr
+Features: default
+Full authoritative default-feature proof remains reserved for push-to-main and mixed runtime policy changes.
+Authoritative coverage test threads: 4
+Authoritative coverage skip patterns: real_pr_,runtime_v2_runtime_inhabitant_integration_proof_route_paths_exist,runtime_v2_runtime_inhabitant_integration_contract_is_stable,runtime_v2_runtime_inhabitant_integration_matches_golden_fixture_and_report,runtime_v2_runtime_inhabitant_integration_validation_rejects_metadata_drift,runtime_v2_runtime_inhabitant_integration_validation_rejects_stage_and_trace_gaps,runtime_v2_runtime_inhabitant_integration_validate_against_rejects_dependency_drift,runtime_v2_runtime_inhabitant_integration_contract_registry_smoke_covers_accessors,csmctl_authenticated_api_client_waits_for_slow_listener_startup
+{"status":"skipped","reason":"source target cache missing","source_target":"/Volumes/FastWork/adl-wp-5719/adl/target","dest_target":"/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T//authoritative-coverage.Oaqy3Q/scratch/target/llvm-cov-target/run-combined-failure/adl-runtime","validation_proof":false}
+Authoritative coverage companion: adl-runtime
+{"status":"skipped","reason":"source target cache missing","source_target":"/Volumes/FastWork/adl-wp-5719/adl/target","dest_target":"/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T//authoritative-coverage.Oaqy3Q/scratch/target/llvm-cov-target/run-combined-failure/workspace","validation_proof":false}
+Authoritative coverage mode: bounded_policy_surface_pr
+Features: default
+Full authoritative default-feature proof remains reserved for push-to-main and mixed runtime policy changes.
+Authoritative coverage test threads: 4
+Authoritative coverage skip patterns: real_pr_,runtime_v2_runtime_inhabitant_integration_proof_route_paths_exist,runtime_v2_runtime_inhabitant_integration_contract_is_stable,runtime_v2_runtime_inhabitant_integration_matches_golden_fixture_and_report,runtime_v2_runtime_inhabitant_integration_validation_rejects_metadata_drift,runtime_v2_runtime_inhabitant_integration_validation_rejects_stage_and_trace_gaps,runtime_v2_runtime_inhabitant_integration_validate_against_rejects_dependency_drift,runtime_v2_runtime_inhabitant_integration_contract_registry_smoke_covers_accessors,csmctl_authenticated_api_client_waits_for_slow_listener_startup
+{"status":"skipped","reason":"source target cache missing","source_target":"/Volumes/FastWork/adl-wp-5719/adl/target","dest_target":"/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T//authoritative-coverage.Oaqy3Q/scratch/target/llvm-cov-target/run-cleanup-failure/adl-runtime","validation_proof":false}
+Authoritative coverage companion: adl-runtime
+{"status":"skipped","reason":"source target cache missing","source_target":"/Volumes/FastWork/adl-wp-5719/adl/target","dest_target":"/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T//authoritative-coverage.Oaqy3Q/scratch/target/llvm-cov-target/run-cleanup-failure/workspace","validation_proof":false}
+Authoritative coverage mode: bounded_policy_surface_pr
+Features: default
+Full authoritative default-feature proof remains reserved for push-to-main and mixed runtime policy changes.
+Authoritative coverage test threads: 4
+Authoritative coverage skip patterns: real_pr_,runtime_v2_runtime_inhabitant_integration_proof_route_paths_exist,runtime_v2_runtime_inhabitant_integration_contract_is_stable,runtime_v2_runtime_inhabitant_integration_matches_golden_fixture_and_report,runtime_v2_runtime_inhabitant_integration_validation_rejects_metadata_drift,runtime_v2_runtime_inhabitant_integration_validation_rejects_stage_and_trace_gaps,runtime_v2_runtime_inhabitant_integration_validate_against_rejects_dependency_drift,runtime_v2_runtime_inhabitant_integration_contract_registry_smoke_covers_accessors,csmctl_authenticated_api_client_waits_for_slow_listener_startup
+{"status":"skipped","reason":"source target cache missing","source_target":"/Volumes/FastWork/adl-wp-5719/adl/target","dest_target":"/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T//authoritative-coverage.Oaqy3Q/scratch/target/llvm-cov-target/run-failing/adl-runtime","validation_proof":false}
+Authoritative coverage companion: adl-runtime
+{"status":"skipped","reason":"source target cache missing","source_target":"/Volumes/FastWork/adl-wp-5719/adl/target","dest_target":"/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T//authoritative-coverage.Oaqy3Q/scratch/target/llvm-cov-target/run-failing/workspace","validation_proof":false}
+Authoritative coverage mode: bounded_policy_surface_pr
+Features: default
+Full authoritative default-feature proof remains reserved for push-to-main and mixed runtime policy changes.
+Authoritative coverage test threads: 4
+Authoritative coverage skip patterns: real_pr_,runtime_v2_runtime_inhabitant_integration_proof_route_paths_exist,runtime_v2_runtime_inhabitant_integration_contract_is_stable,runtime_v2_runtime_inhabitant_integration_matches_golden_fixture_and_report,runtime_v2_runtime_inhabitant_integration_validation_rejects_metadata_drift,runtime_v2_runtime_inhabitant_integration_validation_rejects_stage_and_trace_gaps,runtime_v2_runtime_inhabitant_integration_validate_against_rejects_dependency_drift,runtime_v2_runtime_inhabitant_integration_contract_registry_smoke_covers_accessors,csmctl_authenticated_api_client_waits_for_slow_listener_startup
+{"status":"skipped","reason":"source target cache missing","source_target":"/Volumes/FastWork/adl-wp-5719/adl/target","dest_target":"/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T//authoritative-coverage.Oaqy3Q/scratch/target/llvm-cov-target/run-runtime-only-failure/adl-runtime","validation_proof":false}
+Authoritative coverage companion: adl-runtime
+{"status":"skipped","reason":"source target cache missing","source_target":"/Volumes/FastWork/adl-wp-5719/adl/target","dest_target":"/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T//authoritative-coverage.Oaqy3Q/scratch/target/llvm-cov-target/run-runtime-only-failure/workspace","validation_proof":false}
+Authoritative coverage mode: bounded_policy_surface_pr
+Features: default
+Full authoritative default-feature proof remains reserved for push-to-main and mixed runtime policy changes.
+Authoritative coverage test threads: 4
+Authoritative coverage skip patterns: real_pr_,runtime_v2_runtime_inhabitant_integration_proof_route_paths_exist,runtime_v2_runtime_inhabitant_integration_contract_is_stable,runtime_v2_runtime_inhabitant_integration_matches_golden_fixture_and_report,runtime_v2_runtime_inhabitant_integration_validation_rejects_metadata_drift,runtime_v2_runtime_inhabitant_integration_validation_rejects_stage_and_trace_gaps,runtime_v2_runtime_inhabitant_integration_validate_against_rejects_dependency_drift,runtime_v2_runtime_inhabitant_integration_contract_registry_smoke_covers_accessors,csmctl_authenticated_api_client_waits_for_slow_listener_startup
+{"status":"skipped","reason":"source target cache missing","source_target":"/Volumes/FastWork/adl-wp-5719/adl/target","dest_target":"/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T//authoritative-coverage.Oaqy3Q/scratch/target/llvm-cov-target/run-workspace-only-failure/adl-runtime","validation_proof":false}
+Authoritative coverage companion: adl-runtime
+{"status":"skipped","reason":"source target cache missing","source_target":"/Volumes/FastWork/adl-wp-5719/adl/target","dest_target":"/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T//authoritative-coverage.Oaqy3Q/scratch/target/llvm-cov-target/run-workspace-only-failure/workspace","validation_proof":false}
+Authoritative coverage mode: bounded_policy_surface_pr
+Features: default
+Full authoritative default-feature proof remains reserved for push-to-main and mixed runtime policy changes.
+Authoritative coverage test threads: 4
+Authoritative coverage skip patterns: real_pr_,runtime_v2_runtime_inhabitant_integration_proof_route_paths_exist,runtime_v2_runtime_inhabitant_integration_contract_is_stable,runtime_v2_runtime_inhabitant_integration_matches_golden_fixture_and_report,runtime_v2_runtime_inhabitant_integration_validation_rejects_metadata_drift,runtime_v2_runtime_inhabitant_integration_validation_rejects_stage_and_trace_gaps,runtime_v2_runtime_inhabitant_integration_validate_against_rejects_dependency_drift,runtime_v2_runtime_inhabitant_integration_contract_registry_smoke_covers_accessors,csmctl_authenticated_api_client_waits_for_slow_listener_startup
+{"status":"skipped","reason":"source target cache missing","source_target":"/Volumes/FastWork/adl-wp-5719/adl/target","dest_target":"/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T//authoritative-coverage.Oaqy3Q/scratch/target/llvm-cov-target/run-distinct-failures/adl-runtime","validation_proof":false}
+Authoritative coverage companion: adl-runtime
+{"status":"skipped","reason":"source target cache missing","source_target":"/Volumes/FastWork/adl-wp-5719/adl/target","dest_target":"/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T//authoritative-coverage.Oaqy3Q/scratch/target/llvm-cov-target/run-distinct-failures/workspace","validation_proof":false}
+Authoritative coverage mode: bounded_policy_surface_pr
+Features: default
+Authoritative coverage mode: bounded_policy_surface_pr
+Full authoritative default-feature proof remains reserved for push-to-main and mixed runtime policy changes.
+Features: default
+Authoritative coverage test threads: 4
+Full authoritative default-feature proof remains reserved for push-to-main and mixed runtime policy changes.
+Authoritative coverage test threads: 4
+Authoritative coverage skip patterns: real_pr_,runtime_v2_runtime_inhabitant_integration_proof_route_paths_exist,runtime_v2_runtime_inhabitant_integration_contract_is_stable,runtime_v2_runtime_inhabitant_integration_matches_golden_fixture_and_report,runtime_v2_runtime_inhabitant_integration_validation_rejects_metadata_drift,runtime_v2_runtime_inhabitant_integration_validation_rejects_stage_and_trace_gaps,runtime_v2_runtime_inhabitant_integration_validate_against_rejects_dependency_drift,runtime_v2_runtime_inhabitant_integration_contract_registry_smoke_covers_accessors,csmctl_authenticated_api_client_waits_for_slow_listener_startup
+Authoritative coverage skip patterns: real_pr_,runtime_v2_runtime_inhabitant_integration_proof_route_paths_exist,runtime_v2_runtime_inhabitant_integration_contract_is_stable,runtime_v2_runtime_inhabitant_integration_matches_golden_fixture_and_report,runtime_v2_runtime_inhabitant_integration_validation_rejects_metadata_drift,runtime_v2_runtime_inhabitant_integration_validation_rejects_stage_and_trace_gaps,runtime_v2_runtime_inhabitant_integration_validate_against_rejects_dependency_drift,runtime_v2_runtime_inhabitant_integration_contract_registry_smoke_covers_accessors,csmctl_authenticated_api_client_waits_for_slow_listener_startup
+{"status":"skipped","reason":"source target cache missing","source_target":"/Volumes/FastWork/adl-wp-5719/adl/target","dest_target":"/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T//authoritative-coverage.Oaqy3Q/scratch/target/llvm-cov-target/run-concurrent-b/adl-runtime","validation_proof":false}
+{"status":"skipped","reason":"source target cache missing","source_target":"/Volumes/FastWork/adl-wp-5719/adl/target","dest_target":"/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T//authoritative-coverage.Oaqy3Q/scratch/target/llvm-cov-target/run-concurrent-a/adl-runtime","validation_proof":false}
+Authoritative coverage companion: adl-runtime
+Authoritative coverage companion: adl-runtime
+{"status":"skipped","reason":"source target cache missing","source_target":"/Volumes/FastWork/adl-wp-5719/adl/target","dest_target":"/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T//authoritative-coverage.Oaqy3Q/scratch/target/llvm-cov-target/run-concurrent-b/workspace","validation_proof":false}
+{"status":"skipped","reason":"source target cache missing","source_target":"/Volumes/FastWork/adl-wp-5719/adl/target","dest_target":"/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T//authoritative-coverage.Oaqy3Q/scratch/target/llvm-cov-target/run-concurrent-a/workspace","validation_proof":false}
+Authoritative coverage mode: full_authoritative_default_features
+Features: default
+Authoritative coverage linker mode: lld
+Authoritative coverage test threads: 2
+Authoritative coverage skip patterns: live_pr_fixture_
+{"status":"skipped","reason":"source target cache missing","source_target":"/Volumes/FastWork/adl-wp-5719/adl/target","dest_target":"/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T//authoritative-coverage.Oaqy3Q/scratch/target/llvm-cov-target/run-lld/adl-runtime","validation_proof":false}
+Authoritative coverage companion: adl-runtime
+{"status":"skipped","reason":"source target cache missing","source_target":"/Volumes/FastWork/adl-wp-5719/adl/target","dest_target":"/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T//authoritative-coverage.Oaqy3Q/scratch/target/llvm-cov-target/run-lld/workspace","validation_proof":false}
+PASS test_run_authoritative_coverage_lane
+ADL CI step log start: Coverage run and summary (json)
+started_at=2026-07-29T22:34:16Z
+command_argc=3
+command_redaction=metadata_only
+success-out
+finished_at=2026-07-29T22:34:16Z
+exit_code=0
+elapsed_seconds=0
+ADL CI step log start: failing step
+started_at=2026-07-29T22:34:17Z
+command_argc=3
+command_redaction=metadata_only
+fail-out
+finished_at=2026-07-29T22:34:17Z
+exit_code=37
+elapsed_seconds=0
+ADL CI step log start: secret step
+started_at=2026-07-29T22:34:17Z
+command_argc=6
+command_redaction=metadata_only
+no-secret-output
+finished_at=2026-07-29T22:34:17Z
+exit_code=0
+elapsed_seconds=0
+PASS test_run_ci_step_with_log
+PASS test_setup_required_coverage_toolchain
+PASS test_select_validation_lanes
+PASS test_validation_manager
+PASS: ci_path_policy PR-fast/full-coverage contract
+Authoritative coverage compile failed for workspace: 66; partitions and report command suppressed
+coverage summary merge failed: workspace summary is missing: /var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T/authoritative-coverage.Oaqy3Q/scratch/coverage-output/run-prebuild-failure/coverage-summary.adl.json
+Authoritative coverage profile cleanup failed for workspace: 55
+coverage summary merge failed: workspace summary is missing: /var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T/authoritative-coverage.Oaqy3Q/scratch/coverage-output/run-combined-failure/coverage-summary.adl.json
+Authoritative coverage profile cleanup failed for adl-runtime: 55
+Authoritative coverage profile cleanup failed for workspace: 55
+coverage summary merge failed: workspace summary is missing: /var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T/authoritative-coverage.Oaqy3Q/scratch/coverage-output/run-cleanup-failure/coverage-summary.adl.json
+success-err
+fail-err
+==> docs_diff_check: git diff --check
+==> docs_diff_check: git diff --check
+==> nessus_remote_validation: bash adl/tools/run_nessus_remote_validation.sh --command 'printf remote-manager-ok' --local-artifact-dir /private/var/folders/rq/nnff0vs91jzfvmb8tjqxtjgc0000gn/T/tmp.8RzsSs4jlO/remote-manager-artifacts-run

--- a/.csdlc/issues/5719/audit.jsonl
+++ b/.csdlc/issues/5719/audit.jsonl
@@ -1,3 +1,4 @@
 {"sequence":1,"generation":0,"actor":"codex:5719-execution","reason":"initialize issue record and all six cards","operation":"bootstrap"}
 {"sequence":2,"generation":0,"actor":"codex:5719-execution","reason":"bind branch/worktree and activate claim","operation":"bind"}
 {"sequence":3,"generation":0,"actor":"codex:5719-execution","reason":"The reproduced #5716-like failure is an unmapped validation-manager surface, so #5719 must update the validation lane selector manifest as part of the CI coverage selection fix.","operation":"{\"add_protected_paths\":[\"adl/config/validation_lane_selector.v0.91.6.json\"],\"operation\":\"amend_claim_scope\"}"}
+{"sequence":4,"generation":1,"actor":"codex:5719-execution","reason":"atomically record execution, validation, and implemented phase","operation":"finalize_implementation"}

--- a/.csdlc/issues/5719/audit.jsonl
+++ b/.csdlc/issues/5719/audit.jsonl
@@ -5,3 +5,4 @@
 {"sequence":5,"generation":1,"actor":"codex:5719-execution","reason":"assign bounded exact-revision review","operation":"assign_review"}
 {"sequence":6,"generation":2,"actor":"codex:5719-execution","reason":"atomically record assigned review evidence and SRP projection","operation":"record_review"}
 {"sequence":7,"generation":3,"actor":"codex:5719-execution","reason":"Exact bounded review passed with no actionable findings for the podcast CI coverage path-policy fix.","operation":"{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"}
+{"sequence":8,"generation":4,"actor":"codex:5719-execution","reason":"atomically record observed GitHub publication and SOR projection","operation":"record_publication"}

--- a/.csdlc/issues/5719/audit.jsonl
+++ b/.csdlc/issues/5719/audit.jsonl
@@ -2,3 +2,6 @@
 {"sequence":2,"generation":0,"actor":"codex:5719-execution","reason":"bind branch/worktree and activate claim","operation":"bind"}
 {"sequence":3,"generation":0,"actor":"codex:5719-execution","reason":"The reproduced #5716-like failure is an unmapped validation-manager surface, so #5719 must update the validation lane selector manifest as part of the CI coverage selection fix.","operation":"{\"add_protected_paths\":[\"adl/config/validation_lane_selector.v0.91.6.json\"],\"operation\":\"amend_claim_scope\"}"}
 {"sequence":4,"generation":1,"actor":"codex:5719-execution","reason":"atomically record execution, validation, and implemented phase","operation":"finalize_implementation"}
+{"sequence":5,"generation":1,"actor":"codex:5719-execution","reason":"assign bounded exact-revision review","operation":"assign_review"}
+{"sequence":6,"generation":2,"actor":"codex:5719-execution","reason":"atomically record assigned review evidence and SRP projection","operation":"record_review"}
+{"sequence":7,"generation":3,"actor":"codex:5719-execution","reason":"Exact bounded review passed with no actionable findings for the podcast CI coverage path-policy fix.","operation":"{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"}

--- a/.csdlc/issues/5719/audit.jsonl
+++ b/.csdlc/issues/5719/audit.jsonl
@@ -1,0 +1,3 @@
+{"sequence":1,"generation":0,"actor":"codex:5719-execution","reason":"initialize issue record and all six cards","operation":"bootstrap"}
+{"sequence":2,"generation":0,"actor":"codex:5719-execution","reason":"bind branch/worktree and activate claim","operation":"bind"}
+{"sequence":3,"generation":0,"actor":"codex:5719-execution","reason":"The reproduced #5716-like failure is an unmapped validation-manager surface, so #5719 must update the validation lane selector manifest as part of the CI coverage selection fix.","operation":"{\"add_protected_paths\":[\"adl/config/validation_lane_selector.v0.91.6.json\"],\"operation\":\"amend_claim_scope\"}"}

--- a/.csdlc/issues/5719/cards/sip.md
+++ b/.csdlc/issues/5719/cards/sip.md
@@ -1,0 +1,44 @@
+# Structured Intent Prompt
+
+Template: 1.0.0
+
+Issue: 5719
+
+Repository: danielbaustin/agent-design-language
+
+Card: sip
+
+Status: ready
+
+## Goal
+
+Make podcast/demo page and launch packet UI-only PRs select focused validation rather than full hosted runtime plus workspace coverage.
+
+## Required Outcome
+
+A #5716-like podcast studio/static demo path set no longer sets full_coverage_required=true, while Rust/runtime/provider/tooling changes still select their existing coverage requirements.
+
+## Scope
+
+- CI path-policy classifier
+- CI path-policy contract tests
+- workflow contract assertions if needed
+- issue-local C-SDLC lifecycle evidence
+
+## Authority
+
+- GitHub issue #5719
+- Observed PR #5716 hosted coverage selection
+- Existing CI path-policy contract tests
+
+## Assumptions
+
+- none
+
+## Operator Constraints
+
+- Use only FastWork for tracked issue work.
+- Do not write tracked changes on main.
+- Do not remove the adl-coverage-hosted aggregator.
+- Avoid duplicate expensive hosted producer lanes for static podcast/demo page changes.
+- Preserve full coverage for Rust/runtime/provider/tooling policy changes.

--- a/.csdlc/issues/5719/cards/sip.values.json
+++ b/.csdlc/issues/5719/cards/sip.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][ci][coverage] Avoid duplicate hosted coverage on podcast/demo page PRs",
     "slug": "v0-91-8-ci-coverage-avoid-duplicate-hosted-coverage-on-podcast-demo-page-prs",
     "version": "v0.91.8",
-    "generation": 0
+    "generation": 1
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5719/cards/sip.values.json
+++ b/.csdlc/issues/5719/cards/sip.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][ci][coverage] Avoid duplicate hosted coverage on podcast/demo page PRs",
     "slug": "v0-91-8-ci-coverage-avoid-duplicate-hosted-coverage-on-podcast-demo-page-prs",
     "version": "v0.91.8",
-    "generation": 3
+    "generation": 4
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5719/cards/sip.values.json
+++ b/.csdlc/issues/5719/cards/sip.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][ci][coverage] Avoid duplicate hosted coverage on podcast/demo page PRs",
     "slug": "v0-91-8-ci-coverage-avoid-duplicate-hosted-coverage-on-podcast-demo-page-prs",
     "version": "v0.91.8",
-    "generation": 1
+    "generation": 3
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5719/cards/sip.values.json
+++ b/.csdlc/issues/5719/cards/sip.values.json
@@ -1,0 +1,39 @@
+{
+  "identity": {
+    "schema_version": "1.0.0",
+    "template_version": "1.0.0",
+    "issue": 5719,
+    "repository": "danielbaustin/agent-design-language",
+    "title": "[v0.91.8][ci][coverage] Avoid duplicate hosted coverage on podcast/demo page PRs",
+    "slug": "v0-91-8-ci-coverage-avoid-duplicate-hosted-coverage-on-podcast-demo-page-prs",
+    "version": "v0.91.8",
+    "generation": 0
+  },
+  "status": "ready",
+  "content": {
+    "card_kind": "sip",
+    "values": {
+      "goal": "Make podcast/demo page and launch packet UI-only PRs select focused validation rather than full hosted runtime plus workspace coverage.",
+      "required_outcome": "A #5716-like podcast studio/static demo path set no longer sets full_coverage_required=true, while Rust/runtime/provider/tooling changes still select their existing coverage requirements.",
+      "declared_scope": [
+        "CI path-policy classifier",
+        "CI path-policy contract tests",
+        "workflow contract assertions if needed",
+        "issue-local C-SDLC lifecycle evidence"
+      ],
+      "authority_boundary": [
+        "GitHub issue #5719",
+        "Observed PR #5716 hosted coverage selection",
+        "Existing CI path-policy contract tests"
+      ],
+      "initial_assumptions": [],
+      "operator_constraints": [
+        "Use only FastWork for tracked issue work.",
+        "Do not write tracked changes on main.",
+        "Do not remove the adl-coverage-hosted aggregator.",
+        "Avoid duplicate expensive hosted producer lanes for static podcast/demo page changes.",
+        "Preserve full coverage for Rust/runtime/provider/tooling policy changes."
+      ]
+    }
+  }
+}

--- a/.csdlc/issues/5719/cards/sor.md
+++ b/.csdlc/issues/5719/cards/sor.md
@@ -1,0 +1,45 @@
+# Structured Output Record
+
+Template: 1.0.0
+
+Issue: 5719
+
+Repository: danielbaustin/agent-design-language
+
+Card: sor
+
+Status: pre_phase
+
+## Summary
+
+Pre-execution output record.
+
+## Artifacts
+
+- none
+
+## Execution
+
+- none
+
+## Validation
+
+[]
+
+## Integration
+
+not_started
+
+## Publication
+
+Publication: not_published
+
+Merge: not_merged
+
+## Closeout
+
+not_started
+
+## Follow Ups
+
+- none

--- a/.csdlc/issues/5719/cards/sor.md
+++ b/.csdlc/issues/5719/cards/sor.md
@@ -12,19 +12,35 @@ Status: pre_phase
 
 ## Summary
 
-Pre-execution output record.
+Mapped podcast launch/studio demo surfaces into a focused podcast_launch_packet validation lane and taught ci_path_policy to consume that lane without selecting full hosted coverage. Added a #5716-like regression fixture proving podcast static/demo page paths skip full coverage while preserving the coverage aggregator and existing Rust/tooling behavior.
 
 ## Artifacts
 
-- none
+- adl/tools/test_ci_path_policy.sh
+- adl/tools/test_ci_runtime_contracts.sh
 
 ## Execution
 
-- none
+- .csdlc/issues/5719
+- .csdlc/locks/5719.lock
+- .csdlc/prepared/issues/5719
+- adl/config/validation_lane_selector.v0.91.6.json
+- adl/tools/ci_path_policy.sh
+- adl/tools/test_ci_path_policy.sh
 
 ## Validation
 
-[]
+[
+  {
+    "command": [
+      "bash",
+      "adl/tools/test_ci_path_policy.sh"
+    ],
+    "purpose": "Prove podcast launch/studio page changes select focused podcast validation and do not require full hosted runtime plus workspace coverage.",
+    "outcome": "passed",
+    "evidence_ref": "ci-path-policy-podcast-launch-contract.log"
+  }
+]
 
 ## Integration
 

--- a/.csdlc/issues/5719/cards/sor.md
+++ b/.csdlc/issues/5719/cards/sor.md
@@ -44,11 +44,11 @@ Mapped podcast launch/studio demo surfaces into a focused podcast_launch_packet 
 
 ## Integration
 
-not_started
+pr_open
 
 ## Publication
 
-Publication: not_published
+Publication: draft
 
 Merge: not_merged
 

--- a/.csdlc/issues/5719/cards/sor.values.json
+++ b/.csdlc/issues/5719/cards/sor.values.json
@@ -1,0 +1,27 @@
+{
+  "identity": {
+    "schema_version": "1.0.0",
+    "template_version": "1.0.0",
+    "issue": 5719,
+    "repository": "danielbaustin/agent-design-language",
+    "title": "[v0.91.8][ci][coverage] Avoid duplicate hosted coverage on podcast/demo page PRs",
+    "slug": "v0-91-8-ci-coverage-avoid-duplicate-hosted-coverage-on-podcast-demo-page-prs",
+    "version": "v0.91.8",
+    "generation": 0
+  },
+  "status": "pre_phase",
+  "content": {
+    "card_kind": "sor",
+    "values": {
+      "summary": "Pre-execution output record.",
+      "actual_changes": [],
+      "artifacts": [],
+      "actual_validation": [],
+      "integration_state": "not_started",
+      "publication_state": "not_published",
+      "merge_state": "not_merged",
+      "closeout_state": "not_started",
+      "follow_ups": []
+    }
+  }
+}

--- a/.csdlc/issues/5719/cards/sor.values.json
+++ b/.csdlc/issues/5719/cards/sor.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][ci][coverage] Avoid duplicate hosted coverage on podcast/demo page PRs",
     "slug": "v0-91-8-ci-coverage-avoid-duplicate-hosted-coverage-on-podcast-demo-page-prs",
     "version": "v0.91.8",
-    "generation": 1
+    "generation": 3
   },
   "status": "pre_phase",
   "content": {

--- a/.csdlc/issues/5719/cards/sor.values.json
+++ b/.csdlc/issues/5719/cards/sor.values.json
@@ -7,16 +7,36 @@
     "title": "[v0.91.8][ci][coverage] Avoid duplicate hosted coverage on podcast/demo page PRs",
     "slug": "v0-91-8-ci-coverage-avoid-duplicate-hosted-coverage-on-podcast-demo-page-prs",
     "version": "v0.91.8",
-    "generation": 0
+    "generation": 1
   },
   "status": "pre_phase",
   "content": {
     "card_kind": "sor",
     "values": {
-      "summary": "Pre-execution output record.",
-      "actual_changes": [],
-      "artifacts": [],
-      "actual_validation": [],
+      "summary": "Mapped podcast launch/studio demo surfaces into a focused podcast_launch_packet validation lane and taught ci_path_policy to consume that lane without selecting full hosted coverage. Added a #5716-like regression fixture proving podcast static/demo page paths skip full coverage while preserving the coverage aggregator and existing Rust/tooling behavior.",
+      "actual_changes": [
+        ".csdlc/issues/5719",
+        ".csdlc/locks/5719.lock",
+        ".csdlc/prepared/issues/5719",
+        "adl/config/validation_lane_selector.v0.91.6.json",
+        "adl/tools/ci_path_policy.sh",
+        "adl/tools/test_ci_path_policy.sh"
+      ],
+      "artifacts": [
+        "adl/tools/test_ci_path_policy.sh",
+        "adl/tools/test_ci_runtime_contracts.sh"
+      ],
+      "actual_validation": [
+        {
+          "command": [
+            "bash",
+            "adl/tools/test_ci_path_policy.sh"
+          ],
+          "purpose": "Prove podcast launch/studio page changes select focused podcast validation and do not require full hosted runtime plus workspace coverage.",
+          "outcome": "passed",
+          "evidence_ref": "ci-path-policy-podcast-launch-contract.log"
+        }
+      ],
       "integration_state": "not_started",
       "publication_state": "not_published",
       "merge_state": "not_merged",

--- a/.csdlc/issues/5719/cards/sor.values.json
+++ b/.csdlc/issues/5719/cards/sor.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][ci][coverage] Avoid duplicate hosted coverage on podcast/demo page PRs",
     "slug": "v0-91-8-ci-coverage-avoid-duplicate-hosted-coverage-on-podcast-demo-page-prs",
     "version": "v0.91.8",
-    "generation": 3
+    "generation": 4
   },
   "status": "pre_phase",
   "content": {
@@ -37,8 +37,8 @@
           "evidence_ref": "ci-path-policy-podcast-launch-contract.log"
         }
       ],
-      "integration_state": "not_started",
-      "publication_state": "not_published",
+      "integration_state": "pr_open",
+      "publication_state": "draft",
       "merge_state": "not_merged",
       "closeout_state": "not_started",
       "follow_ups": []

--- a/.csdlc/issues/5719/cards/spp.md
+++ b/.csdlc/issues/5719/cards/spp.md
@@ -1,0 +1,118 @@
+# Structured Planning Prompt
+
+Template: 1.0.0
+
+Issue: 5719
+
+Repository: danielbaustin/agent-design-language
+
+Card: spp
+
+Status: ready
+
+## Summary
+
+Add a bounded static podcast/demo path classification, prove #5716-like paths avoid full hosted coverage, preserve producer lanes for behavioral changes, review, and publish.
+
+## Plan
+
+Revision 1
+
+## Steps
+
+[
+  {
+    "id": "S1",
+    "action": "Inspect current path-policy coverage selection and reproduce a #5716-like changed path set.",
+    "acceptance_ids": [
+      "AC-1",
+      "AC-2"
+    ],
+    "status": "pending"
+  },
+  {
+    "id": "S2",
+    "action": "Patch the selector with the smallest static podcast/demo classification.",
+    "acceptance_ids": [
+      "AC-1",
+      "AC-2",
+      "AC-3",
+      "AC-4"
+    ],
+    "status": "pending"
+  },
+  {
+    "id": "S3",
+    "action": "Add focused tests for static podcast/demo paths and Rust/tooling preservation.",
+    "acceptance_ids": [
+      "AC-1",
+      "AC-2",
+      "AC-4",
+      "AC-5"
+    ],
+    "status": "pending"
+  },
+  {
+    "id": "S4",
+    "action": "Run path-policy, workflow contract, and validation-manager focused checks.",
+    "acceptance_ids": [
+      "AC-3",
+      "AC-5"
+    ],
+    "status": "pending"
+  },
+  {
+    "id": "S5",
+    "action": "Run bounded review, record lifecycle truth, and publish with Closes #5719.",
+    "acceptance_ids": [
+      "AC-1",
+      "AC-2",
+      "AC-3",
+      "AC-4",
+      "AC-5"
+    ],
+    "status": "pending"
+  }
+]
+
+## Invariants
+
+- The aggregator job remains the stable coverage check.
+- Full hosted coverage remains fail-closed for source/runtime/provider/tooling-policy changes.
+- Static podcast/demo page changes do not pay for duplicate hosted producer coverage.
+
+## Risks
+
+- Over-broad static classification could skip coverage for code-bearing demo changes.
+- Workflow contract assertions could drift from the selector output.
+- Policy tests are large and may hide the focused regression if no specific fixture is added.
+
+## Estimates
+
+{
+  "elapsed_seconds": 7200,
+  "total_tokens": 40000,
+  "validation_seconds": 1200
+}
+
+## Design
+
+.csdlc/prepared/issues/5719/design.md
+
+Digest: 669865d6d9df6873d4b8b4f54a492499d00d3173912437883abddd0bebee5b35
+
+## Diagram
+
+.csdlc/prepared/issues/5719/diagram.mmd
+
+Digest: 1429f9a11d794b37f2a778dd3691f646b89873013d61a226235092ef77f5cb82
+
+## Stop Conditions
+
+- The selector cannot distinguish static podcast/demo files from code-bearing demo/runtime files.
+- A workflow contract proves both hosted producer lanes are still selected after the path-policy change.
+- A Rust/runtime/provider fixture regresses to skipped coverage.
+
+## Handoff
+
+Proceed only after doctor readiness.

--- a/.csdlc/issues/5719/cards/spp.values.json
+++ b/.csdlc/issues/5719/cards/spp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][ci][coverage] Avoid duplicate hosted coverage on podcast/demo page PRs",
     "slug": "v0-91-8-ci-coverage-avoid-duplicate-hosted-coverage-on-podcast-demo-page-prs",
     "version": "v0.91.8",
-    "generation": 0
+    "generation": 1
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5719/cards/spp.values.json
+++ b/.csdlc/issues/5719/cards/spp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][ci][coverage] Avoid duplicate hosted coverage on podcast/demo page PRs",
     "slug": "v0-91-8-ci-coverage-avoid-duplicate-hosted-coverage-on-podcast-demo-page-prs",
     "version": "v0.91.8",
-    "generation": 3
+    "generation": 4
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5719/cards/spp.values.json
+++ b/.csdlc/issues/5719/cards/spp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][ci][coverage] Avoid duplicate hosted coverage on podcast/demo page PRs",
     "slug": "v0-91-8-ci-coverage-avoid-duplicate-hosted-coverage-on-podcast-demo-page-prs",
     "version": "v0.91.8",
-    "generation": 1
+    "generation": 3
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5719/cards/spp.values.json
+++ b/.csdlc/issues/5719/cards/spp.values.json
@@ -1,0 +1,100 @@
+{
+  "identity": {
+    "schema_version": "1.0.0",
+    "template_version": "1.0.0",
+    "issue": 5719,
+    "repository": "danielbaustin/agent-design-language",
+    "title": "[v0.91.8][ci][coverage] Avoid duplicate hosted coverage on podcast/demo page PRs",
+    "slug": "v0-91-8-ci-coverage-avoid-duplicate-hosted-coverage-on-podcast-demo-page-prs",
+    "version": "v0.91.8",
+    "generation": 0
+  },
+  "status": "ready",
+  "content": {
+    "card_kind": "spp",
+    "values": {
+      "plan_revision": 1,
+      "summary": "Add a bounded static podcast/demo path classification, prove #5716-like paths avoid full hosted coverage, preserve producer lanes for behavioral changes, review, and publish.",
+      "steps": [
+        {
+          "id": "S1",
+          "action": "Inspect current path-policy coverage selection and reproduce a #5716-like changed path set.",
+          "acceptance_ids": [
+            "AC-1",
+            "AC-2"
+          ],
+          "status": "pending"
+        },
+        {
+          "id": "S2",
+          "action": "Patch the selector with the smallest static podcast/demo classification.",
+          "acceptance_ids": [
+            "AC-1",
+            "AC-2",
+            "AC-3",
+            "AC-4"
+          ],
+          "status": "pending"
+        },
+        {
+          "id": "S3",
+          "action": "Add focused tests for static podcast/demo paths and Rust/tooling preservation.",
+          "acceptance_ids": [
+            "AC-1",
+            "AC-2",
+            "AC-4",
+            "AC-5"
+          ],
+          "status": "pending"
+        },
+        {
+          "id": "S4",
+          "action": "Run path-policy, workflow contract, and validation-manager focused checks.",
+          "acceptance_ids": [
+            "AC-3",
+            "AC-5"
+          ],
+          "status": "pending"
+        },
+        {
+          "id": "S5",
+          "action": "Run bounded review, record lifecycle truth, and publish with Closes #5719.",
+          "acceptance_ids": [
+            "AC-1",
+            "AC-2",
+            "AC-3",
+            "AC-4",
+            "AC-5"
+          ],
+          "status": "pending"
+        }
+      ],
+      "affected_areas": [],
+      "invariants": [
+        "The aggregator job remains the stable coverage check.",
+        "Full hosted coverage remains fail-closed for source/runtime/provider/tooling-policy changes.",
+        "Static podcast/demo page changes do not pay for duplicate hosted producer coverage."
+      ],
+      "risks": [
+        "Over-broad static classification could skip coverage for code-bearing demo changes.",
+        "Workflow contract assertions could drift from the selector output.",
+        "Policy tests are large and may hide the focused regression if no specific fixture is added."
+      ],
+      "execution_estimates": {
+        "elapsed_seconds": 7200,
+        "total_tokens": 40000,
+        "validation_seconds": 1200
+      },
+      "stop_conditions": [
+        "The selector cannot distinguish static podcast/demo files from code-bearing demo/runtime files.",
+        "A workflow contract proves both hosted producer lanes are still selected after the path-policy change.",
+        "A Rust/runtime/provider fixture regresses to skipped coverage."
+      ],
+      "replan_triggers": [],
+      "design_ref": ".csdlc/prepared/issues/5719/design.md",
+      "design_digest": "669865d6d9df6873d4b8b4f54a492499d00d3173912437883abddd0bebee5b35",
+      "diagram_ref": ".csdlc/prepared/issues/5719/diagram.mmd",
+      "diagram_digest": "1429f9a11d794b37f2a778dd3691f646b89873013d61a226235092ef77f5cb82"
+    }
+  }
+}

--- a/.csdlc/issues/5719/cards/srp.md
+++ b/.csdlc/issues/5719/cards/srp.md
@@ -1,0 +1,41 @@
+# Structured Review Prompt
+
+Template: 1.0.0
+
+Issue: 5719
+
+Repository: danielbaustin/agent-design-language
+
+Card: srp
+
+Status: pre_phase
+
+## Scope
+
+CI path-policy classifier, CI path-policy tests, workflow contract assertions, and issue-local lifecycle records
+
+## Prompts
+
+- Does the policy narrowly target static podcast/demo page and launch packet UI paths?
+- Can a code-bearing Rust/runtime/provider/tooling path still trigger its required coverage lane?
+- Does the workflow keep the stable aggregator while avoiding duplicate hosted producers?
+
+## Findings
+
+[]
+
+## Dispositions
+
+Every actionable finding requires a terminal disposition.
+
+## Residual Risk
+
+- none
+
+## Review Result
+
+Revision: None
+
+Reviewer: None
+
+Result: pre_review

--- a/.csdlc/issues/5719/cards/srp.md
+++ b/.csdlc/issues/5719/cards/srp.md
@@ -12,7 +12,12 @@ Status: pre_phase
 
 ## Scope
 
-CI path-policy classifier, CI path-policy tests, workflow contract assertions, and issue-local lifecycle records
+.csdlc/issues/5719
+.csdlc/evidence/5719
+.csdlc/prepared/issues/5719
+adl/config/validation_lane_selector.v0.91.6.json
+adl/tools/ci_path_policy.sh
+adl/tools/test_ci_path_policy.sh
 
 ## Prompts
 
@@ -30,12 +35,12 @@ Every actionable finding requires a terminal disposition.
 
 ## Residual Risk
 
-- none
+- Review was read-only and confirmed the selector/path-policy contract at exact HEAD b0f71eabb; hosted CI behavior remains deferred to the published PR checks.
 
 ## Review Result
 
-Revision: None
+Revision: Some("git-blake3:b0f71eabb06945d5a7ad6147d7178586e3db86da:a6218709a4daeb864cd8deaf812e424aa9342260d5592dd722049a4ef0dd5be0")
 
-Reviewer: None
+Reviewer: Some("Heisenberg")
 
-Result: pre_review
+Result: pass

--- a/.csdlc/issues/5719/cards/srp.values.json
+++ b/.csdlc/issues/5719/cards/srp.values.json
@@ -1,0 +1,29 @@
+{
+  "identity": {
+    "schema_version": "1.0.0",
+    "template_version": "1.0.0",
+    "issue": 5719,
+    "repository": "danielbaustin/agent-design-language",
+    "title": "[v0.91.8][ci][coverage] Avoid duplicate hosted coverage on podcast/demo page PRs",
+    "slug": "v0-91-8-ci-coverage-avoid-duplicate-hosted-coverage-on-podcast-demo-page-prs",
+    "version": "v0.91.8",
+    "generation": 0
+  },
+  "status": "pre_phase",
+  "content": {
+    "card_kind": "srp",
+    "values": {
+      "review_scope": "CI path-policy classifier, CI path-policy tests, workflow contract assertions, and issue-local lifecycle records",
+      "review_revision": null,
+      "reviewer": null,
+      "review_prompts": [
+        "Does the policy narrowly target static podcast/demo page and launch packet UI paths?",
+        "Can a code-bearing Rust/runtime/provider/tooling path still trigger its required coverage lane?",
+        "Does the workflow keep the stable aggregator while avoiding duplicate hosted producers?"
+      ],
+      "findings": [],
+      "residual_risk": [],
+      "review_result": "pre_review"
+    }
+  }
+}

--- a/.csdlc/issues/5719/cards/srp.values.json
+++ b/.csdlc/issues/5719/cards/srp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][ci][coverage] Avoid duplicate hosted coverage on podcast/demo page PRs",
     "slug": "v0-91-8-ci-coverage-avoid-duplicate-hosted-coverage-on-podcast-demo-page-prs",
     "version": "v0.91.8",
-    "generation": 0
+    "generation": 1
   },
   "status": "pre_phase",
   "content": {

--- a/.csdlc/issues/5719/cards/srp.values.json
+++ b/.csdlc/issues/5719/cards/srp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][ci][coverage] Avoid duplicate hosted coverage on podcast/demo page PRs",
     "slug": "v0-91-8-ci-coverage-avoid-duplicate-hosted-coverage-on-podcast-demo-page-prs",
     "version": "v0.91.8",
-    "generation": 3
+    "generation": 4
   },
   "status": "pre_phase",
   "content": {

--- a/.csdlc/issues/5719/cards/srp.values.json
+++ b/.csdlc/issues/5719/cards/srp.values.json
@@ -7,23 +7,25 @@
     "title": "[v0.91.8][ci][coverage] Avoid duplicate hosted coverage on podcast/demo page PRs",
     "slug": "v0-91-8-ci-coverage-avoid-duplicate-hosted-coverage-on-podcast-demo-page-prs",
     "version": "v0.91.8",
-    "generation": 1
+    "generation": 3
   },
   "status": "pre_phase",
   "content": {
     "card_kind": "srp",
     "values": {
-      "review_scope": "CI path-policy classifier, CI path-policy tests, workflow contract assertions, and issue-local lifecycle records",
-      "review_revision": null,
-      "reviewer": null,
+      "review_scope": ".csdlc/issues/5719\n.csdlc/evidence/5719\n.csdlc/prepared/issues/5719\nadl/config/validation_lane_selector.v0.91.6.json\nadl/tools/ci_path_policy.sh\nadl/tools/test_ci_path_policy.sh",
+      "review_revision": "git-blake3:b0f71eabb06945d5a7ad6147d7178586e3db86da:a6218709a4daeb864cd8deaf812e424aa9342260d5592dd722049a4ef0dd5be0",
+      "reviewer": "Heisenberg",
       "review_prompts": [
         "Does the policy narrowly target static podcast/demo page and launch packet UI paths?",
         "Can a code-bearing Rust/runtime/provider/tooling path still trigger its required coverage lane?",
         "Does the workflow keep the stable aggregator while avoiding duplicate hosted producers?"
       ],
       "findings": [],
-      "residual_risk": [],
-      "review_result": "pre_review"
+      "residual_risk": [
+        "Review was read-only and confirmed the selector/path-policy contract at exact HEAD b0f71eabb; hosted CI behavior remains deferred to the published PR checks."
+      ],
+      "review_result": "pass"
     }
   }
 }

--- a/.csdlc/issues/5719/cards/stp.md
+++ b/.csdlc/issues/5719/cards/stp.md
@@ -1,0 +1,50 @@
+# Structured Task Prompt
+
+Template: 1.0.0
+
+Issue: 5719
+
+Repository: danielbaustin/agent-design-language
+
+Card: stp
+
+Status: ready
+
+## Task
+
+Fix CI selector policy and focused contract tests only; do not change podcast page content or unrelated CI behavior.
+
+## Deliverables
+
+- path-policy classifier update
+- focused tests for podcast/demo static path selection
+- regression tests proving Rust/tooling changes still select full or required lanes
+- truthful lifecycle and publication evidence
+
+## Acceptance
+
+1. AC-1: A #5716-like podcast studio/static demo path set reports full_coverage_required=false.
+2. AC-2: The same path set does not schedule both hosted runtime and hosted workspace producer coverage.
+3. AC-3: The stable adl-coverage-hosted aggregator/check remains present and truthful.
+4. AC-4: Rust/runtime/provider/tooling policy path changes retain their existing full/focused coverage requirements.
+5. AC-5: Focused CI path-policy and workflow contract tests pass locally.
+
+## Dependencies
+
+- #5716 observed duplicate hosted producer coverage
+- Existing ci_path_policy contract suite
+
+## Inputs
+
+- adl/tools/ci_path_policy.sh
+- adl/tools/test_ci_path_policy.sh
+- .github/workflows/ci.yaml
+- adl/tools/test_ci_runtime_contracts.sh
+- adl/tools/test_validation_manager.sh
+
+## Non Goals
+
+- removing required stable check aggregation
+- rewriting the hosted coverage workflow
+- changing podcast page content
+- weakening Rust/runtime/provider/tooling coverage

--- a/.csdlc/issues/5719/cards/stp.values.json
+++ b/.csdlc/issues/5719/cards/stp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][ci][coverage] Avoid duplicate hosted coverage on podcast/demo page PRs",
     "slug": "v0-91-8-ci-coverage-avoid-duplicate-hosted-coverage-on-podcast-demo-page-prs",
     "version": "v0.91.8",
-    "generation": 0
+    "generation": 1
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5719/cards/stp.values.json
+++ b/.csdlc/issues/5719/cards/stp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][ci][coverage] Avoid duplicate hosted coverage on podcast/demo page PRs",
     "slug": "v0-91-8-ci-coverage-avoid-duplicate-hosted-coverage-on-podcast-demo-page-prs",
     "version": "v0.91.8",
-    "generation": 3
+    "generation": 4
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5719/cards/stp.values.json
+++ b/.csdlc/issues/5719/cards/stp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][ci][coverage] Avoid duplicate hosted coverage on podcast/demo page PRs",
     "slug": "v0-91-8-ci-coverage-avoid-duplicate-hosted-coverage-on-podcast-demo-page-prs",
     "version": "v0.91.8",
-    "generation": 1
+    "generation": 3
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5719/cards/stp.values.json
+++ b/.csdlc/issues/5719/cards/stp.values.json
@@ -1,0 +1,49 @@
+{
+  "identity": {
+    "schema_version": "1.0.0",
+    "template_version": "1.0.0",
+    "issue": 5719,
+    "repository": "danielbaustin/agent-design-language",
+    "title": "[v0.91.8][ci][coverage] Avoid duplicate hosted coverage on podcast/demo page PRs",
+    "slug": "v0-91-8-ci-coverage-avoid-duplicate-hosted-coverage-on-podcast-demo-page-prs",
+    "version": "v0.91.8",
+    "generation": 0
+  },
+  "status": "ready",
+  "content": {
+    "card_kind": "stp",
+    "values": {
+      "task_boundary": "Fix CI selector policy and focused contract tests only; do not change podcast page content or unrelated CI behavior.",
+      "deliverables": [
+        "path-policy classifier update",
+        "focused tests for podcast/demo static path selection",
+        "regression tests proving Rust/tooling changes still select full or required lanes",
+        "truthful lifecycle and publication evidence"
+      ],
+      "acceptance_criteria": [
+        "AC-1: A #5716-like podcast studio/static demo path set reports full_coverage_required=false.",
+        "AC-2: The same path set does not schedule both hosted runtime and hosted workspace producer coverage.",
+        "AC-3: The stable adl-coverage-hosted aggregator/check remains present and truthful.",
+        "AC-4: Rust/runtime/provider/tooling policy path changes retain their existing full/focused coverage requirements.",
+        "AC-5: Focused CI path-policy and workflow contract tests pass locally."
+      ],
+      "dependencies": [
+        "#5716 observed duplicate hosted producer coverage",
+        "Existing ci_path_policy contract suite"
+      ],
+      "repo_inputs": [
+        "adl/tools/ci_path_policy.sh",
+        "adl/tools/test_ci_path_policy.sh",
+        ".github/workflows/ci.yaml",
+        "adl/tools/test_ci_runtime_contracts.sh",
+        "adl/tools/test_validation_manager.sh"
+      ],
+      "non_goals": [
+        "removing required stable check aggregation",
+        "rewriting the hosted coverage workflow",
+        "changing podcast page content",
+        "weakening Rust/runtime/provider/tooling coverage"
+      ]
+    }
+  }
+}

--- a/.csdlc/issues/5719/cards/vpp.md
+++ b/.csdlc/issues/5719/cards/vpp.md
@@ -1,0 +1,69 @@
+# Validation Planning Prompt
+
+Template: 1.0.0
+
+Issue: 5719
+
+Repository: danielbaustin/agent-design-language
+
+Card: vpp
+
+Status: ready
+
+## Summary
+
+Execute the smallest proving validation DAG.
+
+## Lane Inputs
+
+Design: .csdlc/prepared/issues/5719/design.md
+
+Diagram: .csdlc/prepared/issues/5719/diagram.mmd
+
+## Selected Lanes
+
+[
+  {
+    "lane": "ci_path_policy_contracts",
+    "proof_role": "focused selector and workflow contract validation",
+    "acceptance_ids": [
+      "AC-1",
+      "AC-2",
+      "AC-3",
+      "AC-4",
+      "AC-5"
+    ],
+    "deterministic": true,
+    "resource_profile": "small",
+    "budget_seconds": 240,
+    "budget_tokens": 2000,
+    "argv": [
+      "bash",
+      "adl/tools/test_ci_path_policy.sh"
+    ],
+    "parallel_group": "focused",
+    "defer_reason": null
+  }
+]
+
+## Parallelization
+
+Only declared parallel groups may overlap.
+
+## Budgets
+
+Seconds: 1200
+
+Tokens: 10000
+
+## Commands
+
+- `bash adl/tools/test_ci_path_policy.sh`
+
+## Failure Semantics
+
+Fail closed on any selector ambiguity that could skip full coverage for source/runtime/provider/tooling behavior.
+
+## Handoff
+
+Retain typed evidence before convergence.

--- a/.csdlc/issues/5719/cards/vpp.values.json
+++ b/.csdlc/issues/5719/cards/vpp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][ci][coverage] Avoid duplicate hosted coverage on podcast/demo page PRs",
     "slug": "v0-91-8-ci-coverage-avoid-duplicate-hosted-coverage-on-podcast-demo-page-prs",
     "version": "v0.91.8",
-    "generation": 0
+    "generation": 1
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5719/cards/vpp.values.json
+++ b/.csdlc/issues/5719/cards/vpp.values.json
@@ -1,0 +1,49 @@
+{
+  "identity": {
+    "schema_version": "1.0.0",
+    "template_version": "1.0.0",
+    "issue": 5719,
+    "repository": "danielbaustin/agent-design-language",
+    "title": "[v0.91.8][ci][coverage] Avoid duplicate hosted coverage on podcast/demo page PRs",
+    "slug": "v0-91-8-ci-coverage-avoid-duplicate-hosted-coverage-on-podcast-demo-page-prs",
+    "version": "v0.91.8",
+    "generation": 0
+  },
+  "status": "ready",
+  "content": {
+    "card_kind": "vpp",
+    "values": {
+      "summary": "Execute the smallest proving validation DAG.",
+      "lanes": [
+        {
+          "lane": "ci_path_policy_contracts",
+          "proof_role": "focused selector and workflow contract validation",
+          "acceptance_ids": [
+            "AC-1",
+            "AC-2",
+            "AC-3",
+            "AC-4",
+            "AC-5"
+          ],
+          "deterministic": true,
+          "resource_profile": "small",
+          "budget_seconds": 240,
+          "budget_tokens": 2000,
+          "argv": [
+            "bash",
+            "adl/tools/test_ci_path_policy.sh"
+          ],
+          "parallel_group": "focused",
+          "defer_reason": null
+        }
+      ],
+      "planned_validation_seconds": 1200,
+      "planned_validation_tokens": 10000,
+      "failure_policy": "Fail closed on any selector ambiguity that could skip full coverage for source/runtime/provider/tooling behavior.",
+      "design_ref": ".csdlc/prepared/issues/5719/design.md",
+      "design_digest": "669865d6d9df6873d4b8b4f54a492499d00d3173912437883abddd0bebee5b35",
+      "diagram_ref": ".csdlc/prepared/issues/5719/diagram.mmd",
+      "diagram_digest": "1429f9a11d794b37f2a778dd3691f646b89873013d61a226235092ef77f5cb82"
+    }
+  }
+}

--- a/.csdlc/issues/5719/cards/vpp.values.json
+++ b/.csdlc/issues/5719/cards/vpp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][ci][coverage] Avoid duplicate hosted coverage on podcast/demo page PRs",
     "slug": "v0-91-8-ci-coverage-avoid-duplicate-hosted-coverage-on-podcast-demo-page-prs",
     "version": "v0.91.8",
-    "generation": 3
+    "generation": 4
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5719/cards/vpp.values.json
+++ b/.csdlc/issues/5719/cards/vpp.values.json
@@ -7,7 +7,7 @@
     "title": "[v0.91.8][ci][coverage] Avoid duplicate hosted coverage on podcast/demo page PRs",
     "slug": "v0-91-8-ci-coverage-avoid-duplicate-hosted-coverage-on-podcast-demo-page-prs",
     "version": "v0.91.8",
-    "generation": 1
+    "generation": 3
   },
   "status": "ready",
   "content": {

--- a/.csdlc/issues/5719/index.json
+++ b/.csdlc/issues/5719/index.json
@@ -3,13 +3,13 @@
   "issue": 5719,
   "repository": "danielbaustin/agent-design-language",
   "initialization_digest": "3311f6460b0988706cb978ea2fcf7da322d7af3273fc5c96c2813a6f7a4fc271",
-  "phase": "bound",
-  "generation": 0,
-  "digest": "6ff3d9dc7225340bc39b65a35e52d097390ebecacdddd60e662a29bf7ae2e914",
+  "phase": "implemented",
+  "generation": 1,
+  "digest": "84e3c398057b359d7afc1c85049137aaecf4cf9bbd8907c8a763ed5b744b5146",
   "claim": {
     "id": "claim-5719-ci-coverage-page-policy",
     "owner": "codex:5719-execution",
-    "generation": 0,
+    "generation": 1,
     "acquired_unix_seconds": 1785363942,
     "expires_unix_seconds": 1785968742,
     "heartbeat_unix_seconds": 1785363942,
@@ -44,34 +44,34 @@
   },
   "cards": {
     "sip": {
-      "values_digest": "ee3841c333293a813030b6ecdcb4fb19d0dd60b2656b5bb569d05b4a47cad53f",
+      "values_digest": "c258b372d00b3e58ff5e0dccad9e226ad2d0e297d10fc96a556b91eec33e889f",
       "rendered_digest": "5edc703d78bb5d850b627fa794f4eb45e023a7c3cf86f62a04ec9b1e6fbebef0",
       "ast_digest": "9798d8fc4365de347cba719ad458e1c5d6f62b23ba9451554a151dc6a99fd129"
     },
     "stp": {
-      "values_digest": "4da7ef20908f970f6a724cab0705abc3d6bca78d61d21cde774f7e926ea68545",
+      "values_digest": "ce1d4dcd5b9031758ab3990f7b8334a7b2587ee3b455bff3733818f6592cd005",
       "rendered_digest": "3a46127e74167c14f3cf932b65fd169a5f087f132c4f5c0473968f0c7003044c",
       "ast_digest": "36f64615fce3a1933d837007862c8eee9304620c5b01fbe632a35271b7624868"
     },
     "spp": {
-      "values_digest": "ae92709981e42fe5157d42f43f04eb1db1981333c161c48a51e76622180f10a0",
+      "values_digest": "dbe58c1d55113fe481044f72c19f6b03fe846c5be12c3505c7f310461b7426b5",
       "rendered_digest": "4c33e2a1cd788a668dcedeec7d45294528a99aa439cd07ac4118a1181f91cccd",
       "ast_digest": "df7462547dbef6bf41ecf7bbfe77d4f213d05d353d4ea38b290c28e07616325f"
     },
     "vpp": {
-      "values_digest": "407d4fbbededad36a589865a4db4f2603b17b2225e3c564bc9e1af31ba24ba3b",
+      "values_digest": "81727cacca40298974faf0900c125f1ed31d028a61cb7b03709ce6c4b7cd53f8",
       "rendered_digest": "53b870f75afb2af19703292ae1300e6d7251054fe899d5fac6685e941c194b58",
       "ast_digest": "7dde77af196d5a1964814b78770b680f9988b6f569a44e25219157e58306f985"
     },
     "srp": {
-      "values_digest": "0cedbe89db3fd183aa28f463003709a29f639719cb152449812b1e9d9618f088",
+      "values_digest": "bc4ed9e818f325eee449dc67a10ed1648618bf7d3fd0ac881aa59c97cca3598f",
       "rendered_digest": "de2c0c280391ac5563267973a3ff09ec0c37199a8e603dc565911eefb24cb1bd",
       "ast_digest": "32c873c2c71e1ac19d7d7716345bde3535dd54c9aad1205ef2ebd8ff3e78e382"
     },
     "sor": {
-      "values_digest": "70074057b0fe173b70591e34cca9735632e61accfcf0782a80af61fb58497f79",
-      "rendered_digest": "a8ec80b18b27c94bb4c48fd637bc8bcdb75cf73c90cc0366702d08beb6bcbcbf",
-      "ast_digest": "b82237b664796f3985c5ac0644d5b65dd4707aa80739c37653f5116dbf4705a6"
+      "values_digest": "7bc37c78b40efd801496f37bbd80486fd0cc9afc88178cfeb790140fdbacc4c2",
+      "rendered_digest": "9adc0741edb43a4f3bbacf0e588aa47dd18141a9dc55769098d08c8943cc5924",
+      "ast_digest": "a7fc4bbefd160b498756c660b017ec6280a1af3cb39d7fa86ae630e4ae4f6463"
     }
   },
   "transitions": [
@@ -88,6 +88,13 @@
       "to": "bound",
       "actor": "codex:5719-execution",
       "reason": "verified Git worktree binding"
+    },
+    {
+      "sequence": 3,
+      "from": "bound",
+      "to": "implemented",
+      "actor": "codex:5719-execution",
+      "reason": "execution and passing validation finalized atomically"
     }
   ],
   "audit": [
@@ -111,6 +118,13 @@
       "actor": "codex:5719-execution",
       "reason": "The reproduced #5716-like failure is an unmapped validation-manager surface, so #5719 must update the validation lane selector manifest as part of the CI coverage selection fix.",
       "operation": "{\"add_protected_paths\":[\"adl/config/validation_lane_selector.v0.91.6.json\"],\"operation\":\"amend_claim_scope\"}"
+    },
+    {
+      "sequence": 4,
+      "generation": 1,
+      "actor": "codex:5719-execution",
+      "reason": "atomically record execution, validation, and implemented phase",
+      "operation": "finalize_implementation"
     }
   ]
 }

--- a/.csdlc/issues/5719/index.json
+++ b/.csdlc/issues/5719/index.json
@@ -1,0 +1,116 @@
+{
+  "schema": "csdlc.issue.index.v1",
+  "issue": 5719,
+  "repository": "danielbaustin/agent-design-language",
+  "initialization_digest": "3311f6460b0988706cb978ea2fcf7da322d7af3273fc5c96c2813a6f7a4fc271",
+  "phase": "bound",
+  "generation": 0,
+  "digest": "6ff3d9dc7225340bc39b65a35e52d097390ebecacdddd60e662a29bf7ae2e914",
+  "claim": {
+    "id": "claim-5719-ci-coverage-page-policy",
+    "owner": "codex:5719-execution",
+    "generation": 0,
+    "acquired_unix_seconds": 1785363942,
+    "expires_unix_seconds": 1785968742,
+    "heartbeat_unix_seconds": 1785363942,
+    "branch": "codex/5719-ci-coverage-page-policy",
+    "worktree": ".",
+    "protected_paths": [
+      ".csdlc/issues/5719",
+      ".csdlc/locks/5719.lock",
+      ".csdlc/prepared/issues/5719",
+      ".github/workflows/ci.yaml",
+      "adl/config/validation_lane_selector.v0.91.6.json",
+      "adl/tools/ci_path_policy.sh",
+      "adl/tools/test_ci_path_policy.sh",
+      "adl/tools/test_ci_runtime_contracts.sh",
+      "adl/tools/test_validation_manager.sh"
+    ],
+    "purpose": "Fix CI path-policy selection so podcast/demo page-only PRs do not schedule duplicate hosted runtime and workspace coverage while preserving full coverage for Rust/runtime/provider/tooling changes"
+  },
+  "review_assignment": null,
+  "review": null,
+  "publication": null,
+  "readiness": null,
+  "terminal": null,
+  "migration": null,
+  "design_path": ".csdlc/prepared/issues/5719/design.md",
+  "diagram_path": ".csdlc/prepared/issues/5719/diagram.mmd",
+  "design_review": {
+    "approved": {
+      "reviewer": "codex:5719-execution",
+      "revision": "669865d6d9df6873d4b8b4f54a492499d00d3173912437883abddd0bebee5b35"
+    }
+  },
+  "cards": {
+    "sip": {
+      "values_digest": "ee3841c333293a813030b6ecdcb4fb19d0dd60b2656b5bb569d05b4a47cad53f",
+      "rendered_digest": "5edc703d78bb5d850b627fa794f4eb45e023a7c3cf86f62a04ec9b1e6fbebef0",
+      "ast_digest": "9798d8fc4365de347cba719ad458e1c5d6f62b23ba9451554a151dc6a99fd129"
+    },
+    "stp": {
+      "values_digest": "4da7ef20908f970f6a724cab0705abc3d6bca78d61d21cde774f7e926ea68545",
+      "rendered_digest": "3a46127e74167c14f3cf932b65fd169a5f087f132c4f5c0473968f0c7003044c",
+      "ast_digest": "36f64615fce3a1933d837007862c8eee9304620c5b01fbe632a35271b7624868"
+    },
+    "spp": {
+      "values_digest": "ae92709981e42fe5157d42f43f04eb1db1981333c161c48a51e76622180f10a0",
+      "rendered_digest": "4c33e2a1cd788a668dcedeec7d45294528a99aa439cd07ac4118a1181f91cccd",
+      "ast_digest": "df7462547dbef6bf41ecf7bbfe77d4f213d05d353d4ea38b290c28e07616325f"
+    },
+    "vpp": {
+      "values_digest": "407d4fbbededad36a589865a4db4f2603b17b2225e3c564bc9e1af31ba24ba3b",
+      "rendered_digest": "53b870f75afb2af19703292ae1300e6d7251054fe899d5fac6685e941c194b58",
+      "ast_digest": "7dde77af196d5a1964814b78770b680f9988b6f569a44e25219157e58306f985"
+    },
+    "srp": {
+      "values_digest": "0cedbe89db3fd183aa28f463003709a29f639719cb152449812b1e9d9618f088",
+      "rendered_digest": "de2c0c280391ac5563267973a3ff09ec0c37199a8e603dc565911eefb24cb1bd",
+      "ast_digest": "32c873c2c71e1ac19d7d7716345bde3535dd54c9aad1205ef2ebd8ff3e78e382"
+    },
+    "sor": {
+      "values_digest": "70074057b0fe173b70591e34cca9735632e61accfcf0782a80af61fb58497f79",
+      "rendered_digest": "a8ec80b18b27c94bb4c48fd637bc8bcdb75cf73c90cc0366702d08beb6bcbcbf",
+      "ast_digest": "b82237b664796f3985c5ac0644d5b65dd4707aa80739c37653f5116dbf4705a6"
+    }
+  },
+  "transitions": [
+    {
+      "sequence": 1,
+      "from": "initialized",
+      "to": "ready",
+      "actor": "codex:5719-execution",
+      "reason": "automatic readiness verification"
+    },
+    {
+      "sequence": 2,
+      "from": "ready",
+      "to": "bound",
+      "actor": "codex:5719-execution",
+      "reason": "verified Git worktree binding"
+    }
+  ],
+  "audit": [
+    {
+      "sequence": 1,
+      "generation": 0,
+      "actor": "codex:5719-execution",
+      "reason": "initialize issue record and all six cards",
+      "operation": "bootstrap"
+    },
+    {
+      "sequence": 2,
+      "generation": 0,
+      "actor": "codex:5719-execution",
+      "reason": "bind branch/worktree and activate claim",
+      "operation": "bind"
+    },
+    {
+      "sequence": 3,
+      "generation": 0,
+      "actor": "codex:5719-execution",
+      "reason": "The reproduced #5716-like failure is an unmapped validation-manager surface, so #5719 must update the validation lane selector manifest as part of the CI coverage selection fix.",
+      "operation": "{\"add_protected_paths\":[\"adl/config/validation_lane_selector.v0.91.6.json\"],\"operation\":\"amend_claim_scope\"}"
+    }
+  ]
+}

--- a/.csdlc/issues/5719/index.json
+++ b/.csdlc/issues/5719/index.json
@@ -3,13 +3,13 @@
   "issue": 5719,
   "repository": "danielbaustin/agent-design-language",
   "initialization_digest": "3311f6460b0988706cb978ea2fcf7da322d7af3273fc5c96c2813a6f7a4fc271",
-  "phase": "reviewed",
-  "generation": 3,
-  "digest": "74857505551f86a7725ff9186ef05c99ba2be34a241ceb6d5e23a1ecac5fe960",
+  "phase": "published",
+  "generation": 4,
+  "digest": "6be197a401de175642148e96d722b5e743df0a76a3fedc316a0d20f518fe427e",
   "claim": {
     "id": "claim-5719-ci-coverage-page-policy",
     "owner": "codex:5719-execution",
-    "generation": 3,
+    "generation": 4,
     "acquired_unix_seconds": 1785363942,
     "expires_unix_seconds": 1785968742,
     "heartbeat_unix_seconds": 1785363942,
@@ -59,7 +59,17 @@
     "completed": true,
     "non_substantive_proof": null
   },
-  "publication": null,
+  "publication": {
+    "repository": "danielbaustin/agent-design-language",
+    "issue": 5719,
+    "pull_request": 5721,
+    "url": "https://github.com/danielbaustin/agent-design-language/pull/5721",
+    "base": "main",
+    "head": "codex/5719-ci-coverage-page-policy",
+    "revision": "git-blake3:fdd526202033fd0d119ac020e341c1e40f8b0c79:2d5ce896bbe2adadfb376fc119859ec9159eb2f8aed49ac5acfaca25d4612acc",
+    "draft": true,
+    "observed_state": "open"
+  },
   "readiness": null,
   "terminal": null,
   "migration": null,
@@ -73,34 +83,34 @@
   },
   "cards": {
     "sip": {
-      "values_digest": "17ed7544fa7e077fee1ba20731dde0b37357fbe0842a4332fd4e3080e751983d",
+      "values_digest": "cac0dcaa0ee9b77edfb921dae5be3a115e2e81b077f11cd3949b5c666f03f3b0",
       "rendered_digest": "5edc703d78bb5d850b627fa794f4eb45e023a7c3cf86f62a04ec9b1e6fbebef0",
       "ast_digest": "9798d8fc4365de347cba719ad458e1c5d6f62b23ba9451554a151dc6a99fd129"
     },
     "stp": {
-      "values_digest": "2621f8b3b5a9b58627499985b808b4e6add5a28fce4dcc58a35d0962b4554e0e",
+      "values_digest": "eecd6ab781cd3c18078b3f1d11ce54e620af35d881ec201d324198ffaccf01eb",
       "rendered_digest": "3a46127e74167c14f3cf932b65fd169a5f087f132c4f5c0473968f0c7003044c",
       "ast_digest": "36f64615fce3a1933d837007862c8eee9304620c5b01fbe632a35271b7624868"
     },
     "spp": {
-      "values_digest": "0722bbcfb48353d41961a08e44ecb6bebd518d4985b8ba9765be71e174dd926a",
+      "values_digest": "5e1e5a4471c54a5285ff11d4c94de350c311d412add41bc2c762aa5ed360dac6",
       "rendered_digest": "4c33e2a1cd788a668dcedeec7d45294528a99aa439cd07ac4118a1181f91cccd",
       "ast_digest": "df7462547dbef6bf41ecf7bbfe77d4f213d05d353d4ea38b290c28e07616325f"
     },
     "vpp": {
-      "values_digest": "5b065187044f6ffe02ed4188ce470d2601843ba7dc330e414a891d5593fbaeb7",
+      "values_digest": "0907db0945a24b9ca6504d1c6ae1502928060653c7572722d325f4f762052959",
       "rendered_digest": "53b870f75afb2af19703292ae1300e6d7251054fe899d5fac6685e941c194b58",
       "ast_digest": "7dde77af196d5a1964814b78770b680f9988b6f569a44e25219157e58306f985"
     },
     "srp": {
-      "values_digest": "d3a27b679a8b64d849bc1845a26012f0c1c105b8323523027792cdb8ba3a2664",
+      "values_digest": "0f4f1b0c0d4a42bc788212ae02b7acbcdb11cc05b353e81b502d593d0ebbff49",
       "rendered_digest": "5f5fba1cc84a8d39c69abcfc670f8f526070a8cad8012dbdf063a2e9e476d997",
       "ast_digest": "934f41a98fd3d24fc252acd7fa5d5fb1855a993707d3c462451e39e3706e2756"
     },
     "sor": {
-      "values_digest": "ca857ffa733505e36cbfa4dfe331d27275b0b6cb88a7f2b497e9657e421f5e4f",
-      "rendered_digest": "9adc0741edb43a4f3bbacf0e588aa47dd18141a9dc55769098d08c8943cc5924",
-      "ast_digest": "a7fc4bbefd160b498756c660b017ec6280a1af3cb39d7fa86ae630e4ae4f6463"
+      "values_digest": "ab202e8924787b55f69e3b8cca164bcc20981de24e4608b6758ac3622a26c895",
+      "rendered_digest": "2801be906fc260ce5adc6006122d9b4c2f6b2979d58d3b3be4c3ccb0569b96cf",
+      "ast_digest": "1fadc9c2e1f3978efdd0817e40dc16986174ae9c4729c711c9039287101b8835"
     }
   },
   "transitions": [
@@ -131,6 +141,13 @@
       "to": "reviewed",
       "actor": "codex:5719-execution",
       "reason": "Exact bounded review passed with no actionable findings for the podcast CI coverage path-policy fix."
+    },
+    {
+      "sequence": 5,
+      "from": "reviewed",
+      "to": "published",
+      "actor": "codex:5719-execution",
+      "reason": "observed exact PR after current review"
     }
   ],
   "audit": [
@@ -182,6 +199,13 @@
       "actor": "codex:5719-execution",
       "reason": "Exact bounded review passed with no actionable findings for the podcast CI coverage path-policy fix.",
       "operation": "{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"
+    },
+    {
+      "sequence": 8,
+      "generation": 4,
+      "actor": "codex:5719-execution",
+      "reason": "atomically record observed GitHub publication and SOR projection",
+      "operation": "record_publication"
     }
   ]
 }

--- a/.csdlc/issues/5719/index.json
+++ b/.csdlc/issues/5719/index.json
@@ -3,13 +3,13 @@
   "issue": 5719,
   "repository": "danielbaustin/agent-design-language",
   "initialization_digest": "3311f6460b0988706cb978ea2fcf7da322d7af3273fc5c96c2813a6f7a4fc271",
-  "phase": "implemented",
-  "generation": 1,
-  "digest": "84e3c398057b359d7afc1c85049137aaecf4cf9bbd8907c8a763ed5b744b5146",
+  "phase": "reviewed",
+  "generation": 3,
+  "digest": "74857505551f86a7725ff9186ef05c99ba2be34a241ceb6d5e23a1ecac5fe960",
   "claim": {
     "id": "claim-5719-ci-coverage-page-policy",
     "owner": "codex:5719-execution",
-    "generation": 1,
+    "generation": 3,
     "acquired_unix_seconds": 1785363942,
     "expires_unix_seconds": 1785968742,
     "heartbeat_unix_seconds": 1785363942,
@@ -28,8 +28,37 @@
     ],
     "purpose": "Fix CI path-policy selection so podcast/demo page-only PRs do not schedule duplicate hosted runtime and workspace coverage while preserving full coverage for Rust/runtime/provider/tooling changes"
   },
-  "review_assignment": null,
-  "review": null,
+  "review_assignment": {
+    "reviewer": "Heisenberg",
+    "assigned_by": "codex:5719-execution",
+    "revision": "git-blake3:b0f71eabb06945d5a7ad6147d7178586e3db86da:a6218709a4daeb864cd8deaf812e424aa9342260d5592dd722049a4ef0dd5be0",
+    "scope": [
+      ".csdlc/issues/5719",
+      ".csdlc/evidence/5719",
+      ".csdlc/prepared/issues/5719",
+      "adl/config/validation_lane_selector.v0.91.6.json",
+      "adl/tools/ci_path_policy.sh",
+      "adl/tools/test_ci_path_policy.sh"
+    ]
+  },
+  "review": {
+    "reviewer": "Heisenberg",
+    "scope": [
+      ".csdlc/issues/5719",
+      ".csdlc/evidence/5719",
+      ".csdlc/prepared/issues/5719",
+      "adl/config/validation_lane_selector.v0.91.6.json",
+      "adl/tools/ci_path_policy.sh",
+      "adl/tools/test_ci_path_policy.sh"
+    ],
+    "reviewed_revision": "git-blake3:b0f71eabb06945d5a7ad6147d7178586e3db86da:a6218709a4daeb864cd8deaf812e424aa9342260d5592dd722049a4ef0dd5be0",
+    "findings": [],
+    "residual_risks": [
+      "Review was read-only and confirmed the selector/path-policy contract at exact HEAD b0f71eabb; hosted CI behavior remains deferred to the published PR checks."
+    ],
+    "completed": true,
+    "non_substantive_proof": null
+  },
   "publication": null,
   "readiness": null,
   "terminal": null,
@@ -44,32 +73,32 @@
   },
   "cards": {
     "sip": {
-      "values_digest": "c258b372d00b3e58ff5e0dccad9e226ad2d0e297d10fc96a556b91eec33e889f",
+      "values_digest": "17ed7544fa7e077fee1ba20731dde0b37357fbe0842a4332fd4e3080e751983d",
       "rendered_digest": "5edc703d78bb5d850b627fa794f4eb45e023a7c3cf86f62a04ec9b1e6fbebef0",
       "ast_digest": "9798d8fc4365de347cba719ad458e1c5d6f62b23ba9451554a151dc6a99fd129"
     },
     "stp": {
-      "values_digest": "ce1d4dcd5b9031758ab3990f7b8334a7b2587ee3b455bff3733818f6592cd005",
+      "values_digest": "2621f8b3b5a9b58627499985b808b4e6add5a28fce4dcc58a35d0962b4554e0e",
       "rendered_digest": "3a46127e74167c14f3cf932b65fd169a5f087f132c4f5c0473968f0c7003044c",
       "ast_digest": "36f64615fce3a1933d837007862c8eee9304620c5b01fbe632a35271b7624868"
     },
     "spp": {
-      "values_digest": "dbe58c1d55113fe481044f72c19f6b03fe846c5be12c3505c7f310461b7426b5",
+      "values_digest": "0722bbcfb48353d41961a08e44ecb6bebd518d4985b8ba9765be71e174dd926a",
       "rendered_digest": "4c33e2a1cd788a668dcedeec7d45294528a99aa439cd07ac4118a1181f91cccd",
       "ast_digest": "df7462547dbef6bf41ecf7bbfe77d4f213d05d353d4ea38b290c28e07616325f"
     },
     "vpp": {
-      "values_digest": "81727cacca40298974faf0900c125f1ed31d028a61cb7b03709ce6c4b7cd53f8",
+      "values_digest": "5b065187044f6ffe02ed4188ce470d2601843ba7dc330e414a891d5593fbaeb7",
       "rendered_digest": "53b870f75afb2af19703292ae1300e6d7251054fe899d5fac6685e941c194b58",
       "ast_digest": "7dde77af196d5a1964814b78770b680f9988b6f569a44e25219157e58306f985"
     },
     "srp": {
-      "values_digest": "bc4ed9e818f325eee449dc67a10ed1648618bf7d3fd0ac881aa59c97cca3598f",
-      "rendered_digest": "de2c0c280391ac5563267973a3ff09ec0c37199a8e603dc565911eefb24cb1bd",
-      "ast_digest": "32c873c2c71e1ac19d7d7716345bde3535dd54c9aad1205ef2ebd8ff3e78e382"
+      "values_digest": "d3a27b679a8b64d849bc1845a26012f0c1c105b8323523027792cdb8ba3a2664",
+      "rendered_digest": "5f5fba1cc84a8d39c69abcfc670f8f526070a8cad8012dbdf063a2e9e476d997",
+      "ast_digest": "934f41a98fd3d24fc252acd7fa5d5fb1855a993707d3c462451e39e3706e2756"
     },
     "sor": {
-      "values_digest": "7bc37c78b40efd801496f37bbd80486fd0cc9afc88178cfeb790140fdbacc4c2",
+      "values_digest": "ca857ffa733505e36cbfa4dfe331d27275b0b6cb88a7f2b497e9657e421f5e4f",
       "rendered_digest": "9adc0741edb43a4f3bbacf0e588aa47dd18141a9dc55769098d08c8943cc5924",
       "ast_digest": "a7fc4bbefd160b498756c660b017ec6280a1af3cb39d7fa86ae630e4ae4f6463"
     }
@@ -95,6 +124,13 @@
       "to": "implemented",
       "actor": "codex:5719-execution",
       "reason": "execution and passing validation finalized atomically"
+    },
+    {
+      "sequence": 4,
+      "from": "implemented",
+      "to": "reviewed",
+      "actor": "codex:5719-execution",
+      "reason": "Exact bounded review passed with no actionable findings for the podcast CI coverage path-policy fix."
     }
   ],
   "audit": [
@@ -125,6 +161,27 @@
       "actor": "codex:5719-execution",
       "reason": "atomically record execution, validation, and implemented phase",
       "operation": "finalize_implementation"
+    },
+    {
+      "sequence": 5,
+      "generation": 1,
+      "actor": "codex:5719-execution",
+      "reason": "assign bounded exact-revision review",
+      "operation": "assign_review"
+    },
+    {
+      "sequence": 6,
+      "generation": 2,
+      "actor": "codex:5719-execution",
+      "reason": "atomically record assigned review evidence and SRP projection",
+      "operation": "record_review"
+    },
+    {
+      "sequence": 7,
+      "generation": 3,
+      "actor": "codex:5719-execution",
+      "reason": "Exact bounded review passed with no actionable findings for the podcast CI coverage path-policy fix.",
+      "operation": "{\"operation\":\"advance_phase\",\"phase\":\"reviewed\"}"
     }
   ]
 }

--- a/.csdlc/prepared/issues/5719/advance-reviewed.json
+++ b/.csdlc/prepared/issues/5719/advance-reviewed.json
@@ -1,0 +1,14 @@
+{
+  "issue": 5719,
+  "card": "sor",
+  "expected_generation": 2,
+  "expected_digest": "d016b31c9248d1c0a9ed5cd5916a80185a134264958f546273f9b2096227ecb0",
+  "claim_id": "claim-5719-ci-coverage-page-policy",
+  "actor": "codex:5719-execution",
+  "reason": "Exact bounded review passed with no actionable findings for the podcast CI coverage path-policy fix.",
+  "operation": {
+    "operation": "advance_phase",
+    "phase": "reviewed"
+  },
+  "fail_after_backup": false
+}

--- a/.csdlc/prepared/issues/5719/amend-selector-manifest-scope.json
+++ b/.csdlc/prepared/issues/5719/amend-selector-manifest-scope.json
@@ -1,0 +1,12 @@
+{
+  "issue": 5719,
+  "claim_id": "claim-5719-ci-coverage-page-policy",
+  "expected_generation": 0,
+  "expected_digest": "f43d07c74c3540a7ba9145cd27457925007b707ad972bceb3cf61d45f562d43b",
+  "now_unix_seconds": 1785363942,
+  "actor": "codex:5719-execution",
+  "reason": "The reproduced #5716-like failure is an unmapped validation-manager surface, so #5719 must update the validation lane selector manifest as part of the CI coverage selection fix.",
+  "add_protected_paths": [
+    "adl/config/validation_lane_selector.v0.91.6.json"
+  ]
+}

--- a/.csdlc/prepared/issues/5719/bind.json
+++ b/.csdlc/prepared/issues/5719/bind.json
@@ -1,0 +1,27 @@
+{
+  "issue": 5719,
+  "base_branch": "main",
+  "branch": "codex/5719-ci-coverage-page-policy",
+  "worktree": ".",
+  "claim": {
+    "id": "claim-5719-ci-coverage-page-policy",
+    "owner": "codex:5719-execution",
+    "generation": 0,
+    "acquired_unix_seconds": 1785363942,
+    "expires_unix_seconds": 1785968742,
+    "heartbeat_unix_seconds": 1785363942,
+    "branch": "codex/5719-ci-coverage-page-policy",
+    "worktree": ".",
+    "protected_paths": [
+      ".csdlc/issues/5719",
+      ".csdlc/locks/5719.lock",
+      ".csdlc/prepared/issues/5719",
+      ".github/workflows/ci.yaml",
+      "adl/tools/ci_path_policy.sh",
+      "adl/tools/test_ci_path_policy.sh",
+      "adl/tools/test_ci_runtime_contracts.sh",
+      "adl/tools/test_validation_manager.sh"
+    ],
+    "purpose": "Fix CI path-policy selection so podcast/demo page-only PRs do not schedule duplicate hosted runtime and workspace coverage while preserving full coverage for Rust/runtime/provider/tooling changes"
+  }
+}

--- a/.csdlc/prepared/issues/5719/bootstrap.json
+++ b/.csdlc/prepared/issues/5719/bootstrap.json
@@ -1,0 +1,155 @@
+{
+  "issue": 5719,
+  "repository": "danielbaustin/agent-design-language",
+  "design_path": ".csdlc/prepared/issues/5719/design.md",
+  "diagram_path": ".csdlc/prepared/issues/5719/diagram.mmd",
+  "design_reviewer": "codex:5719-execution",
+  "design_approved": true,
+  "claim": {
+    "id": "claim-5719-ci-coverage-page-policy",
+    "owner": "codex:5719-execution",
+    "generation": 0,
+    "acquired_unix_seconds": 1785363942,
+    "expires_unix_seconds": 1785968742,
+    "heartbeat_unix_seconds": 1785363942,
+    "branch": "codex/5719-ci-coverage-page-policy",
+    "worktree": ".",
+    "protected_paths": [
+      ".csdlc/issues/5719",
+      ".csdlc/locks/5719.lock",
+      ".csdlc/prepared/issues/5719",
+      ".github/workflows/ci.yaml",
+      "adl/tools/ci_path_policy.sh",
+      "adl/tools/test_ci_path_policy.sh",
+      "adl/tools/test_ci_runtime_contracts.sh",
+      "adl/tools/test_validation_manager.sh"
+    ],
+    "purpose": "Fix CI path-policy selection so podcast/demo page-only PRs do not schedule duplicate hosted runtime and workspace coverage while preserving full coverage for Rust/runtime/provider/tooling changes"
+  },
+  "initial": {
+    "title": "[v0.91.8][ci][coverage] Avoid duplicate hosted coverage on podcast/demo page PRs",
+    "slug": "v0-91-8-ci-coverage-avoid-duplicate-hosted-coverage-on-podcast-demo-page-prs",
+    "version": "v0.91.8",
+    "goal": "Make podcast/demo page and launch packet UI-only PRs select focused validation rather than full hosted runtime plus workspace coverage.",
+    "required_outcome": "A #5716-like podcast studio/static demo path set no longer sets full_coverage_required=true, while Rust/runtime/provider/tooling changes still select their existing coverage requirements.",
+    "declared_scope": [
+      "CI path-policy classifier",
+      "CI path-policy contract tests",
+      "workflow contract assertions if needed",
+      "issue-local C-SDLC lifecycle evidence"
+    ],
+    "authority_boundary": [
+      "GitHub issue #5719",
+      "Observed PR #5716 hosted coverage selection",
+      "Existing CI path-policy contract tests"
+    ],
+    "operator_constraints": [
+      "Use only FastWork for tracked issue work.",
+      "Do not write tracked changes on main.",
+      "Do not remove the adl-coverage-hosted aggregator.",
+      "Avoid duplicate expensive hosted producer lanes for static podcast/demo page changes.",
+      "Preserve full coverage for Rust/runtime/provider/tooling policy changes."
+    ],
+    "task_boundary": "Fix CI selector policy and focused contract tests only; do not change podcast page content or unrelated CI behavior.",
+    "deliverables": [
+      "path-policy classifier update",
+      "focused tests for podcast/demo static path selection",
+      "regression tests proving Rust/tooling changes still select full or required lanes",
+      "truthful lifecycle and publication evidence"
+    ],
+    "acceptance_criteria": [
+      "AC-1: A #5716-like podcast studio/static demo path set reports full_coverage_required=false.",
+      "AC-2: The same path set does not schedule both hosted runtime and hosted workspace producer coverage.",
+      "AC-3: The stable adl-coverage-hosted aggregator/check remains present and truthful.",
+      "AC-4: Rust/runtime/provider/tooling policy path changes retain their existing full/focused coverage requirements.",
+      "AC-5: Focused CI path-policy and workflow contract tests pass locally."
+    ],
+    "dependencies": [
+      "#5716 observed duplicate hosted producer coverage",
+      "Existing ci_path_policy contract suite"
+    ],
+    "repo_inputs": [
+      "adl/tools/ci_path_policy.sh",
+      "adl/tools/test_ci_path_policy.sh",
+      ".github/workflows/ci.yaml",
+      "adl/tools/test_ci_runtime_contracts.sh",
+      "adl/tools/test_validation_manager.sh"
+    ],
+    "non_goals": [
+      "removing required stable check aggregation",
+      "rewriting the hosted coverage workflow",
+      "changing podcast page content",
+      "weakening Rust/runtime/provider/tooling coverage"
+    ],
+    "plan_summary": "Add a bounded static podcast/demo path classification, prove #5716-like paths avoid full hosted coverage, preserve producer lanes for behavioral changes, review, and publish.",
+    "steps": [
+      {
+        "id": "S1",
+        "action": "Inspect current path-policy coverage selection and reproduce a #5716-like changed path set.",
+        "acceptance_ids": ["AC-1", "AC-2"],
+        "status": "pending"
+      },
+      {
+        "id": "S2",
+        "action": "Patch the selector with the smallest static podcast/demo classification.",
+        "acceptance_ids": ["AC-1", "AC-2", "AC-3", "AC-4"],
+        "status": "pending"
+      },
+      {
+        "id": "S3",
+        "action": "Add focused tests for static podcast/demo paths and Rust/tooling preservation.",
+        "acceptance_ids": ["AC-1", "AC-2", "AC-4", "AC-5"],
+        "status": "pending"
+      },
+      {
+        "id": "S4",
+        "action": "Run path-policy, workflow contract, and validation-manager focused checks.",
+        "acceptance_ids": ["AC-3", "AC-5"],
+        "status": "pending"
+      },
+      {
+        "id": "S5",
+        "action": "Run bounded review, record lifecycle truth, and publish with Closes #5719.",
+        "acceptance_ids": ["AC-1", "AC-2", "AC-3", "AC-4", "AC-5"],
+        "status": "pending"
+      }
+    ],
+    "invariants": [
+      "The aggregator job remains the stable coverage check.",
+      "Full hosted coverage remains fail-closed for source/runtime/provider/tooling-policy changes.",
+      "Static podcast/demo page changes do not pay for duplicate hosted producer coverage."
+    ],
+    "risks": [
+      "Over-broad static classification could skip coverage for code-bearing demo changes.",
+      "Workflow contract assertions could drift from the selector output.",
+      "Policy tests are large and may hide the focused regression if no specific fixture is added."
+    ],
+    "stop_conditions": [
+      "The selector cannot distinguish static podcast/demo files from code-bearing demo/runtime files.",
+      "A workflow contract proves both hosted producer lanes are still selected after the path-policy change.",
+      "A Rust/runtime/provider fixture regresses to skipped coverage."
+    ],
+    "review_prompts": [
+      "Does the policy narrowly target static podcast/demo page and launch packet UI paths?",
+      "Can a code-bearing Rust/runtime/provider/tooling path still trigger its required coverage lane?",
+      "Does the workflow keep the stable aggregator while avoiding duplicate hosted producers?"
+    ],
+    "review_scope": "CI path-policy classifier, CI path-policy tests, workflow contract assertions, and issue-local lifecycle records",
+    "failure_policy": "Fail closed on any selector ambiguity that could skip full coverage for source/runtime/provider/tooling behavior.",
+    "planning_profile": "small",
+    "validation_lanes": [
+      {
+        "lane": "ci_path_policy_contracts",
+        "proof_role": "focused selector and workflow contract validation",
+        "acceptance_ids": ["AC-1", "AC-2", "AC-3", "AC-4", "AC-5"],
+        "deterministic": true,
+        "resource_profile": "small",
+        "budget_seconds": 240,
+        "budget_tokens": 2000,
+        "argv": ["bash", "adl/tools/test_ci_path_policy.sh"],
+        "parallel_group": "focused",
+        "defer_reason": null
+      }
+    ]
+  }
+}

--- a/.csdlc/prepared/issues/5719/design.md
+++ b/.csdlc/prepared/issues/5719/design.md
@@ -1,0 +1,25 @@
+# #5719 Design
+
+## Goal
+
+Fix the CI path-policy selection that caused podcast/demo page-only PRs to schedule both runtime hosted coverage and workspace hosted coverage. The stable `adl-coverage-hosted` job remains the required aggregator/check; the expensive producer lanes should only run when the path policy proves they are required.
+
+## Scope
+
+- `adl/tools/ci_path_policy.sh`
+- `adl/tools/test_ci_path_policy.sh`
+- `.github/workflows/ci.yaml` only if the selector contract shows the workflow consumes the corrected output incorrectly
+- issue-local C-SDLC records and publication evidence
+
+## Approach
+
+1. Reproduce the #5716-like path set in the existing path-policy contract tests.
+2. Add the narrowest path classifier that treats podcast/demo page and launch-packet static surfaces as focused/static validation, not full hosted coverage.
+3. Preserve full hosted coverage for Rust, runtime, provider, and tooling policy changes.
+4. Run the existing CI path-policy contract tests and focused validation-manager checks.
+
+## Non-Goals
+
+- Do not remove the `adl-coverage-hosted` aggregator.
+- Do not weaken full coverage for Rust/runtime/provider/tooling changes.
+- Do not edit the podcast page or any active podcast PR in this issue.

--- a/.csdlc/prepared/issues/5719/diagram.mmd
+++ b/.csdlc/prepared/issues/5719/diagram.mmd
@@ -1,0 +1,10 @@
+flowchart LR
+    A["Changed PR paths"] --> B["ci_path_policy.sh"]
+    B --> C{"Rust/runtime/provider/tooling?"}
+    C -- yes --> D["full hosted coverage producers"]
+    C -- no --> E{"podcast/demo static surface?"}
+    E -- yes --> F["focused static/demo validation, no full hosted coverage"]
+    E -- no --> G["existing docs/tooling policy"]
+    D --> H["adl-coverage-hosted aggregator"]
+    F --> H
+    G --> H

--- a/.csdlc/prepared/issues/5719/finalize.json
+++ b/.csdlc/prepared/issues/5719/finalize.json
@@ -1,0 +1,71 @@
+{
+  "schema": "csdlc.finalize_request.v1",
+  "issue": 5719,
+  "expected_generation": 0,
+  "expected_digest": "6ff3d9dc7225340bc39b65a35e52d097390ebecacdddd60e662a29bf7ae2e914",
+  "claim_id": "claim-5719-ci-coverage-page-policy",
+  "actor": "codex:5719-execution",
+  "summary": "Mapped podcast launch/studio demo surfaces into a focused podcast_launch_packet validation lane and taught ci_path_policy to consume that lane without selecting full hosted coverage. Added a #5716-like regression fixture proving podcast static/demo page paths skip full coverage while preserving the coverage aggregator and existing Rust/tooling behavior.",
+  "changes": [
+    ".csdlc/issues/5719",
+    ".csdlc/locks/5719.lock",
+    ".csdlc/prepared/issues/5719",
+    "adl/config/validation_lane_selector.v0.91.6.json",
+    "adl/tools/ci_path_policy.sh",
+    "adl/tools/test_ci_path_policy.sh"
+  ],
+  "artifacts": [
+    "adl/tools/test_ci_path_policy.sh",
+    "adl/tools/test_ci_runtime_contracts.sh"
+  ],
+  "execution": {
+    "manifest": {
+      "schema": "csdlc.pvf.manifest.v1",
+      "lanes": [
+        {
+          "id": "ci-path-policy-podcast-launch-contract",
+          "proof_role": "selector_regression",
+          "purpose": "Prove podcast launch/studio page changes select focused podcast validation and do not require full hosted runtime plus workspace coverage.",
+          "determinism": "deterministic",
+          "resources": {
+            "cpu_units": 1,
+            "memory_mib": 1024,
+            "tokens": 1000
+          },
+          "credentials": [],
+          "network": "denied",
+          "dependencies": [],
+          "parallel_group": "ci-path-policy",
+          "release_gate": "required",
+          "execution": "local",
+          "timeout_seconds": 240,
+          "executable": "bash",
+          "argv": [
+            "adl/tools/test_ci_path_policy.sh"
+          ],
+          "evidence": {
+            "max_log_bytes": 1048576,
+            "redact_values": [],
+            "require_relative_paths": true
+          }
+        }
+      ]
+    },
+    "selection": {
+      "requested_lanes": [
+        "ci-path-policy-podcast-launch-contract"
+      ],
+      "allow_network": false,
+      "available_credentials": []
+    },
+    "budget": {
+      "max_parallel": 1,
+      "cpu_units": 1,
+      "memory_mib": 1024,
+      "tokens": 1000
+    },
+    "root": ".",
+    "evidence_dir": "./.csdlc/evidence/5719",
+    "cancellation_file": null
+  }
+}

--- a/.csdlc/prepared/issues/5719/publish-draft.json
+++ b/.csdlc/prepared/issues/5719/publish-draft.json
@@ -1,0 +1,16 @@
+{
+  "schema": "csdlc.publication_request.v1",
+  "issue": 5719,
+  "expected_generation": 3,
+  "expected_digest": "74857505551f86a7725ff9186ef05c99ba2be34a241ceb6d5e23a1ecac5fe960",
+  "claim_id": "claim-5719-ci-coverage-page-policy",
+  "actor": "codex:5719-execution",
+  "repository": "danielbaustin/agent-design-language",
+  "remote": "origin",
+  "base": "main",
+  "head": "codex/5719-ci-coverage-page-policy",
+  "title": "[v0.91.8][ci][coverage] Avoid duplicate hosted coverage on podcast/demo page PRs",
+  "body": "Closes #5719\n\nFixes the #5716 coverage-selection regression by mapping podcast launch and studio demo surfaces into the focused `podcast_launch_packet` validation lane, then routing that lane through `ci_path_policy` without setting `coverage_required` or `full_coverage_required`.\n\nThe stable `adl-coverage-hosted` aggregator remains intact; this change prevents podcast/demo static PRs from scheduling both expensive hosted runtime and workspace producer coverage when no Rust/runtime/provider/tooling behavior changed.\n\nValidation:\n- `python3 -m json.tool adl/config/validation_lane_selector.v0.91.6.json`\n- `bash adl/tools/test_ci_path_policy.sh`\n- `bash adl/tools/test_ci_runtime_contracts.sh`\n- `git diff --check`\n- `csdlc-doctor --repo . --issue 5719`\n\nReview: Heisenberg read-only exact-head review at `b0f71eabb06945d5a7ad6147d7178586e3db86da` returned CLEAN.",
+  "draft": true,
+  "token_file": "/Users/daniel/keys/github.token"
+}

--- a/.csdlc/prepared/issues/5719/review-assign-heisenberg.json
+++ b/.csdlc/prepared/issues/5719/review-assign-heisenberg.json
@@ -1,0 +1,16 @@
+{
+  "issue": 5719,
+  "expected_generation": 1,
+  "expected_digest": "84e3c398057b359d7afc1c85049137aaecf4cf9bbd8907c8a763ed5b744b5146",
+  "claim_id": "claim-5719-ci-coverage-page-policy",
+  "reviewer": "Heisenberg",
+  "assigned_by": "codex:5719-execution",
+  "scope": [
+    ".csdlc/issues/5719",
+    ".csdlc/evidence/5719",
+    ".csdlc/prepared/issues/5719",
+    "adl/config/validation_lane_selector.v0.91.6.json",
+    "adl/tools/ci_path_policy.sh",
+    "adl/tools/test_ci_path_policy.sh"
+  ]
+}

--- a/.csdlc/prepared/issues/5719/review-record-heisenberg.json
+++ b/.csdlc/prepared/issues/5719/review-record-heisenberg.json
@@ -1,0 +1,25 @@
+{
+  "issue": 5719,
+  "expected_generation": 1,
+  "expected_digest": "6f346f445ca8d733b7360c2befcd1366bb80711bbe6b82a9097b2d68537a9d33",
+  "claim_id": "claim-5719-ci-coverage-page-policy",
+  "actor": "codex:5719-execution",
+  "evidence": {
+    "reviewer": "Heisenberg",
+    "scope": [
+      ".csdlc/issues/5719",
+      ".csdlc/evidence/5719",
+      ".csdlc/prepared/issues/5719",
+      "adl/config/validation_lane_selector.v0.91.6.json",
+      "adl/tools/ci_path_policy.sh",
+      "adl/tools/test_ci_path_policy.sh"
+    ],
+    "reviewed_revision": "git-blake3:b0f71eabb06945d5a7ad6147d7178586e3db86da:a6218709a4daeb864cd8deaf812e424aa9342260d5592dd722049a4ef0dd5be0",
+    "findings": [],
+    "residual_risks": [
+      "Review was read-only and confirmed the selector/path-policy contract at exact HEAD b0f71eabb; hosted CI behavior remains deferred to the published PR checks."
+    ],
+    "completed": true,
+    "non_substantive_proof": null
+  }
+}

--- a/.csdlc/publication/5719.intent.json
+++ b/.csdlc/publication/5719.intent.json
@@ -1,0 +1,12 @@
+{
+  "schema": "csdlc.publication_intent.v1",
+  "issue": 5719,
+  "repository": "danielbaustin/agent-design-language",
+  "base": "main",
+  "head": "codex/5719-ci-coverage-page-policy",
+  "title": "[v0.91.8][ci][coverage] Avoid duplicate hosted coverage on podcast/demo page PRs",
+  "body": "Closes #5719\n\nFixes the #5716 coverage-selection regression by mapping podcast launch and studio demo surfaces into the focused `podcast_launch_packet` validation lane, then routing that lane through `ci_path_policy` without setting `coverage_required` or `full_coverage_required`.\n\nThe stable `adl-coverage-hosted` aggregator remains intact; this change prevents podcast/demo static PRs from scheduling both expensive hosted runtime and workspace producer coverage when no Rust/runtime/provider/tooling behavior changed.\n\nValidation:\n- `python3 -m json.tool adl/config/validation_lane_selector.v0.91.6.json`\n- `bash adl/tools/test_ci_path_policy.sh`\n- `bash adl/tools/test_ci_runtime_contracts.sh`\n- `git diff --check`\n- `csdlc-doctor --repo . --issue 5719`\n\nReview: Heisenberg read-only exact-head review at `b0f71eabb06945d5a7ad6147d7178586e3db86da` returned CLEAN.",
+  "draft": true,
+  "revision": "git-blake3:fdd526202033fd0d119ac020e341c1e40f8b0c79:2d5ce896bbe2adadfb376fc119859ec9159eb2f8aed49ac5acfaca25d4612acc",
+  "commit_sha": "fdd526202033fd0d119ac020e341c1e40f8b0c79"
+}

--- a/adl/config/validation_lane_selector.v0.91.6.json
+++ b/adl/config/validation_lane_selector.v0.91.6.json
@@ -304,6 +304,33 @@
       "reason": "coverage_impact_surface_requires_coverage_impact_contract_checks"
     },
     {
+      "id": "podcast_launch_packet",
+      "lane_class": "cli_workflow",
+      "default_surface": "tooling",
+      "owner": "review",
+      "proof_role": "demo_contract",
+      "requirement_ids": [
+        "podcast_launch_packet"
+      ],
+      "path_selectors": [
+        "adl/tools/generate_podcast_launch_packet.py",
+        "adl/tools/validate_podcast_launch_packet.py",
+        "adl/tools/test_podcast_launch_packet.sh",
+        "demos/podcast/**",
+        "docs/milestones/v0.91.8/review/podcast_launch_5711/**"
+      ],
+      "path_hints": [
+        "adl/tools/generate_podcast_launch_packet.py",
+        "adl/tools/validate_podcast_launch_packet.py",
+        "adl/tools/test_podcast_launch_packet.sh",
+        "demos/podcast/",
+        "docs/milestones/v0.91.8/review/podcast_launch_5711/"
+      ],
+      "command": "bash adl/tools/test_podcast_launch_packet.sh",
+      "run_command": "bash adl/tools/test_podcast_launch_packet.sh",
+      "reason": "podcast_launch_surface_requires_audio_rss_and_studio_packet_validation"
+    },
+    {
       "id": "html_observatory_governed_surface",
       "lane_class": "cli_workflow",
       "default_surface": "tooling",

--- a/adl/tools/ci_path_policy.sh
+++ b/adl/tools/ci_path_policy.sh
@@ -1378,6 +1378,19 @@ apply_validation_manager_routing() {
       reason="sprint_conductor_surface_requires_helper_contract_checks"
       return 0
       ;;
+    ready_to_run:podcast_launch_packet:false|\
+    ready_to_run:docs_diff_check,podcast_launch_packet:false|\
+    ready_to_run:podcast_launch_packet,docs_diff_check:false)
+      ci_contracts_required=true
+      demo_smoke_required=true
+      coverage_required=false
+      full_coverage_required=false
+      coverage_lane="skip"
+      coverage_authority="not_required"
+      coverage_execution_state="skipped_by_path_policy"
+      reason="podcast_launch_surface_requires_audio_rss_and_studio_packet_validation"
+      return 0
+      ;;
     ready_to_run:rust_dependency_cache_warmup_contracts:false|\
     ready_to_run:docs_diff_check,rust_dependency_cache_warmup_contracts:false|\
     ready_to_run:rust_dependency_cache_warmup_contracts,docs_diff_check:false)

--- a/adl/tools/test_ci_path_policy.sh
+++ b/adl/tools/test_ci_path_policy.sh
@@ -963,6 +963,35 @@ EOF
   assert_has "$policy_surface_plus_demo_output" "coverage_authority=not_required"
   assert_has "$policy_surface_plus_demo_output" "reason=coverage_policy_surface_tooling_change_runs_contract_validation"
 
+  git checkout -q -b podcast-launch-static-surface "$base_sha"
+  mkdir -p .csdlc/issues/5715 adl/tools demos/podcast/studio-reference demos/podcast/studio
+  printf '{"phase":"published"}\n' > .csdlc/issues/5715/index.json
+  printf '#!/usr/bin/env python3\nprint("generate podcast launch packet")\n' > adl/tools/generate_podcast_launch_packet.py
+  printf '#!/usr/bin/env python3\nprint("validate podcast launch packet")\n' > adl/tools/validate_podcast_launch_packet.py
+  printf '<!doctype html><title>Podcast</title>\n' > demos/podcast/index.html
+  printf '<!doctype html><title>Podcast Studio Reference</title>\n' > demos/podcast/studio-reference/podcast-studio.html
+  printf '<!doctype html><title>Podcast Studio</title>\n' > demos/podcast/studio/podcast-studio.html
+  printf 'sha256  podcast-studio.html\n' > demos/podcast/studio/reference.sha256
+  git add .csdlc/issues/5715/index.json adl/tools/generate_podcast_launch_packet.py adl/tools/validate_podcast_launch_packet.py demos/podcast/index.html demos/podcast/studio-reference/podcast-studio.html demos/podcast/studio/podcast-studio.html demos/podcast/studio/reference.sha256
+  git commit -q -m podcast-launch-static-surface
+  podcast_launch_static_head="$(git rev-parse HEAD)"
+
+  podcast_launch_static_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$podcast_launch_static_head" --ref "refs/pull/5716/merge")"
+  assert_has "$podcast_launch_static_output" "rust_required=false"
+  assert_has "$podcast_launch_static_output" "coverage_required=false"
+  assert_has "$podcast_launch_static_output" "full_coverage_required=false"
+  assert_has "$podcast_launch_static_output" "demo_smoke_required=true"
+  assert_has "$podcast_launch_static_output" "ci_contracts_required=true"
+  assert_has "$podcast_launch_static_output" "ci_path_policy_contracts_required=false"
+  assert_has "$podcast_launch_static_output" "coverage_lane=skip"
+  assert_has "$podcast_launch_static_output" "coverage_authority=not_required"
+  assert_has "$podcast_launch_static_output" "coverage_execution_state=skipped_by_path_policy"
+  assert_has "$podcast_launch_static_output" "validation_profile_status=ready_to_run"
+  assert_has "$podcast_launch_static_output" "validation_profile_escalation_required=false"
+  assert_has "$podcast_launch_static_output" "validation_profile_run_lanes=docs_diff_check,podcast_launch_packet"
+  assert_has "$podcast_launch_static_output" "validation_profile_primary_reason=docs_only_surface_requires_diff_hygiene"
+  assert_has "$podcast_launch_static_output" "reason=podcast_launch_surface_requires_audio_rss_and_studio_packet_validation"
+
   git checkout -q -b pvf-runner-policy-surface "$base_sha"
   mkdir -p adl/tools
   printf '#!/usr/bin/env bash\nprintf pvf-runner\n' > adl/tools/run_pvf_validation_lane.sh


### PR DESCRIPTION
Closes #5719

Fixes the #5716 coverage-selection regression by mapping podcast launch and studio demo surfaces into the focused `podcast_launch_packet` validation lane, then routing that lane through `ci_path_policy` without setting `coverage_required` or `full_coverage_required`.

The stable `adl-coverage-hosted` aggregator remains intact; this change prevents podcast/demo static PRs from scheduling both expensive hosted runtime and workspace producer coverage when no Rust/runtime/provider/tooling behavior changed.

Validation:
- `python3 -m json.tool adl/config/validation_lane_selector.v0.91.6.json`
- `bash adl/tools/test_ci_path_policy.sh`
- `bash adl/tools/test_ci_runtime_contracts.sh`
- `git diff --check`
- `csdlc-doctor --repo . --issue 5719`

Review: Heisenberg read-only exact-head review at `b0f71eabb06945d5a7ad6147d7178586e3db86da` returned CLEAN.