### PR TITLE
[v0.91.8][csdlc-v2][tests] Isolate terminal repair fixtures

### DIFF
--- a/.csdlc/designs/5762/design.md
+++ b/.csdlc/designs/5762/design.md
@@ -1,0 +1,19 @@
+# Issue 5762 Design
+
+## Decision
+
+Repair the C-SDLC v2 terminal SOR validation repair tests so their temporary
+repository synthesizes its own deterministic repair authority and terminal
+target state. The tests must not copy active-claim truth from #5613 or any
+mutable tracked issue projection.
+
+## Scope
+
+- `csdlc-v2/src/store.rs` test fixture construction only.
+- Issue-local lifecycle, request, and evidence paths for #5762.
+
+## Non-Goals
+
+- No production lifecycle semantic change.
+- No broad terminal repair refactor.
+- No dependency on `/private/tmp`.

--- a/.csdlc/designs/5762/diagram.mmd
+++ b/.csdlc/designs/5762/diagram.mmd
@@ -1,0 +1,5 @@
+flowchart LR
+  A["temporary repo fixture"] --> B["synthetic repair authority"]
+  A --> C["closed_out claim-free target"]
+  B --> D["terminal SOR validation repair tests"]
+  C --> D

--- a/.csdlc/issues/5762/audit.jsonl
+++ b/.csdlc/issues/5762/audit.jsonl
@@ -1,0 +1,2 @@
+{"sequence":1,"generation":0,"actor":"codex","reason":"initialize issue record and all six cards","operation":"bootstrap"}
+{"sequence":2,"generation":0,"actor":"codex","reason":"bind branch/worktree and activate claim","operation":"bind"}

--- a/.csdlc/issues/5762/cards/sip.md
+++ b/.csdlc/issues/5762/cards/sip.md
@@ -1,0 +1,42 @@
+# Structured Intent Prompt
+
+Template: 1.0.0
+
+Issue: 5762
+
+Repository: danielbaustin/agent-design-language
+
+Card: sip
+
+Status: ready
+
+## Goal
+
+Make the C-SDLC v2 terminal SOR validation repair tests independent of mutable tracked issue active-claim state.
+
+## Required Outcome
+
+The three terminal SOR validation repair tests synthesize deterministic issue-local repair authority in their temporary repository and pass when the terminal target is closed_out and claim-free.
+
+## Scope
+
+- csdlc-v2/src/store.rs test fixture construction
+- issue-local lifecycle and evidence for #5762
+
+## Authority
+
+- typed C-SDLC v2 binaries own lifecycle state
+- no production lifecycle semantic change
+- no dependency on /private/tmp
+- no dependency on #5613 retaining an active claim
+
+## Assumptions
+
+- none
+
+## Operator Constraints
+
+- work only in /Volumes/FastWork/adl-wp-5762
+- do not write tracked files on primary main
+- publish a ready PR with Closes #5762
+- do not block on post-merge typed closeout

--- a/.csdlc/issues/5762/cards/sip.values.json
+++ b/.csdlc/issues/5762/cards/sip.values.json
@@ -1,0 +1,37 @@
+{
+  "identity": {
+    "schema_version": "1.0.0",
+    "template_version": "1.0.0",
+    "issue": 5762,
+    "repository": "danielbaustin/agent-design-language",
+    "title": "[v0.91.8][csdlc-v2][tests] Make terminal repair fixtures independent of live issue claims",
+    "slug": "terminal-sor-validation-fixtures",
+    "version": "v0.91.8",
+    "generation": 0
+  },
+  "status": "ready",
+  "content": {
+    "card_kind": "sip",
+    "values": {
+      "goal": "Make the C-SDLC v2 terminal SOR validation repair tests independent of mutable tracked issue active-claim state.",
+      "required_outcome": "The three terminal SOR validation repair tests synthesize deterministic issue-local repair authority in their temporary repository and pass when the terminal target is closed_out and claim-free.",
+      "declared_scope": [
+        "csdlc-v2/src/store.rs test fixture construction",
+        "issue-local lifecycle and evidence for #5762"
+      ],
+      "authority_boundary": [
+        "typed C-SDLC v2 binaries own lifecycle state",
+        "no production lifecycle semantic change",
+        "no dependency on /private/tmp",
+        "no dependency on #5613 retaining an active claim"
+      ],
+      "initial_assumptions": [],
+      "operator_constraints": [
+        "work only in /Volumes/FastWork/adl-wp-5762",
+        "do not write tracked files on primary main",
+        "publish a ready PR with Closes #5762",
+        "do not block on post-merge typed closeout"
+      ]
+    }
+  }
+}

--- a/.csdlc/issues/5762/cards/sor.md
+++ b/.csdlc/issues/5762/cards/sor.md
@@ -1,0 +1,45 @@
+# Structured Output Record
+
+Template: 1.0.0
+
+Issue: 5762
+
+Repository: danielbaustin/agent-design-language
+
+Card: sor
+
+Status: pre_phase
+
+## Summary
+
+Pre-execution output record.
+
+## Artifacts
+
+- none
+
+## Execution
+
+- none
+
+## Validation
+
+[]
+
+## Integration
+
+not_started
+
+## Publication
+
+Publication: not_published
+
+Merge: not_merged
+
+## Closeout
+
+not_started
+
+## Follow Ups
+
+- none

--- a/.csdlc/issues/5762/cards/sor.values.json
+++ b/.csdlc/issues/5762/cards/sor.values.json
@@ -1,0 +1,27 @@
+{
+  "identity": {
+    "schema_version": "1.0.0",
+    "template_version": "1.0.0",
+    "issue": 5762,
+    "repository": "danielbaustin/agent-design-language",
+    "title": "[v0.91.8][csdlc-v2][tests] Make terminal repair fixtures independent of live issue claims",
+    "slug": "terminal-sor-validation-fixtures",
+    "version": "v0.91.8",
+    "generation": 0
+  },
+  "status": "pre_phase",
+  "content": {
+    "card_kind": "sor",
+    "values": {
+      "summary": "Pre-execution output record.",
+      "actual_changes": [],
+      "artifacts": [],
+      "actual_validation": [],
+      "integration_state": "not_started",
+      "publication_state": "not_published",
+      "merge_state": "not_merged",
+      "closeout_state": "not_started",
+      "follow_ups": []
+    }
+  }
+}

