### PR TITLE
[v0.91.8][csdlc-v2][review] Allow implemented SPP review remediation

### DIFF
--- a/csdlc-v2/src/store.rs
+++ b/csdlc-v2/src/store.rs
@@ -3434,6 +3434,18 @@ fn authorize_card_operation(
             CardKind::Spp,
             SemanticOperation::UpdatePlanStep { .. },
         ) | (
+            LifecyclePhase::Implemented,
+            CardKind::Spp,
+            SemanticOperation::ReplacePlanSteps { .. },
+        ) | (
+            LifecyclePhase::Implemented,
+            CardKind::Spp,
+            SemanticOperation::ReplacePlanningCollection {
+                field: crate::cards::PlanningCollectionField::Invariants
+                    | crate::cards::PlanningCollectionField::StopConditions,
+                ..
+            },
+        ) | (
             LifecyclePhase::Bound | LifecyclePhase::Implemented,
             CardKind::Vpp,
             SemanticOperation::ReplaceValidationLanes { .. },
@@ -3497,6 +3509,78 @@ fn authorize_card_operation(
             ErrorCode::InvalidTransition,
             format!("{card} mutation is not allowed during {phase}"),
         ))
+    }
+}
+
+#[cfg(test)]
+mod edit_authorization_tests {
+    use super::*;
+
+    fn replacement_steps() -> Vec<crate::cards::PlanStep> {
+        vec![crate::cards::PlanStep {
+            id: "review-fix".into(),
+            action: "correct bounded review finding".into(),
+            acceptance_ids: vec!["AC-1".into()],
+            status: StepStatus::Pending,
+        }]
+    }
+
+    #[test]
+    fn implemented_spp_review_remediation_authorizes_only_bounded_replacements() {
+        for operation in [
+            SemanticOperation::ReplacePlanSteps {
+                steps: replacement_steps(),
+            },
+            SemanticOperation::ReplacePlanningCollection {
+                field: crate::cards::PlanningCollectionField::Invariants,
+                values: vec!["invariant".into()],
+            },
+            SemanticOperation::ReplacePlanningCollection {
+                field: crate::cards::PlanningCollectionField::StopConditions,
+                values: vec!["stop".into()],
+            },
+        ] {
+            authorize_card_operation(LifecyclePhase::Implemented, CardKind::Spp, &operation)
+                .expect("implemented bounded SPP remediation");
+        }
+
+        let error = authorize_card_operation(
+            LifecyclePhase::Implemented,
+            CardKind::Spp,
+            &SemanticOperation::ReplacePlanningCollection {
+                field: crate::cards::PlanningCollectionField::Risks,
+                values: vec!["risk".into()],
+            },
+        )
+        .expect_err("unbounded SPP collection remains rejected");
+        assert_eq!(error.code, ErrorCode::InvalidTransition);
+    }
+
+    #[test]
+    fn post_review_spp_replacements_remain_rejected() {
+        for phase in [
+            LifecyclePhase::Reviewed,
+            LifecyclePhase::Published,
+            LifecyclePhase::MergeReady,
+        ] {
+            for operation in [
+                SemanticOperation::ReplacePlanSteps {
+                    steps: replacement_steps(),
+                },
+                SemanticOperation::ReplacePlanningCollection {
+                    field: crate::cards::PlanningCollectionField::Invariants,
+                    values: vec!["late invariant".into()],
+                },
+                SemanticOperation::ReplacePlanningCollection {
+                    field: crate::cards::PlanningCollectionField::StopConditions,
+                    values: vec!["late stop".into()],
+                },
+            ] {
+                let error = authorize_card_operation(phase, CardKind::Spp, &operation)
+                    .expect_err("late SPP replacement remains rejected");
+                assert_eq!(error.code, ErrorCode::InvalidTransition);
+            }
+        }
     }
 }
 

