### PR TITLE
[v0.92][WP-02A] Make CI and coverage routing explicit

### DIFF
--- a/.csdlc/evidence/5801/ci-topology.md
+++ b/.csdlc/evidence/5801/ci-topology.md
@@ -1,0 +1,51 @@
+# WP-02A CI Topology
+
+## Authority Flow
+
+1. `.github/workflows/ci.yaml` invokes `adl/tools/ci_path_policy.sh` with the
+   pull-request base and head revisions.
+2. The policy emits a normalized `change_class`, `pvf_lane`, and
+   `release_gate_role` plus the existing lane booleans, coverage authority,
+   validation profile, and fail-closed state.
+3. The workflow fans selected proof into focused C-SDLC v2, ADL v2, Runtime
+   v3, tooling-contract, Rust, demo, slow-proof, and coverage jobs.
+4. Stable `adl-ci` and `adl-coverage` aggregators accept only `success` and
+   `skipped`; cancelled, failed, or missing lane results fail the aggregator.
+5. PR-fast coverage is non-authoritative. Full coverage uses isolated runtime
+   and workspace producers, run-attempt-bound artifacts, and one hosted
+   aggregation gate.
+
+## Normalized Classes
+
+| Change class | Minimum PVF role |
+|---|---|
+| `current_docs_review` | diff hygiene |
+| `lifecycle_metadata` | typed metadata or diff-hygiene proof |
+| `workflow_tooling` | focused contract proof |
+| `ordinary_product_source` | focused Rust source proof |
+| `runtime_critical_source` | Runtime v3 or stronger source proof |
+| `unknown` | fail-closed authoritative proof |
+| `mixed` | strongest selected constituent proof |
+
+The normalized summary is additive. Existing required-check names, routing
+booleans, coverage thresholds, and source-proof authority remain unchanged.
+
+## Cancellation And Final State
+
+Workflow concurrency uses one group per workflow and pull request or ref with
+`cancel-in-progress: true`. Cancellation prevents stale work from consuming
+resources; it is not success authority. Both stable aggregators use an explicit
+allowlist of `success|skipped`, and focused contract tests parse that allowlist
+and reject `cancelled`, `failure`, and an empty result.
+
+## Invariants
+
+- Unknown or unavailable diffs require authoritative proof.
+- Mixed changes never select less proof than their strongest constituent.
+- Required check names remain `adl-ci` and `adl-coverage`.
+- Full coverage is aggregated once for one exact run/head lineage.
+- Destination migration settings, AWS, runner size, secrets, and branch
+  protection are outside WP-02A.
+- The WP-02A stop condition treats destination CI state as stable when its
+  disabled, pre-cutover configuration is inventoried and unchanged. It does
+  not authorize enabling destination Actions before Sprint 1 completes.

--- a/.csdlc/evidence/5801/gemini-3.1-pro-review.json
+++ b/.csdlc/evidence/5801/gemini-3.1-pro-review.json
@@ -5,13 +5,30 @@
   "reviewed_revision": "bc3581b390bfc90cfbc10a134d085df2fbadb0b5",
   "prompt_path": ".csdlc/evidence/5801/gemini-review-prompt.md",
   "prompt_sha256": "bd8ae103624f7abb0f70973aa742743500bbca05fe692c13e914af7f665475ba",
+  "initial_response_path": ".csdlc/evidence/5801/gemini-review-response-initial.json",
+  "initial_response_sha256": "5c329bb98ab0ec4df509a1f4cacdf8a7d797a5a30c6b133a8c2e89154d732c1b",
   "response_path": ".csdlc/evidence/5801/gemini-review-response.json",
   "response_sha256": "89d5b4be36efd6caf60c93daa026473c4a611895c2264e23f2be5a8e62cab4d5",
   "topology_path": ".csdlc/evidence/5801/ci-topology.md",
   "topology_sha256": "405e19dc7d2821e7b1e40a39f44f7ab5070ac71fec4d36bd33b092ddb36851f4",
   "topology_blob": "058bd1b4dbacb2b71e0426d96b00639671584f83",
   "reviewed_at": "2026-08-06T18:56:40Z",