--- a/.csdlc/issues/5762/cards/spp.md
+++ b/.csdlc/issues/5762/cards/spp.md
@@ -1,0 +1,111 @@
+# Structured Planning Prompt
+
+Template: 1.0.0
+
+Issue: 5762
+
+Repository: danielbaustin/agent-design-language
+
+Card: spp
+
+Status: ready
+
+## Summary
+
+Bind #5762, repair the store.rs terminal SOR validation fixture authority setup, validate focused and full C-SDLC v2 lanes, run bounded review, publish a ready PR, and shepherd it green.
+
+## Plan
+
+Revision 1
+
+## Steps
+
+[
+  {
+    "id": "S1",
+    "action": "Initialize and bind #5762 in the issue worktree.",
+    "acceptance_ids": [
+      "AC-1",
+      "AC-2",
+      "AC-3",
+      "AC-4",
+      "AC-5",
+      "AC-6"
+    ],
+    "status": "pending"
+  },
+  {
+    "id": "S2",
+    "action": "Repair the terminal SOR validation fixture authority setup.",
+    "acceptance_ids": [
+      "AC-1",
+      "AC-2",
+      "AC-3",
+      "AC-4",
+      "AC-5",
+      "AC-6"
+    ],
+    "status": "pending"
+  },
+  {
+    "id": "S3",
+    "action": "Run focused tests, full locked all-target C-SDLC v2 tests, strict Clippy, and diff hygiene.",
+    "acceptance_ids": [
+      "AC-2",
+      "AC-3",
+      "AC-4"
+    ],
+    "status": "pending"
+  },
+  {
+    "id": "S4",
+    "action": "Run bounded gpt-5.5 review, fix findings, publish ready PR, and shepherd checks green.",
+    "acceptance_ids": [
+      "AC-5",
+      "AC-6"
+    ],
+    "status": "pending"
+  }
+]
+
+## Invariants
+
+- Production terminal repair semantics remain unchanged.
+- Temporary test authority is deterministic and issue-local.
+- Closed_out targets remain claim-free.
+
+## Risks
+
+- Fixture copied from live tracked records can drift as issues close out.
+- A broad repair could accidentally weaken production active-claim authorization.
+
+## Estimates
+
+{
+  "elapsed_seconds": 21600,
+  "total_tokens": 80000,
+  "validation_seconds": 3600
+}
+
+## Design
+
+.csdlc/designs/5762/design.md
+
+Digest: ac6d85e2f2ec631133731b7d4f07d0066fc83d19f6b89a7f041cefe20ac3e246
+
+## Diagram
+
+.csdlc/designs/5762/diagram.mmd
+
+Digest: 88fbc0f5ba880e12b0902ae4574bf587f85c5a26d15d3438c842f36e2d1201c1
+
+## Stop Conditions
+
+- typed lifecycle claim collision
+- focused terminal SOR validation tests fail after fixture repair
+- full locked all-target C-SDLC v2 tests fail with an in-scope regression
+- bounded review finds actionable issues
+
+## Handoff
+
+Proceed only after doctor readiness.

--- a/.csdlc/issues/5762/cards/spp.values.json
+++ b/.csdlc/issues/5762/cards/spp.values.json
@@ -1,0 +1,93 @@
+{
+  "identity": {
+    "schema_version": "1.0.0",
+    "template_version": "1.0.0",
+    "issue": 5762,
+    "repository": "danielbaustin/agent-design-language",
+    "title": "[v0.91.8][csdlc-v2][tests] Make terminal repair fixtures independent of live issue claims",
+    "slug": "terminal-sor-validation-fixtures",
+    "version": "v0.91.8",
+    "generation": 0
+  },
+  "status": "ready",
+  "content": {
+    "card_kind": "spp",
+    "values": {
+      "plan_revision": 1,
+      "summary": "Bind #5762, repair the store.rs terminal SOR validation fixture authority setup, validate focused and full C-SDLC v2 lanes, run bounded review, publish a ready PR, and shepherd it green.",
+      "steps": [
+        {
+          "id": "S1",
+          "action": "Initialize and bind #5762 in the issue worktree.",
+          "acceptance_ids": [
+            "AC-1",
+            "AC-2",
+            "AC-3",
+            "AC-4",
+            "AC-5",
+            "AC-6"
+          ],
+          "status": "pending"
+        },
+        {
+          "id": "S2",
+          "action": "Repair the terminal SOR validation fixture authority setup.",
+          "acceptance_ids": [
+            "AC-1",
+            "AC-2",
+            "AC-3",
+            "AC-4",
+            "AC-5",
+            "AC-6"
+          ],
+          "status": "pending"
+        },
+        {
+          "id": "S3",
+          "action": "Run focused tests, full locked all-target C-SDLC v2 tests, strict Clippy, and diff hygiene.",
+          "acceptance_ids": [
+            "AC-2",
+            "AC-3",
+            "AC-4"
+          ],
+          "status": "pending"
+        },
+        {
+          "id": "S4",
+          "action": "Run bounded gpt-5.5 review, fix findings, publish ready PR, and shepherd checks green.",
+          "acceptance_ids": [
+            "AC-5",
+            "AC-6"
+          ],
+          "status": "pending"
+        }
+      ],
+      "affected_areas": [],
+      "invariants": [
+        "Production terminal repair semantics remain unchanged.",
+        "Temporary test authority is deterministic and issue-local.",
+        "Closed_out targets remain claim-free."
+      ],
+      "risks": [
+        "Fixture copied from live tracked records can drift as issues close out.",
+        "A broad repair could accidentally weaken production active-claim authorization."
+      ],
+      "execution_estimates": {
+        "elapsed_seconds": 21600,
+        "total_tokens": 80000,
+        "validation_seconds": 3600
+      },
+      "stop_conditions": [
+        "typed lifecycle claim collision",
+        "focused terminal SOR validation tests fail after fixture repair",
+        "full locked all-target C-SDLC v2 tests fail with an in-scope regression",
+        "bounded review finds actionable issues"
+      ],
+      "replan_triggers": [],
+      "design_ref": ".csdlc/designs/5762/design.md",
+      "design_digest": "ac6d85e2f2ec631133731b7d4f07d0066fc83d19f6b89a7f041cefe20ac3e246",
+      "diagram_ref": ".csdlc/designs/5762/diagram.mmd",
+      "diagram_digest": "88fbc0f5ba880e12b0902ae4574bf587f85c5a26d15d3438c842f36e2d1201c1"
+    }
+  }
+}

