### PR TITLE
[v0.91.8][csdlc-v2] Validate derived terminal publication lineage

### DIFF
--- a/csdlc-v2/src/finish.rs
+++ b/csdlc-v2/src/finish.rs
@@ -241,7 +241,13 @@ fn validate_publication_head_lineage_in_repo(
     }
     let changed = git::run(
         root,
-        &["diff", "--name-only", published_head, expected_head],
+        &[
+            "diff",
+            "--name-only",
+            "--no-renames",
+            published_head,
+            expected_head,
+        ],
     )?;
     if changed
         .stdout

--- a/csdlc-v2/src/finish.rs
+++ b/csdlc-v2/src/finish.rs
@@ -179,12 +179,6 @@ pub fn validate_publication_head_in_repo(
     let Some(expected_head) = request.expected_head_sha.as_deref() else {
         return Ok(());
     };
-    let publication = record.publication.as_ref().ok_or_else(|| {
-        V2Error::new(
-            ErrorCode::ReconciliationRequired,
-            "publication evidence is missing",
-        )
-    })?;
     if git::run(root, &["rev-parse", "HEAD"])?.stdout != expected_head
         || !git::run(
             root,
@@ -203,6 +197,26 @@ pub fn validate_publication_head_in_repo(
         return Err(V2Error::new(
             ErrorCode::ReconciliationRequired,
             "finish requires the exact clean local head",
+        ));
+    }
+    validate_publication_head_lineage_in_repo(root, record, expected_head)
+}
+
+fn validate_publication_head_lineage_in_repo(
+    root: &Path,
+    record: &IssueRecord,
+    expected_head: &str,
+) -> Result<()> {
+    let publication = record.publication.as_ref().ok_or_else(|| {
+        V2Error::new(
+            ErrorCode::ReconciliationRequired,
+            "publication evidence is missing",
+        )
+    })?;
+    if expected_head.len() != 40 || !expected_head.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(V2Error::new(
+            ErrorCode::ReconciliationRequired,
+            "publication head cannot prove an exact commit identity",
         ));
     }
     let published_head = parse_clean_git_revision(&publication.revision).ok_or_else(|| {
@@ -274,17 +288,21 @@ pub fn validate_publication_head_in_repo(
             "review revision cannot prove exact clean commit authority",
         )
     })?;
-    if !git::substantive_scope_matches_commit(root, reviewed_commit, &review.scope)?
-        || git::run(
-            root,
-            &[
-                "merge-base",
-                "--is-ancestor",
-                reviewed_commit,
-                expected_head,
-            ],
-        )
-        .is_err()
+    if !git::substantive_scope_matches_revisions(
+        root,
+        reviewed_commit,
+        expected_head,
+        &review.scope,
+    )? || git::run(
+        root,
+        &[
+            "merge-base",
+            "--is-ancestor",
+            reviewed_commit,
+            expected_head,
+        ],
+    )
+    .is_err()
     {
         return Err(V2Error::new(
             ErrorCode::ReconciliationRequired,
@@ -529,29 +547,51 @@ pub fn envelope_matches_record(
     record: &IssueRecord,
 ) -> Result<bool> {
     validate_envelope(envelope)?;
-    Ok(envelope.issue == record.issue
-        && envelope.repository == record.repository
-        && envelope.initialization_digest == record.initialization_digest
-        && envelope.canonical_generation == record.generation
-        && envelope.canonical_digest == record.digest
+    Ok(envelope_matches_record_identity(envelope, record)
         && match envelope.pull_request {
-            Some(pull_request) => record.publication.as_ref().is_some_and(|publication| {
-                publication.pull_request == pull_request
-                    && envelope
-                        .head_sha
-                        .as_deref()
-                        .is_some_and(|head| publication.revision == clean_commit_revision(head))
+            Some(_) => record.publication.as_ref().is_some_and(|publication| {
+                envelope
+                    .head_sha
+                    .as_deref()
+                    .is_some_and(|head| publication.revision == clean_commit_revision(head))
             }),
             None => true,
         })
 }
 
+fn envelope_matches_record_identity(
+    envelope: &DerivedTerminalEnvelope,
+    record: &IssueRecord,
+) -> bool {
+    envelope.issue == record.issue
+        && envelope.repository == record.repository
+        && envelope.initialization_digest == record.initialization_digest
+        && envelope.canonical_generation == record.generation
+        && envelope.canonical_digest == record.digest
+        && match envelope.pull_request {
+            Some(pull_request) => record
+                .publication
+                .as_ref()
+                .is_some_and(|publication| publication.pull_request == pull_request),
+            None => true,
+        }
+}
+
 pub fn envelope_releases_claim(
+    root: &Path,
     envelope: &DerivedTerminalEnvelope,
     record: &IssueRecord,
     now_unix_seconds: u64,
 ) -> Result<bool> {
-    if !envelope_matches_record(envelope, record)? {
+    validate_envelope(envelope)?;
+    if !envelope_matches_record_identity(envelope, record) {
+        return Ok(false);
+    }
+    if envelope.pull_request.is_some()
+        && !envelope.head_sha.as_deref().is_some_and(|head| {
+            validate_publication_head_lineage_in_repo(root, record, head).is_ok()
+        })
+    {
         return Ok(false);
     }
     Ok(envelope.disposition == FinishDisposition::Merged

--- a/csdlc-v2/src/git.rs
+++ b/csdlc-v2/src/git.rs
@@ -228,6 +228,47 @@ pub fn substantive_scope_matches_commit(
     Ok(output.stdout.is_empty())
 }
 
+pub fn substantive_scope_matches_revisions(
+    root: &Path,
+    reviewed_commit: &str,
+    candidate_commit: &str,
+    scope: &[String],
+) -> Result<bool> {
+    if scope.is_empty()
+        || [reviewed_commit, candidate_commit].iter().any(|commit| {
+            commit.len() != 40 || !commit.bytes().all(|byte| byte.is_ascii_hexdigit())
+        })
+    {
+        return Err(V2Error::new(
+            ErrorCode::InvalidInput,
+            "two exact commits and a non-empty review scope are required",
+        ));
+    }
+    let status = Command::new("git")
+        .current_dir(root)
+        .args([
+            "diff",
+            "--quiet",
+            "--no-ext-diff",
+            reviewed_commit,
+            candidate_commit,
+            "--",
+        ])
+        .args(scoped_pathspec(scope))
+        .status()
+        .map_err(|error| V2Error::new(ErrorCode::GitFailure, error.to_string()))?;
+    if status.code() == Some(1) {
+        return Ok(false);
+    }
+    if !status.success() {
+        return Err(V2Error::new(
+            ErrorCode::GitFailure,
+            "git diff failed while comparing reviewed and candidate revisions",
+        ));
+    }
+    Ok(true)
+}
+
 fn scoped_pathspec(scope: &[String]) -> Vec<String> {
     let mut pathspec = scope.to_vec();
     pathspec.push(":(exclude).csdlc/**".into());

--- a/csdlc-v2/src/lifecycle.rs
+++ b/csdlc-v2/src/lifecycle.rs
@@ -217,7 +217,12 @@ fn terminal_projection_overlap_is_released(
     let cached_terminal = crate::finish::load_cached_terminal(store.root(), local.issue)?;
     let immutable_terminal = if let Some(terminal) = &cached_terminal {
         terminal.disposition == crate::finish::FinishDisposition::Merged
-            && crate::finish::envelope_releases_claim(terminal, local, now_unix_seconds)?
+            && crate::finish::envelope_releases_claim(
+                observed_store.root(),
+                terminal,
+                local,
+                now_unix_seconds,
+            )?
     } else {
         false
     };
@@ -236,7 +241,12 @@ fn terminal_projection_overlap_is_released(
         return Ok(false);
     }
     if let Some(terminal) = &cached_terminal {
-        if crate::finish::envelope_releases_claim(terminal, local, now_unix_seconds)? {
+        if crate::finish::envelope_releases_claim(
+            observed_store.root(),
+            terminal,
+            local,
+            now_unix_seconds,
+        )? {
             return Ok(true);
         }
     }

--- a/csdlc-v2/tests/gate2.rs
+++ b/csdlc-v2/tests/gate2.rs
@@ -1637,6 +1637,197 @@ fn active_nonoverlap_does_not_consult_stale_terminal_identity() {
 }
 
 #[test]
+fn fresh_initialization_accepts_overlap_released_by_metadata_advanced_merged_terminal() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    git(temp.path(), &["init", "-b", "main"]);
+    git(
+        temp.path(),
+        &["config", "user.email", "test@example.invalid"],
+    );
+    git(temp.path(), &["config", "user.name", "C-SDLC Test"]);
+    fs::create_dir_all(temp.path().join("docs")).expect("docs");
+    fs::create_dir_all(temp.path().join("csdlc-v2/src")).expect("csdlc source");
+    fs::create_dir_all(temp.path().join("docs/templates/prompts")).expect("registry directory");
+    fs::create_dir_all(temp.path().join("csdlc-v2/operator")).expect("manifest directory");
+    fs::write(
+        temp.path().join("docs/templates/prompts/current.json"),
+        include_bytes!("../../docs/templates/prompts/current.json"),
+    )
+    .expect("registry fixture");
+    fs::write(
+        temp.path().join("csdlc-v2/operator/native-card-shape.json"),
+        include_bytes!("../operator/native-card-shape.json"),
+    )
+    .expect("manifest fixture");
+    fs::write(temp.path().join("docs/design.md"), "# Reviewed design\n").expect("design");
+    fs::write(
+        temp.path().join("docs/diagram.mmd"),
+        "flowchart LR\n  A --> B\n",
+    )
+    .expect("diagram");
+    fs::write(
+        temp.path().join("csdlc-v2/src/lib.rs"),
+        "pub fn stable() {}\n",
+    )
+    .expect("source");
+    git(temp.path(), &["add", "."]);
+    git(temp.path(), &["commit", "-m", "reviewed source"]);
+    let reviewed_revision = csdlc_v2::git::substantive_revision(temp.path(), &["csdlc-v2".into()])
+        .expect("reviewed revision");
+
+    let review = csdlc_v2::ReviewEvidence {
+        reviewer: "independent-reviewer".into(),
+        scope: vec!["csdlc-v2".into()],
+        reviewed_revision,
+        findings: vec![],
+        residual_risks: vec![],
+        completed: true,
+        non_substantive_proof: None,
+    };
+    let mut finished = csdlc_v2::IssueRecord {
+        schema: "csdlc.issue.v2".into(),
+        issue: 5_778,
+        repository: "example/repo".into(),
+        initialization_digest: "initialization-5778".into(),
+        phase: LifecyclePhase::Reviewed,
+        generation: 25,
+        digest: "canonical-5778".into(),
+        claim: Some(Claim {
+            id: "claim-5778".into(),
+            owner: "finished-session".into(),
+            generation: 25,
+            acquired_unix_seconds: 1,
+            expires_unix_seconds: u64::MAX,
+            heartbeat_unix_seconds: 1,
+            branch: "main".into(),
+            worktree: ".".into(),
+            protected_paths: vec!["csdlc-v2".into()],
+            purpose: "implementation".into(),
+        }),
+        review_assignment: None,
+        review: Some(review),
+        publication: None,
+        readiness: None,
+        terminal: None,
+        migration: None,
+        design_path: "docs/design.md".into(),
+        diagram_path: "docs/diagram.mmd".into(),
+        design_review: csdlc_v2::DesignReview::Approved {
+            reviewer: "reviewer".into(),
+            revision: "reviewed".into(),
+        },
+        cards: std::collections::BTreeMap::new(),
+        transitions: vec![],
+        audit: vec![],
+    };
+    fs::create_dir_all(temp.path().join(".csdlc/issues/5778")).expect("issue directory");
+    fs::write(
+        temp.path().join(".csdlc/issues/5778/index.json"),
+        serde_json::to_vec_pretty(&finished).expect("historical record"),
+    )
+    .expect("historical projection");
+    git(temp.path(), &["add", ".csdlc/issues/5778/index.json"]);
+    git(temp.path(), &["commit", "-m", "review metadata"]);
+    let published = csdlc_v2::git::run(temp.path(), &["rev-parse", "HEAD"])
+        .expect("published head")
+        .stdout;
+
+    finished.phase = LifecyclePhase::Published;
+    finished.publication = Some(csdlc_v2::PublicationEvidence {
+        repository: "example/repo".into(),
+        issue: 5_778,
+        pull_request: 5_782,
+        url: "https://example.test/pull/5782".into(),
+        base: "main".into(),
+        head: "codex/5778".into(),
+        revision: csdlc_v2::git::clean_commit_revision(&published),
+        draft: false,
+        observed_state: "open".into(),
+    });
+    fs::write(
+        temp.path().join(".csdlc/issues/5778/index.json"),
+        serde_json::to_vec_pretty(&finished).expect("published record"),
+    )
+    .expect("published projection");
+    git(temp.path(), &["add", ".csdlc/issues/5778/index.json"]);
+    git(temp.path(), &["commit", "-m", "publication metadata"]);
+    let final_head = csdlc_v2::git::run(temp.path(), &["rev-parse", "HEAD"])
+        .expect("final head")
+        .stdout;
+
+    let finish_request = csdlc_v2::FinishRequest {
+        schema: "csdlc.finish_request.v1".into(),
+        issue: 5_778,
+        expected_generation: 25,
+        expected_digest: "canonical-5778".into(),
+        claim_id: "claim-5778".into(),
+        actor: "finished-session".into(),
+        repository: "example/repo".into(),
+        pull_request: Some(5_782),
+        base: Some("main".into()),
+        head: Some("codex/5778".into()),
+        expected_head_sha: Some(final_head.clone()),
+        merge_method: csdlc_v2::MergeMethod::Squash,
+        required_checks: vec![],
+        require_review: true,
+        approved_no_pr_reason: None,
+        token_file: None,
+    };
+    let packet = csdlc_v2::github::PrStatePacket {
+        schema: "csdlc.github_pr_state.v1".into(),
+        repository: "example/repo".into(),
+        pull_request: 5_782,
+        linked_issue: Some(5_778),
+        linkage_source: Some("github".into()),
+        state: "closed".into(),
+        draft: false,
+        merge_state: "unknown".into(),
+        review_decision: "approved".into(),
+        base_ref: Some("main".into()),
+        head_ref: Some("codex/5778".into()),
+        head_sha: final_head,
+        url: Some("https://example.test/pull/5782".into()),
+        body: Some("Closes #5778".into()),
+        merged: true,
+        merge_commit_sha: Some("1111111111111111111111111111111111111111".into()),
+        checks: vec![],
+        required_check_names: vec![],
+        classification: "merged".into(),
+    };
+    let envelope = csdlc_v2::finish::derive_terminal(
+        &finished,
+        &finish_request,
+        &csdlc_v2::IssueTerminalObservation {
+            state: "closed".into(),
+            labels: vec![],
+            observed_unix_seconds: 100,
+        },
+        Some(&packet),
+    )
+    .expect("derive merged terminal")
+    .expect("merged terminal");
+    csdlc_v2::finish::retain_cached_terminal(temp.path(), &envelope)
+        .expect("retain derived terminal");
+
+    fs::write(
+        temp.path().join("csdlc-v2/src/later.rs"),
+        "pub fn later_unrelated_change() {}\n",
+    )
+    .expect("later source");
+    git(temp.path(), &["add", "csdlc-v2/src/later.rs"]);
+    git(
+        temp.path(),
+        &["commit", "-m", "later unrelated main change"],
+    );
+
+    let store = Store::new(temp.path());
+    let mut next = request();
+    next.claim.protected_paths = vec!["csdlc-v2/src/finish.rs".into()];
+    initialize_issue(&store, next)
+        .expect("strictly validated merged terminal releases overlapping finished claim");
+}
+
+#[test]
 fn amend_scope_accepts_only_exact_receipt_backed_terminal_projection_overlap() {
     let temp = tempfile::tempdir().expect("tempdir");
     git(temp.path(), &["init", "-b", "main"]);

--- a/csdlc-v2/tests/gate_finish.rs
+++ b/csdlc-v2/tests/gate_finish.rs
@@ -5,6 +5,7 @@ use csdlc_v2::finish::{
     derive_terminal, envelope_matches_record, envelope_releases_claim, load_cached_terminal,
     retain_cached_terminal, validate_finish_merge_authority, validate_publication_head_in_repo,
 };
+use csdlc_v2::github::PrStatePacket;
 use csdlc_v2::{
     Claim, DesignReview, FinishDisposition, FinishRequest, IssueRecord, IssueTerminalObservation,
     LifecyclePhase, MergeMethod, PublicationEvidence, ReviewEvidence,
@@ -125,11 +126,19 @@ fn mutable_terminal_cache_expires_and_is_bound_to_exact_record() {
     let envelope = derive_terminal(&record, &no_pr_request(), &issue("closed", true), None)
         .expect("derive")
         .expect("terminal");
-    assert!(envelope_releases_claim(&envelope, &record, 400).expect("fresh"));
-    assert!(!envelope_releases_claim(&envelope, &record, 401).expect("expired"));
+    assert!(
+        envelope_releases_claim(std::path::Path::new("."), &envelope, &record, 400).expect("fresh")
+    );
+    assert!(
+        !envelope_releases_claim(std::path::Path::new("."), &envelope, &record, 401)
+            .expect("expired")
+    );
     let mut changed = record.clone();
     changed.generation += 1;
-    assert!(!envelope_releases_claim(&envelope, &changed, 100).expect("record drift"));
+    assert!(
+        !envelope_releases_claim(std::path::Path::new("."), &envelope, &changed, 100)
+            .expect("record drift")
+    );
 }
 
 #[cfg(unix)]
@@ -370,6 +379,43 @@ fn publication_accepts_clean_forward_csdlc_metadata_only_head() {
     validate_publication_head_in_repo(temp.path(), &record, &request)
         .expect("metadata-only forward head");
 
+    let merged_packet = PrStatePacket {
+        schema: "csdlc.github_pr_state.v1".into(),
+        repository: "owner/repo".into(),
+        pull_request: 9,
+        linked_issue: Some(5778),
+        linkage_source: Some("github".into()),
+        state: "closed".into(),
+        draft: false,
+        merge_state: "unknown".into(),
+        review_decision: "approved".into(),
+        base_ref: Some("main".into()),
+        head_ref: Some("codex/5778".into()),
+        head_sha: current.clone(),
+        url: Some("https://example.test/pull/9".into()),
+        body: Some("Closes #5778".into()),
+        merged: true,
+        merge_commit_sha: Some("1111111111111111111111111111111111111111".into()),
+        checks: vec![],
+        required_check_names: vec![],
+        classification: "merged".into(),
+    };
+    let merged = derive_terminal(
+        &record,
+        &request,
+        &IssueTerminalObservation {
+            state: "closed".into(),
+            labels: vec![],
+            observed_unix_seconds: 100,
+        },
+        Some(&merged_packet),
+    )
+    .expect("derive merged terminal")
+    .expect("merged terminal");
+    assert!(!envelope_matches_record(&merged, &record).expect("exact publication identity"));
+    assert!(envelope_releases_claim(temp.path(), &merged, &record, 100)
+        .expect("strict metadata lineage releases claim"));
+
     let mut exact = record.clone();
     exact.publication.as_mut().unwrap().revision = csdlc_v2::git::clean_commit_revision(&current);
     std::fs::write(temp.path().join("src/lib.rs"), "dirty\n").unwrap();
@@ -385,6 +431,10 @@ fn publication_accepts_clean_forward_csdlc_metadata_only_head() {
         format!("git-blake3:{published}:garbage");
     assert!(
         validate_publication_head_in_repo(temp.path(), &malformed_publication, &request).is_err()
+    );
+    assert!(
+        !envelope_releases_claim(temp.path(), &merged, &malformed_publication, 100)
+            .expect("malformed publication must not release claim")
     );
 
     let mut changed_scope = record.clone();
@@ -412,4 +462,23 @@ fn publication_accepts_clean_forward_csdlc_metadata_only_head() {
     let error = validate_publication_head_in_repo(temp.path(), &record, &request)
         .expect_err("substantive forward head must fail closed");
     assert_eq!(error.code, csdlc_v2::ErrorCode::ReconciliationRequired);
+
+    let mut substantive_packet = merged_packet;
+    substantive_packet.head_sha = request.expected_head_sha.clone().unwrap();
+    let substantive = derive_terminal(
+        &record,
+        &request,
+        &IssueTerminalObservation {
+            state: "closed".into(),
+            labels: vec![],
+            observed_unix_seconds: 101,
+        },
+        Some(&substantive_packet),
+    )
+    .expect("derive substantive terminal")
+    .expect("substantive terminal");
+    assert!(
+        !envelope_releases_claim(temp.path(), &substantive, &record, 101)
+            .expect("substantive drift must not release claim")
+    );
 }

--- a/csdlc-v2/tests/gate_finish.rs
+++ b/csdlc-v2/tests/gate_finish.rs
@@ -322,7 +322,8 @@ fn publication_accepts_clean_forward_csdlc_metadata_only_head() {
     git(&["config", "user.name", "Test"]);
     std::fs::create_dir_all(temp.path().join("src")).unwrap();
     std::fs::write(temp.path().join("src/lib.rs"), "pub fn stable() {}\n").unwrap();
-    git(&["add", "src/lib.rs"]);
+    std::fs::write(temp.path().join("outside-review.txt"), "substantive\n").unwrap();
+    git(&["add", "src/lib.rs", "outside-review.txt"]);
     git(&["commit", "-qm", "source"]);
     let source = git(&["rev-parse", "HEAD"]);
     let reviewed = csdlc_v2::git::substantive_revision(temp.path(), &["src".into()]).unwrap();
@@ -418,7 +419,11 @@ fn publication_accepts_clean_forward_csdlc_metadata_only_head() {
 
     git(&["checkout", "-qb", "rename-drift", &current]);
     std::fs::create_dir_all(temp.path().join(".csdlc/moved")).unwrap();
-    git(&["mv", "src/lib.rs", ".csdlc/moved/lib.rs"]);
+    git(&[
+        "mv",
+        "outside-review.txt",
+        ".csdlc/moved/outside-review.txt",
+    ]);
     git(&["commit", "-qm", "move substantive source into metadata"]);
     let rename_head = git(&["rev-parse", "HEAD"]);
     let mut rename_request = request.clone();
@@ -428,6 +433,24 @@ fn publication_accepts_clean_forward_csdlc_metadata_only_head() {
     assert_eq!(
         rename_error.code,
         csdlc_v2::ErrorCode::ReconciliationRequired
+    );
+    let mut rename_packet = merged_packet.clone();
+    rename_packet.head_sha = rename_request.expected_head_sha.clone().unwrap();
+    let rename_terminal = derive_terminal(
+        &record,
+        &rename_request,
+        &IssueTerminalObservation {
+            state: "closed".into(),
+            labels: vec![],
+            observed_unix_seconds: 102,
+        },
+        Some(&rename_packet),
+    )
+    .expect("derive renamed terminal")
+    .expect("renamed terminal");
+    assert!(
+        !envelope_releases_claim(temp.path(), &rename_terminal, &record, 102)
+            .expect("renamed substantive drift must not release claim")
     );
     git(&["checkout", "-q", "codex/5778"]);
 

--- a/csdlc-v2/tests/gate_finish.rs
+++ b/csdlc-v2/tests/gate_finish.rs
@@ -416,6 +416,21 @@ fn publication_accepts_clean_forward_csdlc_metadata_only_head() {
     assert!(envelope_releases_claim(temp.path(), &merged, &record, 100)
         .expect("strict metadata lineage releases claim"));
 
+    git(&["checkout", "-qb", "rename-drift", &current]);
+    std::fs::create_dir_all(temp.path().join(".csdlc/moved")).unwrap();
+    git(&["mv", "src/lib.rs", ".csdlc/moved/lib.rs"]);
+    git(&["commit", "-qm", "move substantive source into metadata"]);
+    let rename_head = git(&["rev-parse", "HEAD"]);
+    let mut rename_request = request.clone();
+    rename_request.expected_head_sha = Some(rename_head);
+    let rename_error = validate_publication_head_in_repo(temp.path(), &record, &rename_request)
+        .expect_err("renamed substantive source must not become metadata-only drift");
+    assert_eq!(
+        rename_error.code,
+        csdlc_v2::ErrorCode::ReconciliationRequired
+    );
+    git(&["checkout", "-q", "codex/5778"]);
+
     let mut exact = record.clone();
     exact.publication.as_mut().unwrap().revision = csdlc_v2::git::clean_commit_revision(&current);
     std::fs::write(temp.path().join("src/lib.rs"), "dirty\n").unwrap();


### PR DESCRIPTION
## Summary

- reuse finish's strict publication-lineage validation when deciding whether a derived terminal envelope releases a claim
- compare reviewed and final PR-head commits directly so later checkout state cannot invalidate retained terminal authority
- preserve exact canonical identity and reject malformed or substantive drift
- prove a fresh initialization can overlap paths held by a successfully finished merged issue

## Validation

- `cargo test --locked --manifest-path csdlc-v2/Cargo.toml`
- `cargo clippy --locked --manifest-path csdlc-v2/Cargo.toml --all-targets -- -D warnings`
- `cargo fmt --manifest-path csdlc-v2/Cargo.toml -- --check`
- `git diff --check`

Closes #5787