-  "findings": [],
+  "findings": [
+    {
+      "id": "invalid-non-pr-change-class",
+      "severity": "high",
+      "actionable": true,
+      "path": "adl/tools/ci_path_policy.sh",
+      "summary": "The policy assigns an undocumented 'non_pr_authoritative' class to non-pull-request events instead of 'unknown'. This violates the normalized classes topology and incorrectly classifies changes where the diff is unavailable."
+    },
+    {
+      "id": "incomplete-aggregator-contract-test",
+      "severity": "critical",
+      "actionable": true,
+      "path": "adl/tools/test_ci_runtime_contracts.sh",
+      "summary": "The accepted_lane_results regex only parses the first case arm of the aggregator block. This allows a defective aggregator to accept cancelled, failure, or missing results in subsequent case arms without failing the contract test."
+    }
+  ],
   "dispositions": [
     {
       "finding_id": "invalid-non-pr-change-class",

--- a/.csdlc/evidence/5801/gemini-3.1-pro-review.json
+++ b/.csdlc/evidence/5801/gemini-3.1-pro-review.json
@@ -1,0 +1,27 @@
+{
+  "provider": "google",
+  "model": "gemini-3.1-pro",
+  "api_model": "gemini-3.1-pro-preview",
+  "reviewed_revision": "bc3581b390bfc90cfbc10a134d085df2fbadb0b5",
+  "prompt_path": ".csdlc/evidence/5801/gemini-review-prompt.md",
+  "prompt_sha256": "bd8ae103624f7abb0f70973aa742743500bbca05fe692c13e914af7f665475ba",
+  "response_path": ".csdlc/evidence/5801/gemini-review-response.json",
+  "response_sha256": "89d5b4be36efd6caf60c93daa026473c4a611895c2264e23f2be5a8e62cab4d5",
+  "topology_path": ".csdlc/evidence/5801/ci-topology.md",
+  "topology_sha256": "405e19dc7d2821e7b1e40a39f44f7ab5070ac71fec4d36bd33b092ddb36851f4",
+  "topology_blob": "058bd1b4dbacb2b71e0426d96b00639671584f83",
+  "reviewed_at": "2026-08-06T18:56:40Z",
+  "findings": [],
+  "dispositions": [
+    {
+      "finding_id": "invalid-non-pr-change-class",
+      "disposition": "fixed",
+      "evidence": "Non-PR events now use the documented unknown class while retaining authoritative full proof."
+    },
+    {
+      "finding_id": "incomplete-aggregator-contract-test",
+      "disposition": "fixed",
+      "evidence": "The contract parser now requires exactly success|skipped and wildcard arms, with cancelled, failure, and missing-result negative fixtures."
+    }
+  ]
+}

--- a/.csdlc/evidence/5801/gemini-review-prompt.md
+++ b/.csdlc/evidence/5801/gemini-review-prompt.md
@@ -1,0 +1,25 @@
+# Gemini 3.1 Pro Review Prompt
+
+Review the supplied exact ADL revision for issue #5801, WP-02A CI and coverage
+reliability. Treat the repository diff and `ci-topology.md` as the bounded
+review surface.
+
+Prioritize correctness defects that could:
+
+- classify docs, lifecycle metadata, workflow/tooling, ordinary source,
+  runtime-critical source, unknown, or mixed changes incorrectly;
+- allow a cancelled, failed, or missing child result to satisfy a stable
+  required-check aggregator;
+- duplicate coverage authority or weaken exact-head source proof;
+- change required-check names, coverage thresholds, AWS, runner sizing, or
+  migration settings outside scope.
+
+Return strict JSON with:
+
+- `summary`: concise assessment;
+- `findings`: array of objects containing `id`, `severity`, `actionable`,
+  `path`, and `summary`;
+- `recommendation`: `pass` or `changes_required`.
+
+Do not recommend broad refactors. A finding is actionable only when it names a
+specific defect in the supplied revision.

--- a/.csdlc/evidence/5801/gemini-review-response-initial.json
+++ b/.csdlc/evidence/5801/gemini-review-response-initial.json
@@ -1,0 +1,22 @@
+{
+  "api_model": "gemini-3.1-pro-preview",
+  "reviewed_revision": "5b7a445a7a3f1837023e25c5835d6c51357f9d9b",
+  "summary": "The revision introduces a critical flaw in the aggregator contract test and incorrectly classifies non-PR events, violating the normalized classes topology.",
+  "findings": [
+    {
+      "id": "invalid-non-pr-change-class",
+      "severity": "high",
+      "actionable": true,
+      "path": "adl/tools/ci_path_policy.sh",
+      "summary": "The policy assigns an undocumented 'non_pr_authoritative' class to non-pull-request events instead of 'unknown'. This violates the normalized classes topology and incorrectly classifies changes where the diff is unavailable."
+    },
+    {
+      "id": "incomplete-aggregator-contract-test",
+      "severity": "critical",
+      "actionable": true,
+      "path": "adl/tools/test_ci_runtime_contracts.sh",
+      "summary": "The accepted_lane_results regex only parses the first case arm of the aggregator block. This allows a defective aggregator to accept cancelled, failure, or missing results in subsequent case arms without failing the contract test."
+    }
+  ],
+  "recommendation": "changes_required"
+}

--- a/.csdlc/evidence/5801/gemini-review-response.json
+++ b/.csdlc/evidence/5801/gemini-review-response.json
@@ -1,0 +1,7 @@
+{
+  "api_model": "gemini-3.1-pro-preview",
+  "reviewed_revision": "bc3581b390bfc90cfbc10a134d085df2fbadb0b5",
+  "summary": "The revision correctly implements the WP-02A CI topology invariants. The non-PR event classification correctly defaults to 'unknown', and the aggregator contract test robustly parses all case arms to reject cancelled, failed, or missing results.",
+  "findings": [],
+  "recommendation": "pass"
+}

--- a/.csdlc/prepared/issues/5801/validate-gemini-review.rb
+++ b/.csdlc/prepared/issues/5801/validate-gemini-review.rb
@@ -11,12 +11,12 @@ path = root.join(".csdlc/evidence/5801/gemini-3.1-pro-review.json")
 abort "missing Gemini 3.1 Pro review packet" unless path.file? && !path.zero?
 packet = JSON.parse(path.read)
 abort "wrong reviewer model" unless packet["provider"] == "google" && packet["model"] == "gemini-3.1-pro"
-%w[reviewed_revision prompt_path prompt_sha256 response_path response_sha256 topology_path topology_sha256 topology_blob reviewed_at].each do |field|
+%w[reviewed_revision prompt_path prompt_sha256 initial_response_path initial_response_sha256 response_path response_sha256 topology_path topology_sha256 topology_blob reviewed_at].each do |field|
   abort "Gemini review missing #{field}" if packet[field].to_s.empty?
 end
 abort "invalid reviewed revision" unless packet["reviewed_revision"].match?(/\A[0-9a-f]{40}\z/)
 
-%w[prompt response topology].each do |kind|
+%w[prompt initial_response response topology].each do |kind|
   relative = packet.fetch("#{kind}_path")
   digest = packet.fetch("#{kind}_sha256")
   abort "invalid #{kind} digest" unless digest.match?(/\A[0-9a-f]{64}\z/)
@@ -28,12 +28,19 @@ end
 
 topology_ref = "#{packet.fetch('reviewed_revision')}:#{packet.fetch('topology_path')}"
 topology_blob = `git rev-parse #{topology_ref.shellescape} 2>/dev/null`.strip
-abort "topology is absent from reviewed revision" unless $CHILD_STATUS.success?
+abort "topology is absent from reviewed revision" unless $?.success?
 abort "topology blob mismatch" unless topology_blob == packet["topology_blob"]
 abort "Gemini review findings missing" unless packet["findings"].is_a?(Array)
 abort "Gemini review dispositions missing" unless packet["dispositions"].is_a?(Array)
-open_ids = packet["findings"].filter_map { |finding| finding["id"] if finding["actionable"] == true }
+initial_response = JSON.parse(root.join(packet.fetch("initial_response_path")).read)
+final_response = JSON.parse(root.join(packet.fetch("response_path")).read)
+abort "Gemini packet findings do not match retained initial response" unless packet["findings"] == initial_response["findings"]
+abort "final Gemini response is not clean" unless final_response["findings"] == [] && final_response["recommendation"] == "pass"
+open_ids = packet["findings"].each_with_object([]) do |finding, ids|
+  ids << finding["id"] if finding["actionable"] == true
+end
 disposed = packet["dispositions"].map { |disposition| disposition["finding_id"] }
 abort "undisposed Gemini findings: #{(open_ids - disposed).join(', ')}" unless (open_ids - disposed).empty?
+abort "unknown Gemini dispositions: #{(disposed - open_ids).join(', ')}" unless (disposed - open_ids).empty?
 
 puts "WP-02A retained Gemini 3.1 Pro review valid at #{packet['reviewed_revision']}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,9 @@ jobs:
       pull-requests: read
     outputs:
       reason: ${{ steps.path-policy.outputs.reason }}
+      change_class: ${{ steps.path-policy.outputs.change_class }}
+      pvf_lane: ${{ steps.path-policy.outputs.pvf_lane }}
+      release_gate_role: ${{ steps.path-policy.outputs.release_gate_role }}
       rust_required: ${{ steps.path-policy.outputs.rust_required }}
       coverage_required: ${{ steps.path-policy.outputs.coverage_required }}
       full_coverage_required: ${{ steps.path-policy.outputs.full_coverage_required }}
@@ -84,6 +87,9 @@ jobs:
             echo "| Field | Value |"
             echo "|---|---|"
             echo "| reason | \`${{ steps.path-policy.outputs.reason }}\` |"
+            echo "| change class | \`${{ steps.path-policy.outputs.change_class }}\` |"
+            echo "| PVF lane | \`${{ steps.path-policy.outputs.pvf_lane }}\` |"
+            echo "| release-gate role | \`${{ steps.path-policy.outputs.release_gate_role }}\` |"
             echo "| selected profile | \`${{ steps.path-policy.outputs.validation_profile_selected }}\` |"
             echo "| profile status | \`${{ steps.path-policy.outputs.validation_profile_status }}\` |"
             echo "| PR publication sufficient | \`${{ steps.path-policy.outputs.validation_profile_pr_publication_sufficient }}\` |"

--- a/adl/tools/ci_path_policy.sh
+++ b/adl/tools/ci_path_policy.sh
@@ -119,6 +119,9 @@ reason="path_policy_docs_or_tooling_only"
 changed_count=0
 changed_files=""
 changed_rows=""
+change_class="unknown"
+pvf_lane="authoritative_full"
+release_gate_role="source_required"
 validation_profile_selected=""
 validation_profile_status=""
 validation_profile_pr_publication_sufficient=""
@@ -1805,6 +1808,84 @@ if [ "$fail_closed" = true ]; then
   coverage_execution_state="fail_closed_authoritative_full_required"
 fi
 
+classify_changed_path() {
+  local path="$1"
+  case "$path" in
+    .csdlc/*)
+      printf '%s\n' "lifecycle_metadata"
+      ;;
+    .github/workflows/*|adl/tools/*|tools/*)
+      printf '%s\n' "workflow_tooling"
+      ;;
+    docs/*|.adl/docs/TBD/*|README.md|*/README.md|*.md)
+      printf '%s\n' "current_docs_review"
+      ;;
+    adl-runtime/*|adl-runtime-kernel/*|infra/runtime-v3/*|adl/src/csm*|adl/src/long_lived*)
+      printf '%s\n' "runtime_critical_source"
+      ;;
+    adl/src/*|adl/tests/*|adl/Cargo.toml|adl/Cargo.lock|adl/build.rs|adl-v2/*|csdlc-v2/*)
+      printf '%s\n' "ordinary_product_source"
+      ;;
+    *)
+      printf '%s\n' "unknown"
+      ;;
+  esac
+}
+
+derive_normalized_policy_summary() {
+  local path path_class
+  local classes=""
+
+  if [ "$event_name" != "pull_request" ]; then
+    change_class="non_pr_authoritative"
+  elif [ -n "$changed_files" ]; then
+    while IFS= read -r path; do
+      [ -n "$path" ] || continue
+      path_class="$(classify_changed_path "$path")"
+      case ",$classes," in
+        *",$path_class,"*) ;;
+        *) classes="${classes}${classes:+,}${path_class}" ;;
+      esac
+    done <<EOF
+$changed_files
+EOF
+    if [[ "$classes" == *,* ]]; then
+      change_class="mixed"
+    elif [ -n "$classes" ]; then
+      change_class="$classes"
+    else
+      change_class="unknown"
+    fi
+  else
+    change_class="unknown"
+  fi
+
+  if [ "$full_coverage_required" = true ]; then
+    pvf_lane="authoritative_full"
+    release_gate_role="source_required"
+  elif [ "$runtime_v3_fast_required" = true ]; then
+    pvf_lane="runtime_v3_fast"
+    release_gate_role="source_required"
+  elif [ "$rust_required" = true ]; then
+    pvf_lane="focused_rust"
+    release_gate_role="source_required"
+  elif [ "$csdlc_v2_standalone_required" = true ] || [ "$adl_v2_standalone_required" = true ]; then
+    pvf_lane="standalone_focused"
+    release_gate_role="source_required"
+  elif [ "$ci_contracts_required" = true ]; then
+    pvf_lane="contract"
+    release_gate_role="contract_required"
+  else
+    pvf_lane="diff_hygiene"
+    release_gate_role="docs_guardrail"
+  fi
+}
+
+derive_normalized_policy_summary
+
+emit "change_class" "$change_class"
+emit "pvf_lane" "$pvf_lane"
+emit "release_gate_role" "$release_gate_role"
 emit "rust_required" "$rust_required"
 emit "coverage_required" "$coverage_required"
 emit "full_coverage_required" "$full_coverage_required"
@@ -1840,6 +1921,9 @@ emit "validation_profile_error" "$validation_profile_error"
 emit "validation_profile_report" "$validation_profile_report"
 
 printf '\nChanged path policy: %s\n' "$reason"
+printf '  change_class=%s\n' "$change_class"
+printf '  pvf_lane=%s\n' "$pvf_lane"
+printf '  release_gate_role=%s\n' "$release_gate_role"
 printf '  rust_required=%s\n' "$rust_required"
 printf '  coverage_required=%s\n' "$coverage_required"
 printf '  full_coverage_required=%s\n' "$full_coverage_required"

--- a/adl/tools/ci_path_policy.sh
+++ b/adl/tools/ci_path_policy.sh
@@ -1837,7 +1837,7 @@ derive_normalized_policy_summary() {
   local classes=""
 
   if [ "$event_name" != "pull_request" ]; then
-    change_class="non_pr_authoritative"
+    change_class="unknown"
   elif [ -n "$changed_files" ]; then
     while IFS= read -r path; do
       [ -n "$path" ] || continue

--- a/adl/tools/test_ci_path_policy.sh
+++ b/adl/tools/test_ci_path_policy.sh
@@ -1972,6 +1972,9 @@ PY
   assert_has "$main_output" "coverage_authority=push_main"
   assert_has "$main_output" "coverage_execution_state=authoritative_full_required"
   assert_has "$main_output" "reason=push_main_runs_authoritative_full_coverage"
+  assert_has "$main_output" "change_class=unknown"
+  assert_has "$main_output" "pvf_lane=authoritative_full"
+  assert_has "$main_output" "release_gate_role=source_required"
 
   non_pr_output="$($POLICY --event-name schedule --ref "refs/heads/main")"
   assert_has "$non_pr_output" "rust_required=true"
@@ -1990,6 +1993,9 @@ PY
   assert_has "$non_pr_output" "coverage_authority=non_pr_event"
   assert_has "$non_pr_output" "coverage_execution_state=authoritative_full_required"
   assert_has "$non_pr_output" "reason=non_pull_request_event_runs_full_validation"
+  assert_has "$non_pr_output" "change_class=unknown"
+  assert_has "$non_pr_output" "pvf_lane=authoritative_full"
+  assert_has "$non_pr_output" "release_gate_role=source_required"
 
   fail_closed_output="$("$POLICY" --event-name pull_request --base "" --head "$runtime_head" --ref "refs/pull/1/merge")"
   assert_has "$fail_closed_output" "rust_required=true"

--- a/adl/tools/test_ci_path_policy.sh
+++ b/adl/tools/test_ci_path_policy.sh
@@ -246,6 +246,9 @@ EOF
   docs_head="$(git rev-parse HEAD)"
 
   docs_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$docs_head" --ref "refs/pull/1/merge")"
+  assert_has "$docs_output" "change_class=current_docs_review"
+  assert_has "$docs_output" "pvf_lane=diff_hygiene"
+  assert_has "$docs_output" "release_gate_role=docs_guardrail"
   assert_has "$docs_output" "rust_required=false"
   assert_has "$docs_output" "coverage_required=false"
   assert_has "$docs_output" "full_coverage_required=false"
@@ -311,6 +314,7 @@ PY
   git commit -q -m csdlc-metadata-only
   csdlc_metadata_head="$(git rev-parse HEAD)"
   csdlc_metadata_output="$($POLICY --event-name pull_request --base "$base_sha" --head "$csdlc_metadata_head" --ref "refs/pull/1/merge")"
+  assert_has "$csdlc_metadata_output" "change_class=lifecycle_metadata"
   assert_has "$csdlc_metadata_output" "csdlc_v2_standalone_required=false"
   assert_has "$csdlc_metadata_output" "rust_required=false"
   assert_has "$csdlc_metadata_output" "coverage_required=false"
@@ -385,6 +389,9 @@ PY
   git commit -q -m runtime-v3-only
   runtime_v3_head="$(git rev-parse HEAD)"
   runtime_v3_output="$($POLICY --event-name pull_request --base "$base_sha" --head "$runtime_v3_head" --ref "refs/pull/1/merge")"
+  assert_has "$runtime_v3_output" "change_class=runtime_critical_source"
+  assert_has "$runtime_v3_output" "pvf_lane=runtime_v3_fast"
+  assert_has "$runtime_v3_output" "release_gate_role=source_required"
   assert_has "$runtime_v3_output" "runtime_v3_fast_required=true"
   assert_has "$runtime_v3_output" "rust_required=false"
   assert_has "$runtime_v3_output" "coverage_required=false"
@@ -402,6 +409,7 @@ PY
   git commit -q -m runtime-v3-mixed
   runtime_v3_mixed_head="$(git rev-parse HEAD)"
   runtime_v3_mixed_output="$($POLICY --event-name pull_request --base "$base_sha" --head "$runtime_v3_mixed_head" --ref "refs/pull/1/merge")"
+  assert_has "$runtime_v3_mixed_output" "change_class=mixed"
   assert_has "$runtime_v3_mixed_output" "runtime_v3_fast_required=false"
   assert_has "$runtime_v3_mixed_output" "rust_required=true"
 
@@ -412,6 +420,8 @@ PY
   git commit -q -m runtime-v3-unmapped
   runtime_v3_unmapped_head="$(git rev-parse HEAD)"
   runtime_v3_unmapped_output="$($POLICY --event-name pull_request --base "$base_sha" --head "$runtime_v3_unmapped_head" --ref "refs/pull/1/merge")"
+  assert_has "$runtime_v3_unmapped_output" "change_class=unknown"
+  assert_has "$runtime_v3_unmapped_output" "pvf_lane=authoritative_full"
   assert_has "$runtime_v3_unmapped_output" "runtime_v3_fast_required=false"
   assert_has "$runtime_v3_unmapped_output" "full_coverage_required=true"
   assert_has "$runtime_v3_unmapped_output" "fail_closed=true"
@@ -516,6 +526,9 @@ EOF
   runtime_head="$(git rev-parse HEAD)"
 
   runtime_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$runtime_head" --ref "refs/pull/1/merge")"
+  assert_has "$runtime_output" "change_class=ordinary_product_source"
+  assert_has "$runtime_output" "pvf_lane=focused_rust"
+  assert_has "$runtime_output" "release_gate_role=source_required"
   assert_has "$runtime_output" "rust_required=true"
   assert_has "$runtime_output" "coverage_required=false"
   assert_has "$runtime_output" "full_coverage_required=false"
@@ -804,6 +817,9 @@ EOF
   classifier_followup_head="$(git rev-parse HEAD)"
 
   classifier_followup_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$classifier_followup_head" --ref "refs/pull/1/merge")"
+  assert_has "$classifier_followup_output" "change_class=mixed"
+  assert_has "$classifier_followup_output" "pvf_lane=contract"
+  assert_has "$classifier_followup_output" "release_gate_role=contract_required"
   assert_has "$classifier_followup_output" "rust_required=false"
   assert_has "$classifier_followup_output" "coverage_required=false"
   assert_has "$classifier_followup_output" "full_coverage_required=false"
@@ -947,6 +963,9 @@ EOF
   policy_surface_head="$(git rev-parse HEAD)"
 
   policy_surface_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$policy_surface_head" --ref "refs/pull/1/merge")"
+  assert_has "$policy_surface_output" "change_class=workflow_tooling"
+  assert_has "$policy_surface_output" "pvf_lane=contract"
+  assert_has "$policy_surface_output" "release_gate_role=contract_required"
   assert_has "$policy_surface_output" "rust_required=false"
   assert_has "$policy_surface_output" "coverage_required=false"
   assert_has "$policy_surface_output" "full_coverage_required=false"

--- a/adl/tools/test_ci_runtime_contracts.sh
+++ b/adl/tools/test_ci_runtime_contracts.sh
@@ -286,6 +286,27 @@ for required_fragment in (
             f"missing fragment: {required_fragment}"
         )
 
+def accepted_lane_results(block: str) -> set[str]:
+    match = re.search(
+        r'case "\$result" in\s*\n\s*([^\n)]+)\)',
+        block,
+        re.MULTILINE,
+    )
+    if not match:
+        raise SystemExit("stable aggregator is missing its lane-result case contract")
+    return {item.strip() for item in match.group(1).split("|") if item.strip()}
+
+for name, block in (
+    ("adl-ci", aggregator_block),
+    ("adl-coverage", step_block("Aggregate hosted or Spot coverage lane")),
+):
+    accepted = accepted_lane_results(block)
+    if accepted != {"success", "skipped"}:
+        raise SystemExit(f"{name} aggregator accepts unexpected lane states: {sorted(accepted)}")
+    for rejected in ("cancelled", "failure", ""):
+        if rejected in accepted:
+            raise SystemExit(f"{name} aggregator must reject {rejected or 'missing'} lane state")
+
 podcast_launch_packet_if = step_optional_if("podcast launch packet contract")
 if podcast_launch_packet_if != "contains(needs.adl_path_policy.outputs.validation_profile_run_lanes, 'podcast_launch_packet')":
     raise SystemExit(

--- a/adl/tools/test_ci_runtime_contracts.sh
+++ b/adl/tools/test_ci_runtime_contracts.sh
@@ -286,26 +286,46 @@ for required_fragment in (
             f"missing fragment: {required_fragment}"
         )
 
-def accepted_lane_results(block: str) -> set[str]:
-    match = re.search(
-        r'case "\$result" in\s*\n\s*([^\n)]+)\)',
-        block,
-        re.MULTILINE,
-    )
+def aggregator_result_arms(block: str) -> list[list[str]]:
+    match = re.search(r'case "\$result" in\s*(.*?)^\s*esac\s*$', block, re.MULTILINE | re.DOTALL)
     if not match:
-        raise SystemExit("stable aggregator is missing its lane-result case contract")
-    return {item.strip() for item in match.group(1).split("|") if item.strip()}
+        raise ValueError("stable aggregator is missing its lane-result case contract")
+    arms = re.findall(
+        r"^\s*([^\n)]+)\)\s*.*?(?=^\s*[^\n)]+\)\s*|\Z)",
+        match.group(1),
+        re.MULTILINE | re.DOTALL,
+    )
+    return [
+        [item.strip().strip("\"'") for item in patterns.split("|")]
+        for patterns in arms
+    ]
+
+def require_aggregator_result_contract(name: str, block: str) -> None:
+    try:
+        arms = aggregator_result_arms(block)
+    except ValueError as error:
+        raise SystemExit(str(error)) from error
+    if arms != [["success", "skipped"], ["*"]]:
+        raise SystemExit(f"{name} aggregator has unexpected lane-result arms: {arms}")
 
 for name, block in (
     ("adl-ci", aggregator_block),
     ("adl-coverage", step_block("Aggregate hosted or Spot coverage lane")),
 ):
-    accepted = accepted_lane_results(block)
-    if accepted != {"success", "skipped"}:
-        raise SystemExit(f"{name} aggregator accepts unexpected lane states: {sorted(accepted)}")
-    for rejected in ("cancelled", "failure", ""):
-        if rejected in accepted:
-            raise SystemExit(f"{name} aggregator must reject {rejected or 'missing'} lane state")
+    require_aggregator_result_contract(name, block)
+    for rejected in ("cancelled", "failure", '""'):
+        fixture = re.sub(
+            r'(case "\$result" in.*?)(^\s*)\*\)',
+            lambda match: f"{match.group(1)}{match.group(2)}{rejected}) ;;\n{match.group(2)}*)",
+            block,
+            count=1,
+            flags=re.MULTILINE | re.DOTALL,
+        )
+        try:
+            require_aggregator_result_contract(name, fixture)
+        except SystemExit:
+            continue
+        raise SystemExit(f"{name} aggregator accepted a {rejected or 'missing'} negative fixture")
 
 podcast_launch_packet_if = step_optional_if("podcast launch packet contract")
 if podcast_launch_packet_if != "contains(needs.adl_path_policy.outputs.validation_profile_run_lanes, 'podcast_launch_packet')":


### PR DESCRIPTION
Closes #5801

## Summary
- emit normalized change class, PVF lane, and release-gate role without changing existing route booleans or required-check names
- prove stable CI aggregators reject cancelled, failed, and missing lane states
- retain exact-revision Gemini 3.1 Pro topology review, findings, fixes, and final clean review

## Validation
- `ruby .csdlc/prepared/issues/5801/validate-gemini-review.rb`
- `bash adl/tools/test_ci_path_policy.sh`
- `bash adl/tools/test_ci_runtime_contracts.sh`
- `bash adl/tools/test_check_coverage_impact.sh`
- `bash adl/tools/test_run_pr_fast_test_lane.sh`
- `bash adl/tools/test_coverage_authority_contract.sh`
- `cargo test --locked --manifest-path csdlc-v2/Cargo.toml --test gate_finish metadata`
- `git diff --check`

Independent exact-head review: PASS at `d3bbf28a38eec61bbbc55cfd124ade0df1d66d3d`.

No AWS, runner-size, branch-protection, coverage-threshold, or required-check-name changes.