--- a/.csdlc/issues/5762/cards/srp.md
+++ b/.csdlc/issues/5762/cards/srp.md
@@ -1,0 +1,41 @@
+# Structured Review Prompt
+
+Template: 1.0.0
+
+Issue: 5762
+
+Repository: danielbaustin/agent-design-language
+
+Card: srp
+
+Status: pre_phase
+
+## Scope
+
+csdlc-v2/src/store.rs test fixture repair and #5762 issue-local lifecycle/evidence
+
+## Prompts
+
+- Verify the terminal SOR validation repair tests synthesize deterministic authority rather than depending on #5613 active-claim truth.
+- Verify production terminal SOR validation repair semantics are unchanged.
+- Verify focused/full tests and strict Clippy evidence match the requested scope.
+
+## Findings
+
+[]
+
+## Dispositions
+
+Every actionable finding requires a terminal disposition.
+
+## Residual Risk
+
+- none
+
+## Review Result
+
+Revision: None
+
+Reviewer: None
+
+Result: pre_review

--- a/.csdlc/issues/5762/cards/srp.values.json
+++ b/.csdlc/issues/5762/cards/srp.values.json
@@ -1,0 +1,29 @@
+{
+  "identity": {
+    "schema_version": "1.0.0",
+    "template_version": "1.0.0",
+    "issue": 5762,
+    "repository": "danielbaustin/agent-design-language",
+    "title": "[v0.91.8][csdlc-v2][tests] Make terminal repair fixtures independent of live issue claims",
+    "slug": "terminal-sor-validation-fixtures",
+    "version": "v0.91.8",
+    "generation": 0
+  },
+  "status": "pre_phase",
+  "content": {
+    "card_kind": "srp",
+    "values": {
+      "review_scope": "csdlc-v2/src/store.rs test fixture repair and #5762 issue-local lifecycle/evidence",
+      "review_revision": null,
+      "reviewer": null,
+      "review_prompts": [
+        "Verify the terminal SOR validation repair tests synthesize deterministic authority rather than depending on #5613 active-claim truth.",
+        "Verify production terminal SOR validation repair semantics are unchanged.",
+        "Verify focused/full tests and strict Clippy evidence match the requested scope."
+      ],
+      "findings": [],
+      "residual_risk": [],
+      "review_result": "pre_review"
+    }
+  }
+}

--- a/.csdlc/issues/5762/cards/stp.md
+++ b/.csdlc/issues/5762/cards/stp.md
@@ -1,0 +1,48 @@
+# Structured Task Prompt
+
+Template: 1.0.0
+
+Issue: 5762
+
+Repository: danielbaustin/agent-design-language
+
+Card: stp
+
+Status: ready
+
+## Task
+
+Repair only the terminal SOR validation fixture authority setup and any directly necessary issue-local records.
+
+## Deliverables
+
+- deterministic temporary repair authority in store.rs tests
+- three focused terminal SOR validation repair tests passing together
+- full locked all-target csdlc-v2 tests passing
+- strict Clippy and diff hygiene evidence
+- ready PR closing #5762
+
+## Acceptance
+
+1. AC-1: No terminal SOR validation repair test borrows active-claim truth from #5613 or another mutable tracked issue projection.
+2. AC-2: The three terminal SOR validation repair tests pass together.
+3. AC-3: The full locked all-target C-SDLC v2 test suite passes.
+4. AC-4: Strict Clippy and git diff hygiene pass.
+5. AC-5: A bounded gpt-5.5 review finds no actionable issue before publication.
+6. AC-6: The PR body includes Closes #5762.
+
+## Dependencies
+
+- current origin/main at 57d115741f32b945217ee3cb14188b41ebde9b3f
+
+## Inputs
+
+- GitHub issue #5762
+- csdlc-v2/src/store.rs
+
+## Non Goals
+
+- production lifecycle semantic change
+- terminal repair control-plane redesign
+- closeout blocking
+- work outside the issue worktree

--- a/.csdlc/issues/5762/cards/stp.values.json
+++ b/.csdlc/issues/5762/cards/stp.values.json
@@ -1,0 +1,47 @@
+{
+  "identity": {
+    "schema_version": "1.0.0",
+    "template_version": "1.0.0",
+    "issue": 5762,
+    "repository": "danielbaustin/agent-design-language",
+    "title": "[v0.91.8][csdlc-v2][tests] Make terminal repair fixtures independent of live issue claims",
+    "slug": "terminal-sor-validation-fixtures",
+    "version": "v0.91.8",
+    "generation": 0
+  },
+  "status": "ready",
+  "content": {
+    "card_kind": "stp",
+    "values": {
+      "task_boundary": "Repair only the terminal SOR validation fixture authority setup and any directly necessary issue-local records.",
+      "deliverables": [
+        "deterministic temporary repair authority in store.rs tests",
+        "three focused terminal SOR validation repair tests passing together",
+        "full locked all-target csdlc-v2 tests passing",
+        "strict Clippy and diff hygiene evidence",
+        "ready PR closing #5762"
+      ],
+      "acceptance_criteria": [
+        "AC-1: No terminal SOR validation repair test borrows active-claim truth from #5613 or another mutable tracked issue projection.",
+        "AC-2: The three terminal SOR validation repair tests pass together.",
+        "AC-3: The full locked all-target C-SDLC v2 test suite passes.",
+        "AC-4: Strict Clippy and git diff hygiene pass.",
+        "AC-5: A bounded gpt-5.5 review finds no actionable issue before publication.",
+        "AC-6: The PR body includes Closes #5762."
+      ],
+      "dependencies": [
+        "current origin/main at 57d115741f32b945217ee3cb14188b41ebde9b3f"
+      ],
+      "repo_inputs": [
+        "GitHub issue #5762",
+        "csdlc-v2/src/store.rs"
+      ],
+      "non_goals": [
+        "production lifecycle semantic change",
+        "terminal repair control-plane redesign",
+        "closeout blocking",
+        "work outside the issue worktree"
+      ]
+    }
+  }
+}