--- a/csdlc-v2/tests/gate2.rs
+++ b/csdlc-v2/tests/gate2.rs
@@ -3,8 +3,9 @@ use std::fs;
 use csdlc_v2::doctor::DoctorStatus;
 use csdlc_v2::{
     amend_claim_scope, closeout_issue, diagnose, edit_issue, AmendClaimScopeRequest,
-    BootstrapRequest, CardKind, Claim, EditRequest, ErrorCode, PlanningCollectionField,
-    ReacquireClaimRequest, SemanticOperation, Store, TerminalDisposition, TerminalObservation,
+    BootstrapRequest, CardKind, Claim, EditRequest, ErrorCode, LifecyclePhase,
+    PlanningCollectionField, ReacquireClaimRequest, SemanticOperation, Store, TerminalDisposition,
+    TerminalObservation,
 };
 use tempfile::TempDir;
 
@@ -257,6 +258,56 @@ fn cli_edit_current(
         String::from_utf8_lossy(&output.stderr)
     );
     store.load_record(record.issue).expect("CLI-updated record")
+}
+
+fn implemented_fixture() -> (TempDir, Store, csdlc_v2::IssueRecord) {
+    let (temp, store, mut record) = bind_fixture();
+    record = edit_current(
+        &store,
+        &record,
+        CardKind::Sor,
+        SemanticOperation::RecordExecution {
+            summary: "implemented".into(),
+            changes: vec!["csdlc-v2".into()],
+            artifacts: vec!["focused tests".into()],
+        },
+    );
+    record = edit_current(
+        &store,
+        &record,
+        CardKind::Sip,
+        SemanticOperation::AdvancePhase {
+            phase: LifecyclePhase::Implemented,
+        },
+    );
+    assert_eq!(record.phase, LifecyclePhase::Implemented);
+    (temp, store, record)
+}
+
+fn spp_replacement_request(
+    record: &csdlc_v2::IssueRecord,
+    operation: SemanticOperation,
+) -> EditRequest {
+    EditRequest {
+        issue: 42,
+        card: CardKind::Spp,
+        expected_generation: record.generation,
+        expected_digest: record.digest.clone(),
+        claim_id: "claim-1".into(),
+        actor: "agent".into(),
+        reason: "bounded implemented review remediation".into(),
+        operation,
+        fail_after_backup: false,
+    }
+}
+
+fn replacement_steps() -> Vec<csdlc_v2::cards::PlanStep> {
+    vec![csdlc_v2::cards::PlanStep {
+        id: "correct-review-finding".into(),
+        action: "correct the SPP contradiction found during exact review".into(),
+        acceptance_ids: vec!["AC-1".into(), "AC-2".into()],
+        status: csdlc_v2::cards::StepStatus::Pending,
+    }]
 }
 
 #[test]
@@ -3025,6 +3076,134 @@ fn planning_replacements_are_bound_only_and_cannot_smuggle_progress() {
         },
     )
     .expect_err("post-implementation replan must fail");
