### PR TITLE
[v0.92][Cutover] Point legacy ADL repository to canonical location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> **Canonical development has moved:** New code, branches, and pull requests belong in [agent-logic/agent-design-language](https://github.com/agent-logic/agent-design-language).
+
 # Agent Design Language (ADL)
 
 Agent Design Language is a deterministic cognitive architecture for building


### PR DESCRIPTION
## Summary
- prepend the exact reviewed canonical-location notice to the legacy README
- preserve every other file, repository setting, branch, release, issue, and pull request

## Validation
- exact changed path: README.md only
- diff hygiene: PASS
- notice text matches the reviewed #5891 cutover contract

Part of #5891