--- a/.csdlc/issues/5762/cards/vpp.md
+++ b/.csdlc/issues/5762/cards/vpp.md
@@ -1,0 +1,129 @@
+# Validation Planning Prompt
+
+Template: 1.0.0
+
+Issue: 5762
+
+Repository: danielbaustin/agent-design-language
+
+Card: vpp
+
+Status: ready
+
+## Summary
+
+Execute the smallest proving validation DAG.
+
+## Lane Inputs
+
+Design: .csdlc/designs/5762/design.md
+
+Diagram: .csdlc/designs/5762/diagram.mmd
+
+## Selected Lanes
+
+[
+  {
+    "lane": "focused-terminal-sor-validation",
+    "proof_role": "Runs the three terminal SOR validation repair tests together.",
+    "acceptance_ids": [
+      "AC-1",
+      "AC-2"
+    ],
+    "deterministic": true,
+    "resource_profile": "small",
+    "budget_seconds": 240,
+    "budget_tokens": 1000,
+    "argv": [
+      "cargo",
+      "test",
+      "--locked",
+      "--manifest-path",
+      "csdlc-v2/Cargo.toml",
+      "--test",
+      "store",
+      "terminal_sor_validation_repair"
+    ],
+    "parallel_group": "local",
+    "defer_reason": null
+  },
+  {
+    "lane": "csdlc-v2-all-target-tests",
+    "proof_role": "Full locked all-target C-SDLC v2 regression suite.",
+    "acceptance_ids": [
+      "AC-1",
+      "AC-2",
+      "AC-3",
+      "AC-4",
+      "AC-5",
+      "AC-6"
+    ],
+    "deterministic": true,
+    "resource_profile": "medium",
+    "budget_seconds": 900,
+    "budget_tokens": 1000,
+    "argv": [
+      "cargo",
+      "test",
+      "--locked",
+      "--manifest-path",
+      "csdlc-v2/Cargo.toml",
+      "--all-targets"
+    ],
+    "parallel_group": "local",
+    "defer_reason": null
+  },
+  {
+    "lane": "strict-clippy",
+    "proof_role": "Strict lint proof for the C-SDLC v2 touched surface.",
+    "acceptance_ids": [
+      "AC-1",
+      "AC-2",
+      "AC-3",
+      "AC-4",
+      "AC-5",
+      "AC-6"
+    ],
+    "deterministic": true,
+    "resource_profile": "medium",
+    "budget_seconds": 900,
+    "budget_tokens": 1000,
+    "argv": [
+      "cargo",
+      "clippy",
+      "--locked",
+      "--manifest-path",
+      "csdlc-v2/Cargo.toml",
+      "--all-targets",
+      "--",
+      "-D",
+      "warnings"
+    ],
+    "parallel_group": "local",
+    "defer_reason": null
+  }
+]
+
+## Parallelization
+
+Only declared parallel groups may overlap.
+
+## Budgets
+
+Seconds: 3600
+
+Tokens: 25000
+
+## Commands
+
+- `cargo test --locked --manifest-path csdlc-v2/Cargo.toml --test store terminal_sor_validation_repair`
+- `cargo test --locked --manifest-path csdlc-v2/Cargo.toml --all-targets`
+- `cargo clippy --locked --manifest-path csdlc-v2/Cargo.toml --all-targets -- -D warnings`
+
+## Failure Semantics
+
+Fail closed, preserve artifacts, and report the typed blocker without widening scope.
+
+## Handoff
+
+Retain typed evidence before convergence.

--- a/.csdlc/issues/5762/cards/vpp.values.json
+++ b/.csdlc/issues/5762/cards/vpp.values.json
@@ -1,0 +1,107 @@
+{
+  "identity": {
+    "schema_version": "1.0.0",
+    "template_version": "1.0.0",
+    "issue": 5762,
+    "repository": "danielbaustin/agent-design-language",
+    "title": "[v0.91.8][csdlc-v2][tests] Make terminal repair fixtures independent of live issue claims",
+    "slug": "terminal-sor-validation-fixtures",
+    "version": "v0.91.8",
+    "generation": 0
+  },
+  "status": "ready",
+  "content": {
+    "card_kind": "vpp",
+    "values": {
+      "summary": "Execute the smallest proving validation DAG.",
+      "lanes": [
+        {
+          "lane": "focused-terminal-sor-validation",
+          "proof_role": "Runs the three terminal SOR validation repair tests together.",
+          "acceptance_ids": [
+            "AC-1",
+            "AC-2"
+          ],
+          "deterministic": true,
+          "resource_profile": "small",
+          "budget_seconds": 240,
+          "budget_tokens": 1000,
+          "argv": [
+            "cargo",
+            "test",
+            "--locked",
+            "--manifest-path",
+            "csdlc-v2/Cargo.toml",
+            "--test",
+            "store",
+            "terminal_sor_validation_repair"
+          ],
+          "parallel_group": "local",
+          "defer_reason": null
+        },
+        {
+          "lane": "csdlc-v2-all-target-tests",
+          "proof_role": "Full locked all-target C-SDLC v2 regression suite.",
+          "acceptance_ids": [
+            "AC-1",
+            "AC-2",
+            "AC-3",
+            "AC-4",
+            "AC-5",
+            "AC-6"
+          ],
+          "deterministic": true,
+          "resource_profile": "medium",
+          "budget_seconds": 900,
+          "budget_tokens": 1000,
+          "argv": [
+            "cargo",
+            "test",
+            "--locked",
+            "--manifest-path",
+            "csdlc-v2/Cargo.toml",
+            "--all-targets"
+          ],
+          "parallel_group": "local",
+          "defer_reason": null
+        },
+        {
+          "lane": "strict-clippy",
+          "proof_role": "Strict lint proof for the C-SDLC v2 touched surface.",
+          "acceptance_ids": [
+            "AC-1",
+            "AC-2",
+            "AC-3",
+            "AC-4",
+            "AC-5",
+            "AC-6"
+          ],
+          "deterministic": true,
+          "resource_profile": "medium",
+          "budget_seconds": 900,
+          "budget_tokens": 1000,
+          "argv": [
+            "cargo",
+            "clippy",
+            "--locked",
+            "--manifest-path",
+            "csdlc-v2/Cargo.toml",
+            "--all-targets",
+            "--",
+            "-D",
+            "warnings"
+          ],
+          "parallel_group": "local",
+          "defer_reason": null
+        }
+      ],
+      "planned_validation_seconds": 3600,
+      "planned_validation_tokens": 25000,
+      "failure_policy": "Fail closed, preserve artifacts, and report the typed blocker without widening scope.",
+      "design_ref": ".csdlc/designs/5762/design.md",
+      "design_digest": "ac6d85e2f2ec631133731b7d4f07d0066fc83d19f6b89a7f041cefe20ac3e246",
+      "diagram_ref": ".csdlc/designs/5762/diagram.mmd",
+      "diagram_digest": "88fbc0f5ba880e12b0902ae4574bf587f85c5a26d15d3438c842f36e2d1201c1"
+    }
+  }
+}