+    assert_eq!(error.code, ErrorCode::InvalidTransition);
+}
+
+#[test]
+fn implemented_spp_review_remediation_allows_guarded_plan_and_stop_condition_corrections() {
+    let (_temp, store, mut record) = implemented_fixture();
+
+    record = edit_issue(
+        &store,
+        spp_replacement_request(
+            &record,
+            SemanticOperation::ReplacePlanSteps {
+                steps: replacement_steps(),
+            },
+        ),
+    )
+    .expect("implemented plan-step correction");
+    let cards = store.load_cards(42).expect("plan-step cards");
+    let csdlc_v2::cards::CardContent::Spp(spp) = &cards[&CardKind::Spp].content else {
+        panic!("SPP");
+    };
+    assert_eq!(spp.steps, replacement_steps());
+    assert!(record
+        .audit
+        .last()
+        .expect("audit")
+        .operation
+        .contains("replace_plan_steps"));
+
+    record = edit_issue(
+        &store,
+        spp_replacement_request(
+            &record,
+            SemanticOperation::ReplacePlanningCollection {
+                field: PlanningCollectionField::Invariants,
+                values: vec!["review-remediated invariant".into()],
+            },
+        ),
+    )
+    .expect("implemented invariant correction");
+    record = edit_issue(
+        &store,
+        spp_replacement_request(
+            &record,
+            SemanticOperation::ReplacePlanningCollection {
+                field: PlanningCollectionField::StopConditions,
+                values: vec!["review-remediated stop condition".into()],
+            },
+        ),
+    )
+    .expect("implemented stop-condition correction");
+
+    let cards = store.load_cards(42).expect("corrected cards");
+    let csdlc_v2::cards::CardContent::Spp(spp) = &cards[&CardKind::Spp].content else {
+        panic!("SPP");
+    };
+    assert_eq!(spp.invariants, vec!["review-remediated invariant"]);
+    assert_eq!(
+        spp.stop_conditions,
+        vec!["review-remediated stop condition"]
+    );
+    assert_eq!(record.phase, LifecyclePhase::Implemented);
+    assert_eq!(
+        record.claim.as_ref().expect("claim").generation,
+        record.generation
+    );
+    assert!(record
+        .audit
+        .iter()
+        .any(|event| event.operation.contains("replace_planning_collection")));
+}
+
+#[test]
+fn implemented_spp_replacements_remain_generation_digest_and_claim_guarded() {
+    let (_temp, store, record) = implemented_fixture();
+    let before_record = store.load_record(42).expect("record snapshot");
+    let before_cards = store.load_cards(42).expect("card snapshot");
+
+    let mut stale_generation = spp_replacement_request(
+        &record,
+        SemanticOperation::ReplacePlanSteps {
+            steps: replacement_steps(),
+        },
+    );
+    stale_generation.expected_generation += 1;
+    let error = edit_issue(&store, stale_generation).expect_err("stale generation");
+    assert_eq!(error.code, ErrorCode::StaleGeneration);
+
+    let mut stale_digest = spp_replacement_request(
+        &record,
+        SemanticOperation::ReplacePlanningCollection {
+            field: PlanningCollectionField::Invariants,
+            values: vec!["guarded".into()],
+        },
+    );
+    stale_digest.expected_digest = "stale".into();
+    let error = edit_issue(&store, stale_digest).expect_err("stale digest");
+    assert_eq!(error.code, ErrorCode::StaleDigest);
+
+    let mut stale_claim = spp_replacement_request(
+        &record,
+        SemanticOperation::ReplacePlanningCollection {
+            field: PlanningCollectionField::StopConditions,
+            values: vec!["guarded".into()],
+        },
+    );
+    stale_claim.claim_id = "not-the-claim".into();
+    let error = edit_issue(&store, stale_claim).expect_err("stale claim");
+    assert_eq!(error.code, ErrorCode::MissingClaim);
+
+    assert_eq!(store.load_record(42).expect("record"), before_record);
+    assert_eq!(store.load_cards(42).expect("cards"), before_cards);
+}
+
+#[test]
+fn implemented_spp_review_remediation_rejects_unbounded_collections() {
+    let (_temp, store, record) = implemented_fixture();
+    let error = edit_issue(
+        &store,
+        spp_replacement_request(
+            &record,
+            SemanticOperation::ReplacePlanningCollection {
+                field: PlanningCollectionField::Risks,
+                values: vec!["not bounded review remediation".into()],
+            },
+        ),
+    )
+    .expect_err("implemented risks replacement remains rejected");
     assert_eq!(error.code, ErrorCode::InvalidTransition);
 }
 


### PR DESCRIPTION
Closes #5770

Allows typed, claim-guarded SPP review remediation during the implemented phase for plan steps, invariants, and stop conditions only. Reviewed, published, and merge-ready phases remain fail-closed.

Validation:
- focused authorization tests pass
- Gate 2 passes
- format and strict Clippy pass
- exact GPT-5.5 review at ecfe785f8 found no blockers