--- a/.csdlc/issues/5762/index.json
+++ b/.csdlc/issues/5762/index.json
@@ -1,0 +1,106 @@
+{
+  "schema": "csdlc.issue.index.v1",
+  "issue": 5762,
+  "repository": "danielbaustin/agent-design-language",
+  "initialization_digest": "b0163f8dcda50dfb601d5200558056a562b9343f92f1f994c2ddf2b8ff49d298",
+  "phase": "bound",
+  "generation": 0,
+  "digest": "4897cc9cf6f1269c6a3ff8e19dedd9766ea442b0d013e2fc0b1a764988732146",
+  "claim": {
+    "id": "codex-5762-terminal-sor-validation-fixtures",
+    "owner": "codex",
+    "generation": 0,
+    "acquired_unix_seconds": 1785574293,
+    "expires_unix_seconds": 1785660693,
+    "heartbeat_unix_seconds": 1785574293,
+    "branch": "codex/5762-terminal-sor-validation-fixtures",
+    "worktree": ".",
+    "protected_paths": [
+      "csdlc-v2/src/store.rs",
+      ".csdlc/designs/5762",
+      ".csdlc/evidence/5762",
+      ".csdlc/issues/5762",
+      ".csdlc/prepared/issues/5762",
+      ".csdlc/requests/5762"
+    ],
+    "purpose": "Fix terminal SOR validation repair tests to use deterministic temporary authority"
+  },
+  "review_assignment": null,
+  "review": null,
+  "publication": null,
+  "readiness": null,
+  "terminal": null,
+  "migration": null,
+  "design_path": ".csdlc/designs/5762/design.md",
+  "diagram_path": ".csdlc/designs/5762/diagram.mmd",
+  "design_review": {
+    "approved": {
+      "reviewer": "operator",
+      "revision": "ac6d85e2f2ec631133731b7d4f07d0066fc83d19f6b89a7f041cefe20ac3e246"
+    }
+  },
+  "cards": {
+    "sip": {
+      "values_digest": "010eb374f67775348e6ad18e57b02e79159ded9b5f929a85679a1517c6f84fa7",
+      "rendered_digest": "097e446c15b25d89f1790d68a1922c6483c575a4a4938f51cf3caee6f980bd5d",
+      "ast_digest": "a88663cf02b1cbe14be1bde2a15f5533467562faffa5f715490465f16676928c"
+    },
+    "stp": {
+      "values_digest": "904fadb8a8a62399fdf3a675f5130426e7f1e5e677fdbd52dc008fda69a2595d",
+      "rendered_digest": "24093e67736f914405eb2892bf53b88c3257ea5d46e4f91f4d051cc6aac2481e",
+      "ast_digest": "efb2c57cfa82f64c20402ac76d98cafd8fb6da3b724d748bb350c95864b8c3cd"
+    },
+    "spp": {
+      "values_digest": "81bf9f5fc2914aecded1e614a61f011bc1a777f01087e0e1f4c1dac03499461f",
+      "rendered_digest": "71ba0d0ad9ec1aeefc48b13bf89b792d7769b4eb2930b62962e923a63a57c2e2",
+      "ast_digest": "ff845c69cb28cb3ab6254e571a918d1613fd2cdd2700f4ac8d33c2c2f0905f34"
+    },
+    "vpp": {
+      "values_digest": "85d7ca7e1629788d113f31c321db4c6951c24a21c55ec1363494af5073e567d1",
+      "rendered_digest": "2dd98b76879f8b4d19ffeaecbdf0693955202e510d4c67afcb67dab69428550c",
+      "ast_digest": "6e8ce994b9fe4c2863033c05376326dced63d50496b1ebd7fea78d500fdc1f67"
+    },
+    "srp": {
+      "values_digest": "799c4daf81faaa0a9ddba2b8b6019d9f05031d935041759859d4276ab0c85131",
+      "rendered_digest": "ce0494a0edc08e8f4775ef058cd6141ac6a37342a16ab87319461abbcc500e87",
+      "ast_digest": "76b497006503d703af59590d4cd12f659e173bee7633352897d8ed8a01913adb"
+    },
+    "sor": {
+      "values_digest": "a0ef1536f5c56717b54f935f2333b9bed5950ca4d0ecef08df8d16168339d4a8",
+      "rendered_digest": "9df237c5ca3fb93ac4753cbc7e7753537dfdbda48013c0efe6c01c6bd1073d26",
+      "ast_digest": "2addd86a1da5e1d092a0a9e834f5bb2009e0baa1a206815971affdaf1c32c40c"
+    }
+  },
+  "transitions": [
+    {
+      "sequence": 1,
+      "from": "initialized",
+      "to": "ready",
+      "actor": "codex",
+      "reason": "automatic readiness verification"
+    },
+    {
+      "sequence": 2,
+      "from": "ready",
+      "to": "bound",
+      "actor": "codex",
+      "reason": "verified Git worktree binding"
+    }
+  ],
+  "audit": [
+    {
+      "sequence": 1,
+      "generation": 0,
+      "actor": "codex",
+      "reason": "initialize issue record and all six cards",
+      "operation": "bootstrap"
+    },
+    {
+      "sequence": 2,
+      "generation": 0,
+      "actor": "codex",
+      "reason": "bind branch/worktree and activate claim",
+      "operation": "bind"
+    }
+  ]
+}

--- a/.csdlc/requests/5762/bind.json
+++ b/.csdlc/requests/5762/bind.json
@@ -1,0 +1,25 @@
+{
+  "issue": 5762,
+  "base_branch": "main",
+  "branch": "codex/5762-terminal-sor-validation-fixtures",
+  "worktree": ".",
+  "claim": {
+    "id": "codex-5762-terminal-sor-validation-fixtures",
+    "owner": "codex",
+    "generation": 0,
+    "acquired_unix_seconds": 1785574293,
+    "expires_unix_seconds": 1785660693,
+    "heartbeat_unix_seconds": 1785574293,
+    "branch": "codex/5762-terminal-sor-validation-fixtures",
+    "worktree": ".",
+    "protected_paths": [
+      "csdlc-v2/src/store.rs",
+      ".csdlc/designs/5762",
+      ".csdlc/evidence/5762",
+      ".csdlc/issues/5762",
+      ".csdlc/prepared/issues/5762",
+      ".csdlc/requests/5762"
+    ],
+    "purpose": "Fix terminal SOR validation repair tests to use deterministic temporary authority"
+  }
+}

--- a/.csdlc/requests/5762/init.json
+++ b/.csdlc/requests/5762/init.json
@@ -1,0 +1,193 @@
+{
+  "issue": 5762,
+  "repository": "danielbaustin/agent-design-language",
+  "design_path": ".csdlc/designs/5762/design.md",
+  "diagram_path": ".csdlc/designs/5762/diagram.mmd",
+  "design_reviewer": "operator",
+  "design_approved": true,
+  "claim": {
+    "id": "codex-5762-terminal-sor-validation-fixtures",
+    "owner": "codex",
+    "generation": 0,
+    "acquired_unix_seconds": 1785574293,
+    "expires_unix_seconds": 1785660693,
+    "heartbeat_unix_seconds": 1785574293,
+    "branch": "codex/5762-terminal-sor-validation-fixtures",
+    "worktree": ".",
+    "protected_paths": [
+      "csdlc-v2/src/store.rs",
+      ".csdlc/designs/5762",
+      ".csdlc/evidence/5762",
+      ".csdlc/issues/5762",
+      ".csdlc/prepared/issues/5762",
+      ".csdlc/requests/5762"
+    ],
+    "purpose": "Fix terminal SOR validation repair tests to use deterministic temporary authority"
+  },
+  "initial": {
+    "title": "[v0.91.8][csdlc-v2][tests] Make terminal repair fixtures independent of live issue claims",
+    "slug": "terminal-sor-validation-fixtures",
+    "version": "v0.91.8",
+    "goal": "Make the C-SDLC v2 terminal SOR validation repair tests independent of mutable tracked issue active-claim state.",
+    "required_outcome": "The three terminal SOR validation repair tests synthesize deterministic issue-local repair authority in their temporary repository and pass when the terminal target is closed_out and claim-free.",
+    "declared_scope": [
+      "csdlc-v2/src/store.rs test fixture construction",
+      "issue-local lifecycle and evidence for #5762"
+    ],
+    "authority_boundary": [
+      "typed C-SDLC v2 binaries own lifecycle state",
+      "no production lifecycle semantic change",
+      "no dependency on /private/tmp",
+      "no dependency on #5613 retaining an active claim"
+    ],
+    "operator_constraints": [
+      "work only in /Volumes/FastWork/adl-wp-5762",
+      "do not write tracked files on primary main",
+      "publish a ready PR with Closes #5762",
+      "do not block on post-merge typed closeout"
+    ],
+    "task_boundary": "Repair only the terminal SOR validation fixture authority setup and any directly necessary issue-local records.",
+    "deliverables": [
+      "deterministic temporary repair authority in store.rs tests",
+      "three focused terminal SOR validation repair tests passing together",
+      "full locked all-target csdlc-v2 tests passing",
+      "strict Clippy and diff hygiene evidence",
+      "ready PR closing #5762"
+    ],
+    "acceptance_criteria": [
+      "AC-1: No terminal SOR validation repair test borrows active-claim truth from #5613 or another mutable tracked issue projection.",
+      "AC-2: The three terminal SOR validation repair tests pass together.",
+      "AC-3: The full locked all-target C-SDLC v2 test suite passes.",
+      "AC-4: Strict Clippy and git diff hygiene pass.",
+      "AC-5: A bounded gpt-5.5 review finds no actionable issue before publication.",
+      "AC-6: The PR body includes Closes #5762."
+    ],
+    "dependencies": [
+      "current origin/main at 57d115741f32b945217ee3cb14188b41ebde9b3f"
+    ],
+    "repo_inputs": [
+      "GitHub issue #5762",
+      "csdlc-v2/src/store.rs"
+    ],
+    "non_goals": [
+      "production lifecycle semantic change",
+      "terminal repair control-plane redesign",
+      "closeout blocking",
+      "work outside the issue worktree"
+    ],
+    "plan_summary": "Bind #5762, repair the store.rs terminal SOR validation fixture authority setup, validate focused and full C-SDLC v2 lanes, run bounded review, publish a ready PR, and shepherd it green.",
+    "steps": [
+      {
+        "id": "S1",
+        "action": "Initialize and bind #5762 in the issue worktree.",
+        "acceptance_ids": ["AC-1", "AC-2", "AC-3", "AC-4", "AC-5", "AC-6"],
+        "status": "pending"
+      },
+      {
+        "id": "S2",
+        "action": "Repair the terminal SOR validation fixture authority setup.",
+        "acceptance_ids": ["AC-1", "AC-2", "AC-3", "AC-4", "AC-5", "AC-6"],
+        "status": "pending"
+      },
+      {
+        "id": "S3",
+        "action": "Run focused tests, full locked all-target C-SDLC v2 tests, strict Clippy, and diff hygiene.",
+        "acceptance_ids": ["AC-2", "AC-3", "AC-4"],
+        "status": "pending"
+      },
+      {
+        "id": "S4",
+        "action": "Run bounded gpt-5.5 review, fix findings, publish ready PR, and shepherd checks green.",
+        "acceptance_ids": ["AC-5", "AC-6"],
+        "status": "pending"
+      }
+    ],
+    "invariants": [
+      "Production terminal repair semantics remain unchanged.",
+      "Temporary test authority is deterministic and issue-local.",
+      "Closed_out targets remain claim-free."
+    ],
+    "risks": [
+      "Fixture copied from live tracked records can drift as issues close out.",
+      "A broad repair could accidentally weaken production active-claim authorization."
+    ],
+    "planning_profile": "medium",
+    "stop_conditions": [
+      "typed lifecycle claim collision",
+      "focused terminal SOR validation tests fail after fixture repair",
+      "full locked all-target C-SDLC v2 tests fail with an in-scope regression",
+      "bounded review finds actionable issues"
+    ],
+    "validation_lanes": [
+      {
+        "lane": "focused-terminal-sor-validation",
+        "proof_role": "Runs the three terminal SOR validation repair tests together.",
+        "acceptance_ids": ["AC-1", "AC-2"],
+        "deterministic": true,
+        "resource_profile": "small",
+        "budget_seconds": 240,
+        "budget_tokens": 1000,
+        "argv": [
+          "cargo",
+          "test",
+          "--locked",
+          "--manifest-path",
+          "csdlc-v2/Cargo.toml",
+          "--test",
+          "store",
+          "terminal_sor_validation_repair"
+        ],
+        "parallel_group": "local",
+        "defer_reason": null
+      },
+      {
+        "lane": "csdlc-v2-all-target-tests",
+        "proof_role": "Full locked all-target C-SDLC v2 regression suite.",
+        "acceptance_ids": ["AC-1", "AC-2", "AC-3", "AC-4", "AC-5", "AC-6"],
+        "deterministic": true,
+        "resource_profile": "medium",
+        "budget_seconds": 900,
+        "budget_tokens": 1000,
+        "argv": [
+          "cargo",
+          "test",
+          "--locked",
+          "--manifest-path",
+          "csdlc-v2/Cargo.toml",
+          "--all-targets"
+        ],
+        "parallel_group": "local",
+        "defer_reason": null
+      },
+      {
+        "lane": "strict-clippy",
+        "proof_role": "Strict lint proof for the C-SDLC v2 touched surface.",
+        "acceptance_ids": ["AC-1", "AC-2", "AC-3", "AC-4", "AC-5", "AC-6"],
+        "deterministic": true,
+        "resource_profile": "medium",
+        "budget_seconds": 900,
+        "budget_tokens": 1000,
+        "argv": [
+          "cargo",
+          "clippy",
+          "--locked",
+          "--manifest-path",
+          "csdlc-v2/Cargo.toml",
+          "--all-targets",
+          "--",
+          "-D",
+          "warnings"
+        ],
+        "parallel_group": "local",
+        "defer_reason": null
+      }
+    ],
+    "failure_policy": "Fail closed, preserve artifacts, and report the typed blocker without widening scope.",
+    "review_prompts": [
+      "Verify the terminal SOR validation repair tests synthesize deterministic authority rather than depending on #5613 active-claim truth.",
+      "Verify production terminal SOR validation repair semantics are unchanged.",
+      "Verify focused/full tests and strict Clippy evidence match the requested scope."
+    ],
+    "review_scope": "csdlc-v2/src/store.rs test fixture repair and #5762 issue-local lifecycle/evidence"
+  }
+}

--- a/csdlc-v2/src/store.rs
+++ b/csdlc-v2/src/store.rs
@@ -3902,6 +3902,51 @@ mod terminal_design_repair_tests {
         }
     }
 
+    fn basic_initial_input(title: &str) -> InitialCardInput {
+        InitialCardInput {
+            title: title.into(),
+            slug: title.replace(' ', "-"),
+            version: "v0.91.8".into(),
+            goal: "test".into(),
+            required_outcome: "test".into(),
+            declared_scope: vec!["test".into()],
+            authority_boundary: vec!["test".into()],
+            operator_constraints: vec!["none".into()],
+            task_boundary: "test".into(),
+            deliverables: vec!["test".into()],
+            acceptance_criteria: vec!["AC-1: test".into()],
+            dependencies: vec!["none".into()],
+            repo_inputs: vec!["test".into()],
+            non_goals: vec!["test".into()],
+            plan_summary: "test".into(),
+            steps: vec![crate::cards::PlanStep {
+                id: "S1".into(),
+                action: "test".into(),
+                acceptance_ids: vec!["AC-1".into()],
+                status: StepStatus::Pending,
+            }],
+            invariants: vec!["test".into()],
+            risks: vec!["test".into()],
+            planning_profile: crate::cards::PlanningProfile::Small,
+            stop_conditions: vec!["test".into()],
+            validation_lanes: vec![crate::cards::ValidationLane {
+                lane: "test".into(),
+                proof_role: "test".into(),
+                acceptance_ids: vec!["AC-1".into()],
+                deterministic: true,
+                resource_profile: crate::cards::ResourceProfile::Small,
+                budget_seconds: 1,
+                budget_tokens: 1,
+                argv: vec!["test".into()],
+                parallel_group: "test".into(),
+                defer_reason: None,
+            }],
+            failure_policy: "test".into(),
+            review_prompts: vec!["test".into()],
+            review_scope: "test".into(),
+        }
+    }
+
     fn terminal_validation_fixture() -> (
         tempfile::TempDir,
         Store,
@@ -3910,6 +3955,9 @@ mod terminal_design_repair_tests {
         TerminalReceipt,
         ValidationResult,
     ) {
+        const AUTHORITY_ISSUE: u64 = 9_762;
+        const TARGET_ISSUE: u64 = 5358;
+
         let source_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..");
         let source_store = Store::new(&source_root);
         let temp = tempfile::tempdir().expect("temp root");
@@ -3919,36 +3967,68 @@ mod terminal_design_repair_tests {
             .status()
             .expect("git init");
         assert!(status.success());
-        for issue in [5358, 5613] {
-            copy_tree(
-                &source_store.issue_dir(issue),
-                &temp.path().join(".csdlc/issues").join(issue.to_string()),
-            );
-            let record = source_store.load_record(issue).expect("source record");
-            for path in [&record.design_path, &record.diagram_path] {
-                let destination = temp.path().join(path);
-                fs::create_dir_all(destination.parent().expect("authored parent"))
-                    .expect("create authored parent");
-                fs::copy(source_root.join(path), destination).expect("copy authored file");
-            }
+        copy_tree(
+            &source_store.issue_dir(TARGET_ISSUE),
+            &temp
+                .path()
+                .join(".csdlc/issues")
+                .join(TARGET_ISSUE.to_string()),
+        );
+        let source_target = source_store
+            .load_record(TARGET_ISSUE)
+            .expect("source target");
+        for path in [&source_target.design_path, &source_target.diagram_path] {
+            let destination = temp.path().join(path);
+            fs::create_dir_all(destination.parent().expect("authored parent"))
+                .expect("create authored parent");
+            fs::copy(source_root.join(path), destination).expect("copy authored file");
         }
 
         let store = Store::new(temp.path());
-        let mut authority = store.load_record(5613).expect("authority");
-        authority
-            .claim
-            .as_mut()
-            .expect("authority claim")
-            .expires_unix_seconds = u64::MAX;
-        let authority_cards = store.load_cards(5613).expect("authority cards");
-        hydrate_projections(&mut authority, &authority_cards).expect("authority projections");
-        authority.digest = record_digest(&authority).expect("authority digest");
-        store
-            .commit(5613, &authority, &authority_cards, false)
-            .expect("authority commit");
+        let authority_design = ".csdlc/prepared/issues/9762/design.md";
+        let authority_diagram = ".csdlc/prepared/issues/9762/diagram.mmd";
+        fs::create_dir_all(
+            temp.path()
+                .join(authority_design)
+                .parent()
+                .expect("authority design parent"),
+        )
+        .expect("create authority authored parent");
+        fs::write(temp.path().join(authority_design), "# Test Repair Authority\n")
+            .expect("write authority design");
+        fs::write(
+            temp.path().join(authority_diagram),
+            "flowchart LR\n  A-->B\n",
+        )
+        .expect("write authority diagram");
+        let authority = bootstrap_issue(
+            &store,
+            BootstrapRequest {
+                issue: AUTHORITY_ISSUE,
+                repository: "danielbaustin/agent-design-language".into(),
+                design_path: authority_design.into(),
+                diagram_path: authority_diagram.into(),
+                design_reviewer: "test".into(),
+                design_approved: true,
+                claim: Claim {
+                    id: "test-terminal-sor-validation-repair".into(),
+                    owner: "test".into(),
+                    generation: 0,
+                    acquired_unix_seconds: 1,
+                    expires_unix_seconds: u64::MAX,
+                    heartbeat_unix_seconds: 1,
+                    branch: "test-authority".into(),
+                    worktree: ".".into(),
+                    protected_paths: vec![format!(".csdlc/issues/{TARGET_ISSUE}")],
+                    purpose: "repair terminal SOR validation fixture".into(),
+                },
+                initial: basic_initial_input("test repair authority"),
+            },
+        )
+        .expect("bootstrap synthetic authority");
 
-        let target = store.load_record(5358).expect("target");
-        let cards = store.load_cards(5358).expect("target cards");
+        let target = store.load_record(TARGET_ISSUE).expect("target");
+        let cards = store.load_cards(TARGET_ISSUE).expect("target cards");
         let mut authored_artifacts = BTreeMap::new();
         for path in [&target.design_path, &target.diagram_path] {
             authored_artifacts.insert(
@@ -4123,48 +4203,7 @@ mod terminal_design_repair_tests {
             "design",
             "docs/diagram.mmd",
             "diagram",
-            InitialCardInput {
-                title: "test".into(),
-                slug: "test".into(),
-                version: "v0.91.7".into(),
-                goal: "test".into(),
-                required_outcome: "test".into(),
-                declared_scope: vec!["test".into()],
-                authority_boundary: vec!["test".into()],
-                operator_constraints: vec!["none".into()],
-                task_boundary: "test".into(),
-                deliverables: vec!["test".into()],
-                acceptance_criteria: vec!["test".into()],
-                dependencies: vec!["test".into()],
-                repo_inputs: vec!["test".into()],
-                non_goals: vec!["test".into()],
-                plan_summary: "test".into(),
-                steps: vec![crate::cards::PlanStep {
-                    id: "S1".into(),
-                    action: "test".into(),
-                    acceptance_ids: vec!["AC-1".into()],
-                    status: StepStatus::Pending,
-                }],
-                invariants: vec!["test".into()],
-                risks: vec!["test".into()],
-                planning_profile: crate::cards::PlanningProfile::Small,
-                stop_conditions: vec!["test".into()],
-                validation_lanes: vec![crate::cards::ValidationLane {
-                    lane: "test".into(),
-                    proof_role: "test".into(),
-                    acceptance_ids: vec!["AC-1".into()],
-                    deterministic: true,
-                    resource_profile: crate::cards::ResourceProfile::Small,
-                    budget_seconds: 1,
-                    budget_tokens: 1,
-                    argv: vec!["test".into()],
-                    parallel_group: "test".into(),
-                    defer_reason: None,
-                }],
-                failure_policy: "test".into(),
-                review_prompts: vec!["test".into()],
-                review_scope: "test".into(),
-            },
+            basic_initial_input("test"),
         )
         .expect("cards");
         let CardContent::Sor(sor) = &mut cards.get_mut(&CardKind::Sor).unwrap().content else {

--- a/csdlc-v2/src/store.rs
+++ b/csdlc-v2/src/store.rs
@@ -3994,8 +3994,11 @@ mod terminal_design_repair_tests {
                 .expect("authority design parent"),
         )
         .expect("create authority authored parent");
-        fs::write(temp.path().join(authority_design), "# Test Repair Authority\n")
-            .expect("write authority design");
+        fs::write(
+            temp.path().join(authority_design),
+            "# Test Repair Authority\n",
+        )
+        .expect("write authority design");
         fs::write(
             temp.path().join(authority_diagram),
             "flowchart LR\n  A-->B\n",


### PR DESCRIPTION
## Summary
- replace the mutable #5613 active-claim dependency with deterministic temporary repair authority
- preserve terminal receipt, authority scope, stale digest, locking, and rollback semantics
- keep production behavior unchanged

## Validation
- focused terminal SOR repair tests: 4/4 pass
- full locked C-SDLC v2 all-target suite: pass
- strict Clippy: pass
- git diff --check: pass
- exact GPT-5.5 review at 48e22ddaf: 0 blockers

Closes #5762